### PR TITLE
Use duckdb_date_struct instead of duckdb_date

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -65,7 +65,7 @@ func (r *rows) Next(dst []driver.Value) error {
 		case C.DUCKDB_TYPE_DOUBLE:
 			dst[i] = (*[1 << 31]float64)(unsafe.Pointer(col.data))[r.cursor]
 		case C.DUCKDB_TYPE_DATE:
-			val := (*[1 << 31]C.duckdb_date)(unsafe.Pointer(col.data))[r.cursor]
+			val := (*[1 << 31]C.duckdb_date_struct)(unsafe.Pointer(col.data))[r.cursor]
 			dst[i] = time.Date(
 				int(val.year),
 				time.Month(val.month),


### PR DESCRIPTION
As described in #7 `rows#Next` tries to access undefined fields on a struct. Looks like the breaking change was introduced upstream in https://github.com/duckdb/duckdb/pull/2107.

This PR updates `rows#Next` from `duckdb` package to use the [`duckdb_date_struct`](https://github.com/duckdb/duckdb/blob/8ef7ee22c543fb030c0e6e62b5918dd43cc46fc7/src/include/duckdb.h#L81), which contains the fields that this driver expects. 