### PR TITLE
Support for all DuckDB data types and data type names

### DIFF
--- a/duckdb_test.go
+++ b/duckdb_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"reflect"
 	"testing"
 	"time"
 
@@ -620,4 +621,193 @@ func createTable(db *sql.DB, t *testing.T) *sql.Result {
 	res, err := db.Exec("CREATE TABLE foo(bar VARCHAR, baz INTEGER)")
 	require.NoError(t, err)
 	return &res
+}
+
+func TestTypes(t *testing.T) {
+	tests := []struct {
+		sql      string
+		value    any
+		typeName string
+	}{
+		// 	DUCKDB_TYPE_BOOLEAN:
+		{
+			sql:      "SELECT true AS col",
+			value:    true,
+			typeName: "BOOLEAN",
+		},
+		// DUCKDB_TYPE_TINYINT
+		{
+			sql:      "SELECT 31::TINYINT AS col",
+			value:    int8(31),
+			typeName: "TINYINT",
+		},
+		// DUCKDB_TYPE_SMALLINT
+		{
+			sql:      "SELECT 31::SMALLINT AS col",
+			value:    int16(31),
+			typeName: "SMALLINT",
+		},
+		// DUCKDB_TYPE_INTEGER
+		{
+			sql:      "SELECT 31::INTEGER AS col",
+			value:    int32(31),
+			typeName: "INTEGER",
+		},
+		// DUCKDB_TYPE_BIGINT
+		{
+			sql:      "SELECT 31::BIGINT AS col",
+			value:    int64(31),
+			typeName: "BIGINT",
+		},
+		// DUCKDB_TYPE_UTINYINT
+		{
+			sql:      "SELECT 31::UTINYINT AS col",
+			value:    uint8(31),
+			typeName: "UTINYINT",
+		},
+		// DUCKDB_TYPE_USMALLINT
+		{
+			sql:      "SELECT 31::USMALLINT AS col",
+			value:    uint16(31),
+			typeName: "USMALLINT",
+		},
+		// DUCKDB_TYPE_UINTEGER
+		{
+			sql:      "SELECT 31::UINTEGER AS col",
+			value:    uint32(31),
+			typeName: "UINTEGER",
+		},
+		// DUCKDB_TYPE_UBIGINT
+		{
+			sql:      "SELECT 31::UBIGINT AS col",
+			value:    uint64(31),
+			typeName: "UBIGINT",
+		},
+		// DUCKDB_TYPE_FLOAT
+		{
+			sql:      "SELECT 3.14::FLOAT AS col",
+			value:    float32(3.14),
+			typeName: "FLOAT",
+		},
+		// DUCKDB_TYPE_DOUBLE
+		{
+			sql:      "SELECT 3.14::DOUBLE AS col",
+			value:    float64(3.14),
+			typeName: "DOUBLE",
+		},
+		// DUCKDB_TYPE_TIMESTAMP
+		{
+			sql:      "SELECT '1992-09-20 11:30:00'::TIMESTAMP AS col",
+			value:    time.Date(1992, 9, 20, 11, 30, 0, 0, time.UTC),
+			typeName: "TIMESTAMP",
+		},
+		// DUCKDB_TYPE_DATE
+		{
+			sql:      "SELECT '1992-09-20'::DATE AS col",
+			value:    time.Date(1992, 9, 20, 0, 0, 0, 0, time.UTC),
+			typeName: "DATE",
+		},
+		// DUCKDB_TYPE_TIME
+		{
+			sql:      "SELECT '11:30:00'::TIME AS col",
+			value:    time.Date(1970, 1, 1, 11, 30, 0, 0, time.UTC),
+			typeName: "TIME",
+		},
+		// DUCKDB_TYPE_INTERVAL
+		{
+			sql:      "SELECT INTERVAL 15 MINUTES AS col",
+			value:    Interval{Micros: 15 * 60 * 1000000},
+			typeName: "INTERVAL",
+		},
+		// DUCKDB_TYPE_HUGEINT
+		{
+			sql:      "SELECT 31::HUGEINT AS col",
+			value:    HugeInt{lower: 31, upper: 0},
+			typeName: "HUGEINT",
+		},
+		// DUCKDB_TYPE_VARCHAR
+		{
+			sql:      "SELECT 'foo'::VARCHAR AS col",
+			value:    "foo",
+			typeName: "VARCHAR",
+		},
+		// DUCKDB_TYPE_BLOB
+		{
+			sql:      "SELECT 'foo'::BLOB AS col",
+			value:    []byte("foo"),
+			typeName: "BLOB",
+		},
+		// DUCKDB_TYPE_DECIMAL
+		{
+			sql:      "SELECT 31::DECIMAL(30,20) AS col",
+			value:    float64(31),
+			typeName: "DECIMAL(30,20)",
+		},
+		// DUCKDB_TYPE_TIMESTAMP_S
+		{
+			sql:      "SELECT '1992-09-20 11:30:00'::TIMESTAMP_S AS col",
+			value:    time.Date(1992, 9, 20, 11, 30, 0, 0, time.UTC),
+			typeName: "TIMESTAMP_S",
+		},
+		// DUCKDB_TYPE_TIMESTAMP_MS
+		{
+			sql:      "SELECT '1992-09-20 11:30:00'::TIMESTAMP_MS AS col",
+			value:    time.Date(1992, 9, 20, 11, 30, 0, 0, time.UTC),
+			typeName: "TIMESTAMP_MS",
+		},
+		// DUCKDB_TYPE_TIMESTAMP_NS
+		{
+			sql:      "SELECT '1992-09-20 11:30:00'::TIMESTAMP_NS AS col",
+			value:    time.Date(1992, 9, 20, 11, 30, 0, 0, time.UTC),
+			typeName: "TIMESTAMP_NS",
+		},
+		// DUCKDB_TYPE_LIST
+		{
+			sql:      "SELECT [['duck', 'goose', 'heron'], NULL, ['frog', 'toad'], []] AS col",
+			value:    []any{[]any{"duck", "goose", "heron"}, nil, []any{"frog", "toad"}, []any{}},
+			typeName: "VARCHAR[][]",
+		},
+		// DUCKDB_TYPE_STRUCT
+		{
+			sql:      "SELECT {'key1': 'string', 'key2': 1, 'key3': 12.345::DOUBLE} AS col",
+			value:    map[string]any{"key1": "string", "key2": int32(1), "key3": float64(12.345)},
+			typeName: "STRUCT(key1 VARCHAR, key2 INTEGER, key3 DOUBLE)",
+		},
+		// DUCKDB_TYPE_MAP
+		{
+			sql:      "SELECT map([1, 5], ['a', 'e']) AS col",
+			value:    Map{int32(1): "a", int32(5): "e"},
+			typeName: "MAP(INTEGER, VARCHAR)",
+		},
+		// DUCKDB_TYPE_UUID
+		{
+			sql:      "SELECT '53b4e983-b287-481a-94ad-6e3c90489913'::UUID AS col",
+			value:    []byte{0x53, 0xb4, 0xe9, 0x83, 0xb2, 0x87, 0x48, 0x1a, 0x94, 0xad, 0x6e, 0x3c, 0x90, 0x48, 0x99, 0x13},
+			typeName: "UUID",
+		},
+		// DUCKDB_TYPE_JSON
+		{
+			sql:      `SELECT '{"hello": "world"}'::JSON AS col`,
+			value:    `{"hello": "world"}`,
+			typeName: "JSON",
+		},
+	}
+
+	db := openDB(t)
+	for _, test := range tests {
+		t.Run(test.typeName, func(t *testing.T) {
+			rows, err := db.Query(test.sql)
+			require.NoError(t, err)
+
+			cols, err := rows.ColumnTypes()
+			require.NoError(t, err)
+			require.Equal(t, reflect.TypeOf(test.value), cols[0].ScanType())
+			require.Equal(t, test.typeName, cols[0].DatabaseTypeName())
+
+			var val any
+			require.True(t, rows.Next())
+			rows.Scan(&val)
+			require.Equal(t, test.value, val)
+		})
+	}
 }

