### PR TITLE
upgrade duckdb, add variable, macos universal, add race detector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
+DUCKDB_VERSION=0.3.4
 LIB_PATH := $(shell pwd)/lib
 
 ifeq ($(shell uname -s),Darwin)
 LIB_EXT=dylib
-ARCH_OS=osx-amd64
+ARCH_OS=osx-universal
 LIBRARY_PATH := DYLD_LIBRARY_PATH=$(LIB_PATH)
 else
 LIB_EXT=so
@@ -14,7 +15,7 @@ LDFLAGS := LIB=libduckdb.$(LIB_EXT) CGO_LDFLAGS="-L$(LIB_PATH)" $(LIBRARY_PATH) 
 
 $(LIBS):
 	mkdir -p lib
-	curl -Lo lib/libduckdb.zip https://github.com/duckdb/duckdb/releases/download/v0.3.2/libduckdb-$(ARCH_OS).zip
+	curl -Lo lib/libduckdb.zip https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/libduckdb-$(ARCH_OS).zip
 	cd lib; unzip -u libduckdb.zip
 
 .PHONY: install
@@ -27,7 +28,7 @@ examples: $(LIBS)
 
 .PHONY: test
 test: $(LIBS)
-	$(LDFLAGS) go test -ldflags="-r $(LIB_PATH)" -v ./...
+	$(LDFLAGS) go test -ldflags="-r $(LIB_PATH)" -v -race -count=1 ./...
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
- Upgrade duckdb version in Makefile to 0.3.4 and add variable for future updates
- For Mac, use the universal build (support Intel and Apple / Aarch64 / ARM64 CPUs)
- Add race detector to test run