### PR TITLE
fix: release allocated memory for data chunks

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -56,6 +56,7 @@ func (r *rows) Columns() []string {
 
 func (r *rows) Next(dst []driver.Value) error {
 	for r.chunkRowIdx == r.chunkRowCount {
+		C.duckdb_destroy_data_chunk(&r.chunk)
 		if r.chunkIdx == r.chunkCount {
 			return io.EOF
 		}
@@ -257,6 +258,7 @@ func (r *rows) ColumnTypeDatabaseTypeName(index int) string {
 }
 
 func (r *rows) Close() error {
+	C.duckdb_destroy_data_chunk(&r.chunk)
 	C.duckdb_destroy_result(&r.res)
 
 	if r.stmt != nil {


### PR DESCRIPTION
This PR aims to fix #81  by making sure that the memory allocated to each chunk of data from the result will be released before next chunk is fetched. 

## Memory usage without the fix
The memory keeps increasing each time the parquet-file is processed.

The graph below shows the memory usage when running inside a docker container
![memory usage without fix](https://user-images.githubusercontent.com/124244/224948910-f6cc42d3-25d1-4a88-b1ae-54af1668f673.png)

The video below shows the memory usage when running without docker
https://user-images.githubusercontent.com/124244/224948192-fd569a41-0140-4516-aaec-4c80f4f9fcba.mov

## Memory usage with the fix
When running inside a docker container you can see that the memory stabilizes and will not increase further regardless of recurrent file processes.
![memory usage with fix](https://user-images.githubusercontent.com/124244/224949056-6d9ec4df-a025-4ae4-ae86-d501ea6893d5.png)

When we are running without docker you can see that the the memory is released and does not increase on recurrent requests
https://user-images.githubusercontent.com/124244/224948151-72abef6d-5974-462a-8830-c3bcd41c44a7.mov



