### PR TITLE
fix(date): updated code to convert to correct struct

### DIFF
--- a/duckdb_test.go
+++ b/duckdb_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"testing"
+	"time"
 )
 
 func TestOpen(t *testing.T) {
@@ -70,6 +71,29 @@ func TestSumOfInt(t *testing.T) {
 				t.Errorf("can not scan value %v", err)
 			} else if res != expected {
 				t.Errorf("unexpected value %d != resulting value %d", expected, res)
+			}
+		})
+	}
+}
+
+// CAST(? as DATE) generate result of type Date (time.Time)
+func TestDate(t *testing.T) {
+	db := openDB(t)
+	tests := map[string]struct {
+		input string
+		want  time.Time
+	}{
+		"epoch":       {input: "1970-01-01", want: time.UnixMilli(0)},
+		"before 1970": {input: "1950-12-12", want: time.Date(1950, 12, 12, 0, 0, 0, 0, time.UTC).Local()},
+		"after 1970":  {input: "2022-12-12", want: time.Date(2022, 12, 12, 0, 0, 0, 0, time.UTC).Local()},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var res time.Time
+			if err := db.QueryRow("SELECT CAST(? as DATE)", tc.input).Scan(&res); err != nil {
+				t.Errorf("can not scan value %v", err)
+			} else if res != tc.want {
+				t.Errorf("expected value %v != resulting value %v", tc.want, res)
 			}
 		})
 	}

--- a/rows.go
+++ b/rows.go
@@ -76,14 +76,8 @@ func (r *rows) Next(dst []driver.Value) error {
 		case C.DUCKDB_TYPE_DOUBLE:
 			dst[i] = (*[1 << 31]float64)(unsafe.Pointer(colData))[r.cursor]
 		case C.DUCKDB_TYPE_DATE:
-			val := (*[1 << 31]C.duckdb_date_struct)(unsafe.Pointer(colData))[r.cursor]
-			dst[i] = time.Date(
-				int(val.year),
-				time.Month(val.month),
-				int(val.day),
-				0, 0, 0, 0,
-				time.UTC,
-			)
+			val := (*[1 << 31]C.duckdb_date)(unsafe.Pointer(colData))[r.cursor]
+			dst[i] = time.UnixMilli(0).Add(time.Duration(int64(val.days)) * 24 * time.Hour)
 		case C.DUCKDB_TYPE_VARCHAR:
 			dst[i] = C.GoString((*[1 << 31]*C.char)(unsafe.Pointer(colData))[r.cursor])
 		case C.DUCKDB_TYPE_TIMESTAMP:


### PR DESCRIPTION
Looks like at some point the structure returned in rows went back to `duckdb_date` therefore dates were all messed up.

I added a test to pick up this regression in the future.
