### PR TITLE
use extract statement api - better support for multiple statments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 run.sh
 duckdb/
 /lib
+.idea

--- a/connection.go
+++ b/connection.go
@@ -91,6 +91,7 @@ func (c *conn) QueryContext(ctx context.Context, query string, args []driver.Nam
 	// prepare and execute last statement with args and return result
 	stmt, err := c.prepareExtractedStmt(stmts, size-1)
 	if err != nil {
+		stmt.Close()
 		return nil, err
 	}
 

--- a/connection.go
+++ b/connection.go
@@ -33,13 +33,26 @@ func (c *conn) ExecContext(ctx context.Context, query string, args []driver.Name
 		panic("database/sql/driver: misuse of duckdb driver: ExecContext after Close")
 	}
 
-	if len(args) == 0 {
-		// This should be removed once duckdb_extract_statements and related APIs are available to parse multiple statements
-		// so query cancellation works for this case as well
-		return c.execUnprepared(query)
+	stmts, size := c.extractStmts(query)
+	if size == 0 {
+		return nil, errors.New("no statements found")
 	}
 
-	stmt, err := c.prepareStmt(query)
+	// execute all statements but the last one, apply args only to last statement and return result of last statement
+	for i := C.idx_t(0); i < size-1; i++ {
+		stmt, err := c.prepareExtractedStmt(stmts, i)
+		if err != nil {
+			return nil, err
+		}
+		defer stmt.Close()
+		// send nil args to execute statement and ignore result
+		_, err = stmt.ExecContext(ctx, nil)
+		if err != nil {
+			return nil, err
+		}
+	}
+	// prepare and execute last statement with args and return result
+	stmt, err := c.prepareExtractedStmt(stmts, size-1)
 	if err != nil {
 		return nil, err
 	}
@@ -52,13 +65,25 @@ func (c *conn) QueryContext(ctx context.Context, query string, args []driver.Nam
 		panic("database/sql/driver: misuse of duckdb driver: QueryContext after Close")
 	}
 
-	if len(args) == 0 {
-		// This should be removed once duckdb_extract_statements and related APIs are available to parse multiple statements
-		// so query cancellation works for this case as well
-		return c.queryUnprepared(query)
+	stmts, size := c.extractStmts(query)
+	if size == 0 {
+		return nil, errors.New("no statements found")
 	}
 
-	stmt, err := c.prepareStmt(query)
+	// execute all statements but the last one, apply args only to last statement and return result of last statement
+	for i := C.idx_t(0); i < size-1; i++ {
+		stmt, err := c.prepareExtractedStmt(stmts, i)
+		if err != nil {
+			return nil, err
+		}
+		// send nil args to execute statement and ignore result
+		_, err = stmt.QueryContext(ctx, nil)
+		if err != nil {
+			return nil, err
+		}
+	}
+	// prepare and execute last statement with args and return result
+	stmt, err := c.prepareExtractedStmt(stmts, size-1)
 	if err != nil {
 		return nil, err
 	}
@@ -127,33 +152,25 @@ func (c *conn) prepareStmt(cmd string) (*stmt, error) {
 	return &stmt{c: c, stmt: &s}, nil
 }
 
-func (c *conn) execUnprepared(cmd string) (driver.Result, error) {
-	cmdstr := C.CString(cmd)
-	defer C.free(unsafe.Pointer(cmdstr))
+func (c *conn) extractStmts(query string) (C.duckdb_extracted_statements, C.idx_t) {
+	cquery := C.CString(query)
+	defer C.free(unsafe.Pointer(cquery))
 
-	var res C.duckdb_result
-	err := C.duckdb_query(*c.con, cmdstr, &res)
-	defer C.duckdb_destroy_result(&res)
+	var stmts C.duckdb_extracted_statements
+	var stmtCount C.idx_t
+	stmtCount = C.duckdb_extract_statements(*c.con, cquery, &stmts)
 
-	if err == C.DuckDBError {
-		dbErr := C.GoString(C.duckdb_result_error(&res))
-		return nil, errors.New(dbErr)
-	}
-
-	ra := int64(C.duckdb_value_int64(&res, 0, 0))
-	return &result{ra}, nil
+	return stmts, stmtCount
 }
 
-func (c *conn) queryUnprepared(cmd string) (driver.Rows, error) {
-	cmdstr := C.CString(cmd)
-	defer C.free(unsafe.Pointer(cmdstr))
+func (c *conn) prepareExtractedStmt(extractedStmts C.duckdb_extracted_statements, index C.idx_t) (*stmt, error) {
+	var s C.duckdb_prepared_statement
+	if state := C.duckdb_prepare_extracted_statement(*c.con, extractedStmts, index, &s); state == C.DuckDBError {
+		dbErr := C.GoString(C.duckdb_prepare_error(s))
+		C.duckdb_destroy_prepare(&s)
 
-	var res C.duckdb_result
-	if err := C.duckdb_query(*c.con, cmdstr, &res); err == C.DuckDBError {
-		dbErr := C.GoString(C.duckdb_result_error(&res))
-		C.duckdb_destroy_result(&res)
 		return nil, errors.New(dbErr)
 	}
 
-	return newRows(res), nil
+	return &stmt{c: c, stmt: &s}, nil
 }

--- a/duckdb_test.go
+++ b/duckdb_test.go
@@ -907,7 +907,27 @@ func TestMultipleStatements(t *testing.T) {
 	db := openDB(t)
 	defer db.Close()
 
-	_, err := db.Exec("CREATE TABLE foo (x text); CREATE TABLE bar (x text);")
+	// test empty query
+	_, err := db.Exec("")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no statements found")
+
+	// test invalid query
+	_, err = db.Exec("abc;")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "syntax error at or near \"abc\"")
+
+	// test valid + invalid query
+	_, err = db.Exec("CREATE TABLE foo (x text); abc;")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "syntax error at or near \"abc\"")
+
+	// test invalid + valid query
+	_, err = db.Exec("abc; CREATE TABLE foo (x text);")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "syntax error at or near \"abc\"")
+
+	_, err = db.Exec("CREATE TABLE foo (x text); CREATE TABLE bar (x text);")
 	require.NoError(t, err)
 
 	_, err = db.Exec("INSERT INTO foo VALUES (?); INSERT INTO bar VALUES (?);", "hello", "world")

--- a/rows.go
+++ b/rows.go
@@ -262,8 +262,10 @@ func (r *rows) Close() error {
 	C.duckdb_destroy_result(&r.res)
 
 	if r.stmt != nil {
-		C.duckdb_destroy_prepare(r.stmt.stmt)
 		r.stmt.rows = false
+		if r.stmt.closeOnRowsClose {
+			r.stmt.Close()
+		}
 		r.stmt = nil
 	}
 

--- a/rows.go
+++ b/rows.go
@@ -261,15 +261,16 @@ func (r *rows) Close() error {
 	C.duckdb_destroy_data_chunk(&r.chunk)
 	C.duckdb_destroy_result(&r.res)
 
+	var err error
 	if r.stmt != nil {
 		r.stmt.rows = false
 		if r.stmt.closeOnRowsClose {
-			r.stmt.Close()
+			err = r.stmt.Close()
 		}
 		r.stmt = nil
 	}
 
-	return nil
+	return err
 }
 
 func get[T any](vector C.duckdb_vector, rowIdx C.idx_t) T {

--- a/statement.go
+++ b/statement.go
@@ -16,10 +16,11 @@ import (
 )
 
 type stmt struct {
-	c      *conn
-	stmt   *C.duckdb_prepared_statement
-	closed bool
-	rows   bool
+	c                *conn
+	stmt             *C.duckdb_prepared_statement
+	closeOnRowsClose bool
+	closed           bool
+	rows             bool
 }
 
 func (s *stmt) Close() error {
@@ -198,7 +199,6 @@ func (s *stmt) execute(ctx context.Context, args []driver.NamedValue) (*C.duckdb
 	if state := C.duckdb_pending_prepared(*s.stmt, &pendingRes); state == C.DuckDBError {
 		dbErr := C.GoString(C.duckdb_pending_error(pendingRes))
 		C.duckdb_destroy_pending(&pendingRes)
-		C.duckdb_destroy_prepare(s.stmt)
 		return nil, errors.New(dbErr)
 	}
 	defer C.duckdb_destroy_pending(&pendingRes)


### PR DESCRIPTION
Fixes https://github.com/marcboeker/go-duckdb/issues/55

Use extract statement api to split query into multiple statements. Then execute all but the last statement (without applying any args), if there are no errors then apply the args (if any) to the last statement and return the results. 

This behaviour is same as [Python](https://github.com/duckdb/duckdb/blob/master/tools/pythonpkg/src/pyconnection.cpp#L440) and [C](https://github.com/duckdb/duckdb/blob/master/test/api/capi/test_capi_extract.cpp#L6) driver.

I don't think [Prepare](https://github.com/marcboeker/go-duckdb/blob/master/connection.go#L69) method on `Conn` can be called with multiple statements, so it still uses older `prepareStmt` method without using extract api.