### PR TITLE
connection init function

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,33 @@ If you want to set specific [config options for DuckDB](https://duckdb.org/docs/
 db, err := sql.Open("duckdb", "/path/to/foo.db?access_mode=read_only&threads=4")
 ```
 
+Alternatively, you can also use `sql.OpenDB` when you want to perform some initialization before the connection is created and returned from the connection pool on call to `db.Conn`.
+Here's an example that installs and load json extension for each connection:
+
+```
+	connector, err := duckdb.NewConnector("/path/to/foo.db?access_mode=read_only&threads=4", func(execer driver.Execer) error {
+		bootQueries := []string{
+			"INSTALL 'json'",
+			"LOAD 'json'",
+		}
+
+		for _, qry := range bootQueries {
+			_, err = execer.Exec(qry, nil)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	db := sql.OpenDB(connector)
+	db.SetMaxOpenConns(poolsize)
+	...
+```
+
 Please refer to the [database/sql](https://godoc.org/database/sql) GoDoc for further usage instructions.
 
 ## Linking DuckDB

--- a/duckdb_test.go
+++ b/duckdb_test.go
@@ -59,7 +59,9 @@ func TestConnPool(t *testing.T) {
 
 	// Get two separate connections and check they're consistent
 	conn1, err := db.Conn(context.Background())
+	require.NoError(t, err)
 	conn2, err := db.Conn(context.Background())
+	require.NoError(t, err)
 
 	res, err := conn1.ExecContext(context.Background(), "INSERT INTO foo VALUES ('lala', ?), ('lalo', ?)", 12345, 1234)
 	require.NoError(t, err)
@@ -107,10 +109,11 @@ func TestConnInit(t *testing.T) {
 
 	// Get two separate connections and check they're consistent
 	conn1, err := db.Conn(context.Background())
+	require.NoError(t, err)
 	conn2, err := db.Conn(context.Background())
+	require.NoError(t, err)
 
 	res, err := conn1.ExecContext(context.Background(), "CREATE TABLE example (j JSON)")
-	fmt.Println(err)
 	require.NoError(t, err)
 	ra, err := res.RowsAffected()
 	require.NoError(t, err)


### PR DESCRIPTION
Fixes #62 

The driver implements `Execer` interface which is provided in the init callback function to perform any initializations. Another option is to provide `driver.Conn` handle but it has `Prepare(query string) (Stmt, error)` , `Close()` and `Begin()` methods. So users will have to use `Prepare` and then call `Exec` on `Stmt` interface to execute init queries. 

One more thing to note is that even `Execer` is deprecated, the new interface is `ExecerContext` but driver does not implement it yet.