### PR TITLE
Fixing string with size=12

### DIFF
--- a/duckdb_test.go
+++ b/duckdb_test.go
@@ -344,6 +344,14 @@ func TestVarchar(t *testing.T) {
 	require.NoError(t, db.QueryRow("select 'inline'").Scan(&s))
 	require.Equal(t, "inline", s)
 
+	// size = 12 needs to be verified
+	require.NoError(t, db.QueryRow("select 'inlineSize12'").Scan(&s))
+	require.Equal(t, "inlineSize12", s)
+
+	// size = 13 needs to be verified
+	require.NoError(t, db.QueryRow("select 'inlineSize13_'").Scan(&s))
+	require.Equal(t, "inlineSize13_", s)
+
 	const q = "uninlined string that is greater than 12 bytes long"
 	require.NoError(t, db.QueryRow(fmt.Sprintf("SELECT '%s'", q)).Scan(&s))
 	require.Equal(t, q, s)

--- a/rows.go
+++ b/rows.go
@@ -333,7 +333,7 @@ func scanString(vector C.duckdb_vector, rowIdx C.idx_t) string {
 // `json`, `varchar`, and `blob` have the same repr
 func scanBlob(vector C.duckdb_vector, rowIdx C.idx_t) []byte {
 	s := get[duckdb_string_t](vector, rowIdx)
-	if s.length < stringInlineLength {
+	if s.length <= stringInlineLength {
 		// inline data is stored from byte 4..16 (up to 12 bytes)
 		return C.GoBytes(unsafe.Pointer(&s.prefix), C.int(s.length))
 	} else {


### PR DESCRIPTION
I was getting segmentation fault when string size was exactly 12.
Needed a <= check for the size in scanBlob