### PR TITLE
conn pool consistency fix

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -13,7 +13,6 @@ import (
 )
 
 type conn struct {
-	db     *C.duckdb_database
 	con    *C.duckdb_connection
 	closed bool
 	tx     bool
@@ -88,8 +87,6 @@ func (c *conn) Close() error {
 	c.closed = true
 
 	C.duckdb_disconnect(c.con)
-	C.duckdb_close(c.db)
-	c.db = nil
 
 	return nil
 }

--- a/duckdb.go
+++ b/duckdb.go
@@ -1,7 +1,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// Package duckdb implements a databse/sql driver for the DuckDB database.
+// Package duckdb implements a database/sql driver for the DuckDB database.
 package duckdb
 
 /*
@@ -10,6 +10,7 @@ package duckdb
 import "C"
 
 import (
+	"context"
 	"database/sql"
 	"database/sql/driver"
 	"errors"
@@ -19,14 +20,21 @@ import (
 )
 
 func init() {
-	sql.Register("duckdb", impl{})
+	sql.Register("duckdb", Driver{})
 }
 
-type impl struct{}
+type Driver struct{}
 
-func (impl) Open(dataSourceName string) (driver.Conn, error) {
+func (d Driver) Open(dataSourceName string) (driver.Conn, error) {
+	connector, err := d.OpenConnector(dataSourceName)
+	if err != nil {
+		return nil, err
+	}
+	return connector.Connect(context.Background())
+}
+
+func (Driver) OpenConnector(dataSourceName string) (driver.Connector, error) {
 	var db C.duckdb_database
-	var con C.duckdb_connection
 
 	parsedDSN, err := url.Parse(dataSourceName)
 	if err != nil {
@@ -55,11 +63,29 @@ func (impl) Open(dataSourceName string) (driver.Conn, error) {
 		}
 	}
 
-	if state := C.duckdb_connect(db, &con); state == C.DuckDBError {
+	return &connector{db: &db}, nil
+}
+
+type connector struct {
+	db *C.duckdb_database
+}
+
+func (c *connector) Driver() driver.Driver {
+	return Driver{}
+}
+
+func (c *connector) Connect(context.Context) (driver.Conn, error) {
+	var con C.duckdb_connection
+	if state := C.duckdb_connect(*c.db, &con); state == C.DuckDBError {
 		return nil, openError
 	}
+	return &conn{con: &con}, nil
+}
 
-	return &conn{db: &db, con: &con}, nil
+func (c *connector) Close() error {
+	C.duckdb_close(c.db)
+	c.db = nil
+	return nil
 }
 
 func prepareConfig(options map[string][]string) (C.duckdb_config, error) {


### PR DESCRIPTION
Fixes a consistency bug where changes made in one DuckDB connection are not immediately reflected in other DuckDB connections. Looks like the problem is that In the [go-duckdb](https://github.com/marcboeker/go-duckdb/blob/master/duckdb.go) driver, the Open function creates a new DB handle (using duckdb_open) and new connection handle (using duckdb_connect) each time. So the use of multiple DB handles seems to be the problem here. Thanks @begelundmuller for the analysis.

Driver now implements `DriverContext` so `sql.DB` will call `OpenConnector` to obtain a Connector and then invoke
that Connector's Connect method to obtain each needed connection instead of invoking Driver's Open method which was creating new `C.duckdb_database` each time. Now we create database object once on call to `OpenConnector` and call `C.duckdb_connect` on same database to obtain new connections on call to `Connect`.