### PR TITLE
Return err instead of panic for invalid map keys

### DIFF
--- a/duckdb_test.go
+++ b/duckdb_test.go
@@ -286,6 +286,12 @@ func TestMap(t *testing.T) {
 		}, m)
 	})
 
+	t.Run("select nested map", func(t *testing.T) {
+		var m Map
+		err := db.QueryRow("SELECT map([map([1], [1]), map([2], [2])], ['a', 'e'])").Scan(&m)
+		require.ErrorIs(t, err, errUnsupportedMapKeyType)
+	})
+
 	t.Run("insert map", func(t *testing.T) {
 		tests := []struct {
 			sqlType string


### PR DESCRIPTION
It seems DuckDB supports more map key types than Go, causing the assignment `out[key] = val` to panic. This PR adds a check that map key types are comparable and returns an error if not.

An alternative would be to not scan DuckDB maps into Go `map`, but instead directly return the list object containing `{"key": ..., "value": ...}` maps. What do you prefer?
