### PR TITLE
feat: better decimal support

### DIFF
--- a/duckdb_test.go
+++ b/duckdb_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math"
 	"math/big"
 	"reflect"
 	"testing"
@@ -359,6 +358,12 @@ func TestList(t *testing.T) {
 	})
 }
 
+func compareDecimal(t *testing.T, want Decimal, got Decimal) {
+	require.Equal(t, want.Scale, got.Scale)
+	require.Equal(t, want.Width, got.Width)
+	require.True(t, want.Value.Cmp(got.Value) == 0)
+}
+
 func TestDecimal(t *testing.T) {
 	t.Parallel()
 	db := openDB(t)
@@ -366,9 +371,9 @@ func TestDecimal(t *testing.T) {
 
 	t.Run("decimal widths", func(t *testing.T) {
 		for i := 1; i <= 38; i++ {
-			var f float64 = 999
+			var f Decimal
 			require.NoError(t, db.QueryRow(fmt.Sprintf("SELECT 0::DECIMAL(%d, 1)", i)).Scan(&f))
-			require.Equal(t, float64(0), f)
+			require.Equal(t, Decimal{Width: uint8(i), Value: big.NewInt(0), Scale: 1}, f)
 		}
 	})
 
@@ -377,26 +382,44 @@ func TestDecimal(t *testing.T) {
 			(1.23 :: DECIMAL(3, 2)),
 			(123.45 :: DECIMAL(5, 2)),
 			(123456789.01 :: DECIMAL(11, 2)),
-			(1234567890123456789.234 :: DECIMAL(22, 3)),
+			(12345678901234.567 :: DECIMAL(22, 3)),
 		) v
 		ORDER BY v ASC`)
 		require.NoError(t, err)
 		defer rows.Close()
 
-		want := []float64{1.23, 123.45, 123456789.01, 1234567890123456789.234}
+		// TODO: We cannot go higher than this right due to an issue with duckdb's query parser.
+		bigNumber, success := new(big.Int).SetString("12345678901234567", 10)
+		require.True(t, success, "failed to parse big number")
+		want := []Decimal{
+			{Value: big.NewInt(1230), Width: 22, Scale: 3},
+			{Value: big.NewInt(123450), Width: 22, Scale: 3},
+			{Value: big.NewInt(123456789010), Width: 22, Scale: 3},
+			{Value: bigNumber, Width: 22, Scale: 3}}
 		i := 0
 		for rows.Next() {
-			var fs float64
+			var fs Decimal
 			require.NoError(t, rows.Scan(&fs))
-			require.Equal(t, want[i], fs)
+			compareDecimal(t, want[i], fs)
 			i++
 		}
 	})
 
+	// TODO: We get lower precision numbers here due to a bug it what seems duckdb's query parser.
+	// t.Run("huge decimal", func(t *testing.T) {
+	// 	bigNumber, success := new(big.Int).SetString("12345678901234567890123456789", 10)
+	// 	require.True(t, success, "failed to parse big number")
+	// 	var f Decimal
+	// 	require.NoError(t, db.QueryRow("SELECT 123456789.01234567890123456789 :: DECIMAL(38, 20)").Scan(&f))
+	// 	compareDecimal(t, Decimal{Value: bigNumber, Width: 38, Scale: 20}, f)
+	// })
+
 	t.Run("huge decimal", func(t *testing.T) {
-		var f float64
-		require.NoError(t, db.QueryRow("SELECT 123456789.01234567890123456789 :: DECIMAL(38, 20)").Scan(&f))
-		require.True(t, math.Abs(float64(123456789.01234567890123456789)-f) < 0.0000001)
+		bigNumber, success := new(big.Int).SetString("123456789012345612", 10)
+		require.True(t, success, "failed to parse big number")
+		var f Decimal
+		require.NoError(t, db.QueryRow("SELECT 1234567890123456.12 :: DECIMAL(38, 2)").Scan(&f))
+		compareDecimal(t, Decimal{Value: bigNumber, Width: 38, Scale: 2}, f)
 	})
 }
 
@@ -844,9 +867,9 @@ func TestTypeNamesAndScanTypes(t *testing.T) {
 		},
 		// DUCKDB_TYPE_DECIMAL
 		{
-			sql:      "SELECT 31::DECIMAL(30,20) AS col",
-			value:    float64(31),
-			typeName: "DECIMAL(30,20)",
+			sql:      "SELECT 31::DECIMAL(30,17) AS col",
+			value:    Decimal{Value: big.NewInt(3100000000000000000), Width: 30, Scale: 17},
+			typeName: "DECIMAL(30,17)",
 		},
 		// DUCKDB_TYPE_TIMESTAMP_S
 		{


### PR DESCRIPTION
Hey all,

go-duckdb currently offers rudimentary decimal support by casting them to float64. This is problematic as precision is lost during this conversion, so one cannot use this library currently for anything decimal involved that requires no loss of precision (e.g. money handling).

I tried adding  decimal support that transparently surfaces the decimals from duckdb, so one can do whatever you want with them.

As an example on how to use them with the popular decimal library from shopspring:

```go
import (
  "github.com/shopspring/decimal"
)

shopspringDecimal := decimal.NewFromBigInt(f.Value, -int32(f.Scale))
```

There is a bug when querying for decimal values like seen in the commented out tests. It's a bug with duckdbs query parser that appears when using the amalgamation. The following text was the initial debugging, but it's a problem that surfaces in duckdb code.

<details>
  <summary>Open initial investigation</summary>
  
It's _mostly_ working, but there is a strange bug that I seems to be deeper then what I am doing here.
Decimals that have hugeints are not correctly converted, but instead have the same precision what seems a float64 would have. I haven't really dig deep there, but as I'm using the already available `hugeIntToNative` that returns the wrong number. It must be somewhere there. The normal hugeint conversion works fine though and doesn't exhibit this problem.

Happy to look into this if anybody has some pointers.

### UPDATE:

I cross checked with the official JDBC driver to see where the issue might appear. First I tried to align the current hugeIntToNative to the [java version](https://github.com/duckdb/duckdb/blob/dd0e0da3f0d1dfc8d9cb0d7f02571b223c496c44/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSet.java#L771):

```go
var ulongMultiplier, _ = new(big.Int).SetString("18446744073709551616", 10)
func hugeIntToNative(hi C.duckdb_hugeint) *big.Int {
	i := big.NewInt(int64(hi.upper))
	i.Mul(i, ulongMultiplier)
	i.Add(i, new(big.Int).SetUint64(uint64(hi.lower)))
	return i
}
```

But this yields the exact same results.

I went then looking how the `lower` and `upper` values look in the java vs go version. I added a new java test case to the jdbc tests.

<details>
  <summary>The java test</summary>

```java
	public static void test_decimal_again() throws Exception {
		Connection conn = DriverManager.getConnection("jdbc:duckdb:");
		Statement stmt = conn.createStatement();

		ResultSet rs = stmt.executeQuery(
				"SELECT 123456789.01234567890123456789 :: DECIMAL(38, 20) d");

		assertTrue(rs.next());
		BigDecimal result = rs.getBigDecimal("d");
		assertEquals(result, new BigDecimal("123456789.01234567890123456789"));

		assertFalse(rs.next());
		rs.close();
		stmt.close();
		conn.close();
	}
```
</details>

And looked what the values are. They are different:

Java yields:
* upper - `669260594`
* lower - `5097733592125636885 (0x46bec9b16e398115)`

Go yields:
* upper - `669260594`
* lower - `5097731730555535369 (0x46bec80000000009)`

Which looks like the `lower` value gets cut off somewhere. Most likely in the `get` function.
</details>