### PR TITLE
Support immediate query cancellation

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -34,6 +34,8 @@ func (c *conn) ExecContext(ctx context.Context, query string, args []driver.Name
 	}
 
 	if len(args) == 0 {
+		// This should be removed once duckdb_extract_statements and related APIs are available to parse multiple statements
+		// so query cancellation works for this case as well
 		return c.execUnprepared(query)
 	}
 
@@ -51,6 +53,8 @@ func (c *conn) QueryContext(ctx context.Context, query string, args []driver.Nam
 	}
 
 	if len(args) == 0 {
+		// This should be removed once duckdb_extract_statements and related APIs are available to parse multiple statements
+		// so query cancellation works for this case as well
 		return c.queryUnprepared(query)
 	}
 

--- a/connection.go
+++ b/connection.go
@@ -44,7 +44,7 @@ func (c *conn) ExecContext(ctx context.Context, query string, args []driver.Name
 		return nil, err
 	}
 	defer stmt.Close()
-	return stmt.(driver.StmtExecContext).ExecContext(ctx, args)
+	return stmt.ExecContext(ctx, args)
 }
 
 func (c *conn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
@@ -63,7 +63,7 @@ func (c *conn) QueryContext(ctx context.Context, query string, args []driver.Nam
 		return nil, err
 	}
 
-	return stmt.(driver.StmtQueryContext).QueryContext(ctx, args)
+	return stmt.QueryContext(ctx, args)
 }
 
 func (c *conn) Prepare(cmd string) (driver.Stmt, error) {
@@ -112,7 +112,7 @@ func (c *conn) Close() error {
 	return nil
 }
 
-func (c *conn) prepareStmt(cmd string) (driver.Stmt, error) {
+func (c *conn) prepareStmt(cmd string) (*stmt, error) {
 	cmdstr := C.CString(cmd)
 	defer C.free(unsafe.Pointer(cmdstr))
 

--- a/duckdb.go
+++ b/duckdb.go
@@ -34,15 +34,15 @@ func (d Driver) Open(dataSourceName string) (driver.Conn, error) {
 }
 
 func (Driver) OpenConnector(dataSourceName string) (driver.Connector, error) {
-	return createConnector(dataSourceName, func(execerContext driver.Execer) error { return nil })
+	return createConnector(dataSourceName, func(execerContext driver.ExecerContext) error { return nil })
 }
 
 // NewConnector creates a new Connector for the DuckDB database.
-func NewConnector(dsn string, connInitFn func(execer driver.Execer) error) (driver.Connector, error) {
+func NewConnector(dsn string, connInitFn func(execer driver.ExecerContext) error) (driver.Connector, error) {
 	return createConnector(dsn, connInitFn)
 }
 
-func createConnector(dataSourceName string, connInitFn func(execer driver.Execer) error) (driver.Connector, error) {
+func createConnector(dataSourceName string, connInitFn func(execer driver.ExecerContext) error) (driver.Connector, error) {
 	var db C.duckdb_database
 
 	parsedDSN, err := url.Parse(dataSourceName)
@@ -77,7 +77,7 @@ func createConnector(dataSourceName string, connInitFn func(execer driver.Execer
 
 type connector struct {
 	db         *C.duckdb_database
-	connInitFn func(execer driver.Execer) error
+	connInitFn func(execer driver.ExecerContext) error
 }
 
 func (c *connector) Driver() driver.Driver {

--- a/duckdb_test.go
+++ b/duckdb_test.go
@@ -88,14 +88,14 @@ func TestConnPool(t *testing.T) {
 }
 
 func TestConnInit(t *testing.T) {
-	connector, err := NewConnector("", func(execer driver.Execer) error {
+	connector, err := NewConnector("", func(execer driver.ExecerContext) error {
 		bootQueries := []string{
 			"INSTALL 'json'",
 			"LOAD 'json'",
 		}
 
 		for _, qry := range bootQueries {
-			_, err := execer.Exec(qry, nil)
+			_, err := execer.ExecContext(context.Background(), qry, nil)
 			if err != nil {
 				return err
 			}

--- a/statement.go
+++ b/statement.go
@@ -6,6 +6,7 @@ package duckdb
 import "C"
 
 import (
+	"context"
 	"database/sql/driver"
 	"errors"
 	"fmt"
@@ -148,6 +149,7 @@ func (s *stmt) start(args []driver.Value) error {
 	return nil
 }
 
+// Deprecated: Use ExecContext instead. This can be removed once driver.Execer implementation is removed from connection.go
 func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
 	if s.closed {
 		panic("database/sql/driver: misuse of duckdb driver: Exec after Close")
@@ -175,6 +177,71 @@ func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
 	return &result{ra}, nil
 }
 
+func (s *stmt) ExecContext(ctx context.Context, nargs []driver.NamedValue) (driver.Result, error) {
+	if s.closed {
+		panic("database/sql/driver: misuse of duckdb driver: ExecContext after Close")
+	}
+	if s.rows {
+		panic("database/sql/driver: misuse of duckdb driver: ExecContext with active Rows")
+	}
+
+	args, err := namedValueToValue(nargs)
+	if err != nil {
+		return nil, err
+	}
+	err = s.start(args)
+	if err != nil {
+		return nil, err
+	}
+
+	var pendingRes C.duckdb_pending_result
+	if state := C.duckdb_pending_prepared(*s.stmt, &pendingRes); state == C.DuckDBError {
+		dbErr := C.GoString(C.duckdb_pending_error(pendingRes))
+		C.duckdb_destroy_pending(&pendingRes)
+		C.duckdb_destroy_prepare(s.stmt)
+		return nil, errors.New(dbErr)
+	}
+	defer C.duckdb_destroy_pending(&pendingRes)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+			// continue
+		}
+		state := C.duckdb_pending_execute_task(pendingRes)
+		ready := false
+		switch state {
+		case C.DUCKDB_PENDING_RESULT_READY:
+			// we are done processing the query, now get the results
+			ready = true
+		case C.DUCKDB_PENDING_ERROR:
+			dbErr := C.GoString(C.duckdb_pending_error(pendingRes))
+			return nil, errors.New(dbErr)
+		case C.DUCKDB_PENDING_RESULT_NOT_READY:
+			// we need to wait for the task to finish
+		default:
+			panic(fmt.Sprintf("found unkonwn state while pending execute: %T", state))
+		}
+		if ready {
+			break
+		}
+	}
+
+	var res C.duckdb_result
+	if state := C.duckdb_execute_pending(pendingRes, &res); state == C.DuckDBError {
+		dbErr := C.GoString(C.duckdb_result_error(&res))
+		C.duckdb_destroy_result(&res)
+		return nil, errors.New(dbErr)
+	}
+	defer C.duckdb_destroy_result(&res)
+
+	ra := int64(C.duckdb_value_int64(&res, 0, 0))
+	return &result{ra}, nil
+}
+
+// Deprecated: Use QueryContext instead. This can be removed once driver.Queryer implementation is removed from connection.go
 func (s *stmt) Query(args []driver.Value) (driver.Rows, error) {
 	if s.closed {
 		panic("database/sql/driver: misuse of duckdb driver: Query after Close")
@@ -198,6 +265,79 @@ func (s *stmt) Query(args []driver.Value) (driver.Rows, error) {
 	s.rows = true
 
 	return newRowsWithStmt(res, s), nil
+}
+
+func (s *stmt) QueryContext(ctx context.Context, nargs []driver.NamedValue) (driver.Rows, error) {
+	if s.closed {
+		panic("database/sql/driver: misuse of duckdb driver: QueryContext after Close")
+	}
+	if s.rows {
+		panic("database/sql/driver: misuse of duckdb driver: QueryContext with active Rows")
+	}
+
+	args, err := namedValueToValue(nargs)
+	if err != nil {
+		return nil, err
+	}
+	err = s.start(args)
+	if err != nil {
+		return nil, err
+	}
+
+	var pendingRes C.duckdb_pending_result
+	if state := C.duckdb_pending_prepared(*s.stmt, &pendingRes); state == C.DuckDBError {
+		dbErr := C.GoString(C.duckdb_pending_error(pendingRes))
+		C.duckdb_destroy_pending(&pendingRes)
+		C.duckdb_destroy_prepare(s.stmt)
+		return nil, errors.New(dbErr)
+	}
+	defer C.duckdb_destroy_pending(&pendingRes)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+			// continue
+		}
+		state := C.duckdb_pending_execute_task(pendingRes)
+		ready := false
+		switch state {
+		case C.DUCKDB_PENDING_RESULT_READY:
+			// we are done processing the query, now get the results
+			ready = true
+		case C.DUCKDB_PENDING_ERROR:
+			dbErr := C.GoString(C.duckdb_pending_error(pendingRes))
+			return nil, errors.New(dbErr)
+		case C.DUCKDB_PENDING_RESULT_NOT_READY:
+			// we need to wait for the task to finish
+		default:
+			panic(fmt.Sprintf("found unkonwn state while pending execute: %T", state))
+		}
+		if ready {
+			break
+		}
+	}
+
+	var res C.duckdb_result
+	if state := C.duckdb_execute_pending(pendingRes, &res); state == C.DuckDBError {
+		dbErr := C.GoString(C.duckdb_result_error(&res))
+		C.duckdb_destroy_result(&res)
+		return nil, errors.New(dbErr)
+	}
+	s.rows = true
+	return newRowsWithStmt(res, s), nil
+}
+
+func namedValueToValue(named []driver.NamedValue) ([]driver.Value, error) {
+	args := make([]driver.Value, len(named))
+	for n, param := range named {
+		if len(param.Name) > 0 {
+			return nil, errors.New("sql: driver does not support the use of Named Parameters")
+		}
+		args[n] = param.Value
+	}
+	return args, nil
 }
 
 var (

--- a/statement.go
+++ b/statement.go
@@ -236,17 +236,6 @@ func (s *stmt) execute(ctx context.Context, args []driver.NamedValue) (*C.duckdb
 	return &res, nil
 }
 
-func namedArgsToArgs(named []driver.NamedValue) ([]driver.Value, error) {
-	args := make([]driver.Value, len(named))
-	for n, param := range named {
-		if len(param.Name) > 0 {
-			return nil, errors.New("duckdb: driver does not support the use of Named Parameters")
-		}
-		args[n] = param.Value
-	}
-	return args, nil
-}
-
 func argsToNamedArgs(values []driver.Value) []driver.NamedValue {
 	args := make([]driver.NamedValue, len(values))
 	for n, param := range values {

--- a/statement.go
+++ b/statement.go
@@ -220,7 +220,7 @@ func (s *stmt) ExecContext(ctx context.Context, nargs []driver.NamedValue) (driv
 			dbErr := C.GoString(C.duckdb_pending_error(pendingRes))
 			return nil, errors.New(dbErr)
 		case C.DUCKDB_PENDING_RESULT_NOT_READY:
-			// we need to wait for the task to finish
+			// we are not done yet, continue to next task
 		default:
 			panic(fmt.Sprintf("found unkonwn state while pending execute: %T", state))
 		}
@@ -310,7 +310,7 @@ func (s *stmt) QueryContext(ctx context.Context, nargs []driver.NamedValue) (dri
 			dbErr := C.GoString(C.duckdb_pending_error(pendingRes))
 			return nil, errors.New(dbErr)
 		case C.DUCKDB_PENDING_RESULT_NOT_READY:
-			// we need to wait for the task to finish
+			// we are not done yet, continue to next task
 		default:
 			panic(fmt.Sprintf("found unkonwn state while pending execute: %T", state))
 		}

--- a/transaction.go
+++ b/transaction.go
@@ -1,7 +1,10 @@
 package duckdb
 
+import "context"
+
 type tx struct {
-	c *conn
+	ctx context.Context
+	c   *conn
 }
 
 func (t *tx) Commit() error {
@@ -10,7 +13,7 @@ func (t *tx) Commit() error {
 	}
 
 	t.c.tx = false
-	_, err := t.c.Exec("COMMIT TRANSACTION", nil)
+	_, err := t.c.ExecContext(t.ctx, "COMMIT TRANSACTION", nil)
 	t.c = nil
 
 	return err
@@ -22,7 +25,7 @@ func (t *tx) Rollback() error {
 	}
 
 	t.c.tx = false
-	_, err := t.c.Exec("ROLLBACK", nil)
+	_, err := t.c.ExecContext(t.ctx, "ROLLBACK", nil)
 	t.c = nil
 
 	return err

--- a/transaction.go
+++ b/transaction.go
@@ -3,8 +3,7 @@ package duckdb
 import "context"
 
 type tx struct {
-	ctx context.Context
-	c   *conn
+	c *conn
 }
 
 func (t *tx) Commit() error {
@@ -13,7 +12,7 @@ func (t *tx) Commit() error {
 	}
 
 	t.c.tx = false
-	_, err := t.c.ExecContext(t.ctx, "COMMIT TRANSACTION", nil)
+	_, err := t.c.ExecContext(context.Background(), "COMMIT TRANSACTION", nil)
 	t.c = nil
 
 	return err
@@ -25,7 +24,7 @@ func (t *tx) Rollback() error {
 	}
 
 	t.c.tx = false
-	_, err := t.c.ExecContext(t.ctx, "ROLLBACK", nil)
+	_, err := t.c.ExecContext(context.Background(), "ROLLBACK", nil)
 	t.c = nil
 
 	return err


### PR DESCRIPTION
Fixes #60 and #43 

Mainly query is executed in steps and context is checked before executing each step. It uses Pending Result Interface C APIs to achieve this. Reference - https://duckdb.org/docs/api/c/api#pending-result-interface