### PR TITLE
Adding support for Interval duckdb type

### DIFF
--- a/duckdb_test.go
+++ b/duckdb_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/georgysavva/scany/sqlscan"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"reflect"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -426,6 +428,39 @@ func TestTimestamp(t *testing.T) {
 			if err := db.QueryRow("SELECT CAST(? as TIMESTAMP)", tc.input).Scan(&res); err != nil {
 				t.Errorf("can not scan value %v", err)
 			} else if res != tc.want {
+				t.Errorf("expected value %v != resulting value %v", tc.want, res)
+			}
+		})
+	}
+}
+
+func TestInterval(t *testing.T) {
+	t.Parallel()
+	db := openDB(t)
+	defer db.Close()
+	tests := map[string]struct {
+		input string
+		want  Interval
+	}{
+		"simple interval": {
+			input: "INTERVAL 5 HOUR",
+			want:  Interval{days: 0, months: 0, micros: 18000000000},
+		},
+		"interval arithmetic": {
+			input: "INTERVAL 1 DAY + INTERVAL 5 DAY",
+			want:  Interval{days: 6, months: 0, micros: 0},
+		},
+		"timestamp arithmetic": {
+			input: "CAST('2022-05-01' as TIMESTAMP) - CAST('2022-04-01' as TIMESTAMP)",
+			want:  Interval{days: 30, months: 0, micros: 0},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var res Interval
+			if err := db.QueryRow(fmt.Sprintf("SELECT %s", tc.input)).Scan(&res); err != nil {
+				t.Errorf("can not scan value %v", err)
+			} else if !reflect.DeepEqual(tc.want, res) {
 				t.Errorf("expected value %v != resulting value %v", tc.want, res)
 			}
 		})

--- a/duckdb_test.go
+++ b/duckdb_test.go
@@ -444,15 +444,15 @@ func TestInterval(t *testing.T) {
 	}{
 		"simple interval": {
 			input: "INTERVAL 5 HOUR",
-			want:  Interval{days: 0, months: 0, micros: 18000000000},
+			want:  Interval{Days: 0, Months: 0, Micros: 18000000000},
 		},
 		"interval arithmetic": {
 			input: "INTERVAL 1 DAY + INTERVAL 5 DAY",
-			want:  Interval{days: 6, months: 0, micros: 0},
+			want:  Interval{Days: 6, Months: 0, Micros: 0},
 		},
 		"timestamp arithmetic": {
 			input: "CAST('2022-05-01' as TIMESTAMP) - CAST('2022-04-01' as TIMESTAMP)",
-			want:  Interval{days: 30, months: 0, micros: 0},
+			want:  Interval{Days: 30, Months: 0, Micros: 0},
 		},
 	}
 	for name, tc := range tests {

--- a/rows.go
+++ b/rows.go
@@ -345,17 +345,17 @@ func scanBlob(vector C.duckdb_vector, rowIdx C.idx_t) []byte {
 }
 
 type Interval struct {
-	days   int32
-	months int32
-	micros int64
+	Days   int32 `json:"days"`
+	Months int32 `json:"months"`
+	Micros int64 `json:"micros"`
 }
 
 func scanInterval(vector C.duckdb_vector, rowIdx C.idx_t) (Interval, error) {
 	i := get[C.duckdb_interval](vector, rowIdx)
 	data := Interval{
-		days:   int32(i.days),
-		months: int32(i.months),
-		micros: int64(i.micros),
+		Days:   int32(i.days),
+		Months: int32(i.months),
+		Micros: int64(i.micros),
 	}
 	return data, nil
 }


### PR DESCRIPTION
Adding support for interval duckdb type by returning a struct `Interval` wherever DUCKDB_TYPE_INTERVAL is encountered,
```
type Interval struct {
    days   int32
    months int32
    micros int64
}
```