### PR TITLE
Use math/big.Int for HUGEINT

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -8,6 +8,7 @@ import "C"
 import (
 	"database/sql/driver"
 	"errors"
+	"math/big"
 	"unsafe"
 )
 
@@ -19,12 +20,8 @@ type conn struct {
 }
 
 func (c *conn) CheckNamedValue(nv *driver.NamedValue) error {
-	switch v := nv.Value.(type) {
-	case HugeInt:
-		nv.Value = HugeInt(v)
-		return nil
-	case Interval:
-		nv.Value = Interval(v)
+	switch nv.Value.(type) {
+	case *big.Int, Interval:
 		return nil
 	}
 	return driver.ErrSkip

--- a/duckdb_test.go
+++ b/duckdb_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"math/big"
 	"reflect"
 	"testing"
 	"time"
@@ -344,32 +345,45 @@ func TestHugeInt(t *testing.T) {
 	db := openDB(t)
 	defer db.Close()
 
-	t.Run("scan HugeInt", func(t *testing.T) {
-		for _, expected := range []int64{0, 1, -1, math.MaxInt64, math.MinInt64} {
-			t.Run(fmt.Sprintf("sum(%d)", expected), func(t *testing.T) {
-				var res HugeInt
-				err := db.QueryRow("SELECT SUM(?)", expected).Scan(&res)
+	t.Run("scan hugeint", func(t *testing.T) {
+		tests := []string{
+			"0",
+			"1",
+			"-1",
+			"9223372036854775807",
+			"-9223372036854775808",
+			"170141183460469231731687303715884105727",
+			"-170141183460469231731687303715884105727",
+		}
+		for _, expected := range tests {
+			t.Run(fmt.Sprintf("sum(%s)", expected), func(t *testing.T) {
+				var res *big.Int
+				err := db.QueryRow(fmt.Sprintf("SELECT %s::HUGEINT", expected)).Scan(&res)
 				require.NoError(t, err)
-
-				expct, err := res.Int64()
-				require.NoError(t, err)
-				require.Equal(t, expected, expct)
+				require.Equal(t, expected, res.String())
 			})
 		}
 	})
 
-	t.Run("bind HugeInt", func(t *testing.T) {
+	t.Run("bind hugeint", func(t *testing.T) {
 		_, err := db.Exec("CREATE TABLE hugeint_test (number HUGEINT)")
 		require.NoError(t, err)
 
-		val := HugeInt{upper: 1, lower: 2}
+		val := big.NewInt(1)
+		val.SetBit(val, 101, 1)
 		_, err = db.Exec("INSERT INTO hugeint_test VALUES(?)", val)
 		require.NoError(t, err)
 
-		var res HugeInt
+		var res *big.Int
 		err = db.QueryRow("SELECT number FROM hugeint_test WHERE number = ?", val).Scan(&res)
 		require.NoError(t, err)
-		require.Equal(t, val, res)
+		require.Equal(t, val.String(), res.String())
+
+		tooHuge := big.NewInt(1)
+		tooHuge.SetBit(tooHuge, 129, 1)
+		_, err = db.Exec("INSERT INTO hugeint_test VALUES(?)", tooHuge)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "too big")
 	})
 }
 
@@ -702,7 +716,7 @@ func TestTypeNamesAndScanTypes(t *testing.T) {
 		// DUCKDB_TYPE_HUGEINT
 		{
 			sql:      "SELECT 31::HUGEINT AS col",
-			value:    HugeInt{lower: 31, upper: 0},
+			value:    big.NewInt(31),
 			typeName: "HUGEINT",
 		},
 		// DUCKDB_TYPE_VARCHAR

--- a/rows.go
+++ b/rows.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/big"
 	"reflect"
 	"time"
 	"unsafe"
@@ -140,7 +141,8 @@ func scan(vector C.duckdb_vector, rowIdx C.idx_t) (any, error) {
 	case C.DUCKDB_TYPE_INTERVAL:
 		return scanInterval(vector, rowIdx)
 	case C.DUCKDB_TYPE_HUGEINT:
-		return get[HugeInt](vector, rowIdx), nil
+		hi := get[C.duckdb_hugeint](vector, rowIdx)
+		return hugeIntToNative(hi), nil
 	case C.DUCKDB_TYPE_VARCHAR:
 		return scanString(vector, rowIdx), nil
 	case C.DUCKDB_TYPE_BLOB:
@@ -160,7 +162,8 @@ func scan(vector C.duckdb_vector, rowIdx C.idx_t) (any, error) {
 	case C.DUCKDB_TYPE_MAP:
 		return scanMap(ty, vector, rowIdx)
 	case C.DUCKDB_TYPE_UUID:
-		return get[HugeInt](vector, rowIdx).UUID(), nil
+		hi := get[C.duckdb_hugeint](vector, rowIdx)
+		return hugeIntToUUID(hi), nil
 	case C.DUCKDB_TYPE_JSON:
 		return scanString(vector, rowIdx), nil
 	default:
@@ -205,7 +208,7 @@ func (r *rows) ColumnTypeScanType(index int) reflect.Type {
 	case C.DUCKDB_TYPE_INTERVAL:
 		return reflect.TypeOf(Interval{})
 	case C.DUCKDB_TYPE_HUGEINT:
-		return reflect.TypeOf(HugeInt{})
+		return reflect.TypeOf(big.NewInt(0))
 	case C.DUCKDB_TYPE_VARCHAR:
 		return reflect.TypeOf("")
 	case C.DUCKDB_TYPE_BLOB:

--- a/statement.go
+++ b/statement.go
@@ -9,6 +9,7 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
+	"math/big"
 	"time"
 	"unsafe"
 )
@@ -72,10 +73,10 @@ func (s *stmt) start(args []driver.Value) error {
 			if rv := C.duckdb_bind_int64(*s.stmt, C.idx_t(i+1), C.int64_t(v)); rv == C.DuckDBError {
 				return errCouldNotBind
 			}
-		case HugeInt:
-			val := C.duckdb_hugeint{
-				upper: C.int64_t(v.upper),
-				lower: C.uint64_t(v.lower),
+		case *big.Int:
+			val, err := hugeIntFromNative(v)
+			if err != nil {
+				return err
 			}
 			if rv := C.duckdb_bind_hugeint(*s.stmt, C.idx_t(i+1), val); rv == C.DuckDBError {
 				return errCouldNotBind

--- a/types.go
+++ b/types.go
@@ -8,31 +8,45 @@ import "C"
 import (
 	"encoding/binary"
 	"fmt"
-	"math"
+	"math/big"
 
 	"github.com/mitchellh/mapstructure"
 )
 
-// HugeInt are composed in a (lower, upper) component
-// The value of the HugeInt is upper * 2^64 + lower
-type HugeInt C.duckdb_hugeint
+// duckdb_hugeint is composed of (lower, upper) components.
+// The value is computed as: upper * 2^64 + lower
 
-func (v HugeInt) UUID() []byte {
+func hugeIntToUUID(hi C.duckdb_hugeint) []byte {
 	var uuid [16]byte
-	// We need to flip the `sign bit` of the signed `HugeInt` to transform it to UUID bytes
-	binary.BigEndian.PutUint64(uuid[:8], uint64(v.upper)^1<<63)
-	binary.BigEndian.PutUint64(uuid[8:], uint64(v.lower))
+	// We need to flip the sign bit of the signed hugeint to transform it to UUID bytes
+	binary.BigEndian.PutUint64(uuid[:8], uint64(hi.upper)^1<<63)
+	binary.BigEndian.PutUint64(uuid[8:], uint64(hi.lower))
 	return uuid[:]
 }
 
-func (v HugeInt) Int64() (int64, error) {
-	if v.upper == 0 && v.lower <= math.MaxInt64 {
-		return int64(v.lower), nil
-	} else if v.upper == -1 {
-		return -int64(math.MaxUint64 - v.lower + 1), nil
-	} else {
-		return 0, fmt.Errorf("can not convert duckdb:hugeint to go:int64 (upper:%d, lower:%d)", v.upper, v.lower)
+func hugeIntToNative(hi C.duckdb_hugeint) *big.Int {
+	i := big.NewInt(int64(hi.upper))
+	i.Lsh(i, 64)
+	i.Add(i, new(big.Int).SetUint64(uint64(hi.lower)))
+	return i
+}
+
+func hugeIntFromNative(i *big.Int) (C.duckdb_hugeint, error) {
+	d := big.NewInt(1)
+	d.Lsh(d, 64)
+
+	q := new(big.Int)
+	r := new(big.Int)
+	q.DivMod(i, d, r)
+
+	if !q.IsInt64() {
+		return C.duckdb_hugeint{}, fmt.Errorf("big.Int(%s) is too big for HUGEINT", i.String())
 	}
+
+	return C.duckdb_hugeint{
+		lower: C.uint64_t(r.Uint64()),
+		upper: C.int64_t(q.Int64()),
+	}, nil
 }
 
 type Map map[any]any


### PR DESCRIPTION
Solves https://github.com/marcboeker/go-duckdb/issues/50.

During this work, I realized we're using `float64` for `DECIMAL` types. Before merging this, should I extend the PR to use `big.Float` for `DECIMAL` types as well? 