--- a/duckdb_test.go
+++ b/duckdb_test.go
@@ -603,33 +603,13 @@ func TestMultiple(t *testing.T) {
 	require.Contains(t, err.Error(), "Cannot prepare multiple statements at once")
 }
 
-func openDB(t *testing.T) *sql.DB {
-	db, err := sql.Open("duckdb", "")
-	require.NoError(t, err)
-	require.NoError(t, db.Ping())
-	return db
-}
-
-func loadJSONExt(t *testing.T, db *sql.DB) {
-	_, err := db.Exec("INSTALL 'json'")
-	require.NoError(t, err)
-	_, err = db.Exec("LOAD 'json'")
-	require.NoError(t, err)
-}
-
-func createTable(db *sql.DB, t *testing.T) *sql.Result {
-	res, err := db.Exec("CREATE TABLE foo(bar VARCHAR, baz INTEGER)")
-	require.NoError(t, err)
-	return &res
-}
-
-func TestTypes(t *testing.T) {
+func TestTypeNamesAndScanTypes(t *testing.T) {
 	tests := []struct {
 		sql      string
 		value    any
 		typeName string
 	}{
-		// 	DUCKDB_TYPE_BOOLEAN:
+		// 	DUCKDB_TYPE_BOOLEAN
 		{
 			sql:      "SELECT true AS col",
 			value:    true,
@@ -810,4 +790,24 @@ func TestTypes(t *testing.T) {
 			require.Equal(t, test.value, val)
 		})
 	}
+}
+
+func openDB(t *testing.T) *sql.DB {
+	db, err := sql.Open("duckdb", "")
+	require.NoError(t, err)
+	require.NoError(t, db.Ping())
+	return db
+}
+
+func loadJSONExt(t *testing.T, db *sql.DB) {
+	_, err := db.Exec("INSTALL 'json'")
+	require.NoError(t, err)
+	_, err = db.Exec("LOAD 'json'")
+	require.NoError(t, err)
+}
+
+func createTable(db *sql.DB, t *testing.T) *sql.Result {
+	res, err := db.Exec("CREATE TABLE foo(bar VARCHAR, baz INTEGER)")
+	require.NoError(t, err)
+	return &res
 }

--- a/duckdb_test.go
+++ b/duckdb_test.go
@@ -609,7 +609,7 @@ func TestTypeNamesAndScanTypes(t *testing.T) {
 		value    any
 		typeName string
 	}{
-		// 	DUCKDB_TYPE_BOOLEAN
+		// DUCKDB_TYPE_BOOLEAN
 		{
 			sql:      "SELECT true AS col",
 			value:    true,

--- a/rows.go
+++ b/rows.go
@@ -439,8 +439,10 @@ func typeName(t C.duckdb_type) string {
 		return "UUID"
 	case C.DUCKDB_TYPE_JSON:
 		return "JSON"
+	default:
+		// Should never happen
+		return ""
 	}
-	return ""
 }
 
 func logicalTypeName(lt C.duckdb_logical_type) string {
@@ -461,8 +463,9 @@ func logicalTypeName(lt C.duckdb_logical_type) string {
 		return logicalTypeNameStruct(lt)
 	case C.DUCKDB_TYPE_MAP:
 		return logicalTypeNameMap(lt)
+	default:
+		return typeName(t)
 	}
-	return typeName(t)
 }
 
 func logicalTypeNameStruct(lt C.duckdb_logical_type) string {


### PR DESCRIPTION
This PR is mainly about adding support for logical type names (like maps and structs) in `ColumnTypeDatabaseTypeName`. While going through the C API, I also noticed a few esoteric data types in DuckDB that were not covered in `scan` and added support for those (unsigned integers, `TIME`, and `TIMESTAMP_(NS|MS|S)`).

To make sure I didn't miss anything, I also reordered all switch statements to follow the ordering of [`enum DUCKDB_TYPE`](https://github.com/duckdb/duckdb/blob/master/src/include/duckdb.h#L66).