### PR TITLE
Automatic Build Support for ARM on Linux

### DIFF
--- a/.github/workflows/deps.yaml
+++ b/.github/workflows/deps.yaml
@@ -50,9 +50,27 @@ jobs:
           name: linux_amd64
           path: deps/linux_amd64/libduckdb.a
           retention-days: 1
+  linux_arm64:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Install cross compile toolchain
+        shell: bash
+        run: |
+          sudo apt update
+          sudo apt install -y g++-aarch64-linux-gnu
+      - shell: bash
+        run: make deps.linux.arm64
+      - uses: actions/upload-artifact@v3
+        with:
+          name: linux_arm64
+          path: deps/linux_arm64/libduckdb.a
+          retention-days: 1
   commit:
     runs-on: ubuntu-latest
-    needs: [darwin_amd64, darwin_arm64, linux_amd64]
+    needs: [darwin_amd64, darwin_arm64, linux_amd64, linux_arm64]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -61,6 +79,7 @@ jobs:
         run: |
           rm -f deps/darwin_amd64/libduckdb.a
           rm -f deps/darwin_arm64/libduckdb.a
+          rm -f deps/linux_amd64/libduckdb.a
           rm -f deps/linux_arm64/libduckdb.a
       - uses: actions/download-artifact@v3
         with:
@@ -74,6 +93,10 @@ jobs:
         with:
           name: linux_amd64
           path: deps/linux_amd64
+      - uses: actions/download-artifact@v3
+        with:
+          name: linux_arm64
+          path: deps/linux_arm64
       - name: Push static libraries
         uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -40,3 +40,10 @@ deps.linux.amd64:
 	g++ -std=c++11 -O3 -DGODUCKDB_FROM_SOURCE -DNDEBUG -c duckdb.cpp
 	ar rvs libduckdb.a duckdb.o
 	mv libduckdb.a deps/linux_amd64/libduckdb.a
+
+.PHONY: deps.linux.arm64
+deps.linux.arm64:
+	if [ "$(shell uname -s | tr '[:upper:]' '[:lower:]')" != "linux" ]; then echo "Error: must run build on linux"; false; fi
+	aarch64-linux-gnu-g++ -std=c++11 -O3 -DGODUCKDB_FROM_SOURCE -DNDEBUG -c duckdb.cpp
+	aarch64-linux-gnu-gcc-ar rvs libduckdb.a duckdb.o
+	mv libduckdb.a deps/linux_arm64/libduckdb.a

--- a/cgo_source.go
+++ b/cgo_source.go
@@ -1,4 +1,4 @@
-//go:build !duckdb_use_lib && (duckdb_from_source || !(darwin || linux))
+//go:build !(duckdb_use_lib || duckdb_from_source) && (darwin || (linux && (amd64 || arm64)))
 
 package duckdb
 

--- a/cgo_source.go
+++ b/cgo_source.go
@@ -1,4 +1,4 @@
-//go:build !duckdb_use_lib && (duckdb_from_source || !(darwin || (linux && amd64)))
+//go:build !duckdb_use_lib && (duckdb_from_source || !(darwin || linux))
 
 package duckdb
 

--- a/cgo_source.go
+++ b/cgo_source.go
@@ -1,4 +1,4 @@
-//go:build !(duckdb_use_lib || duckdb_from_source) && (darwin || (linux && (amd64 || arm64)))
+//go:build !duckdb_use_lib && (duckdb_from_source || !(darwin || (linux && (amd64 || arm64))))
 
 package duckdb
 

--- a/cgo_static.go
+++ b/cgo_static.go
@@ -1,4 +1,4 @@
-//go:build !(duckdb_use_lib || duckdb_from_source) && (darwin || (linux && amd64))
+//go:build !(duckdb_use_lib || duckdb_from_source) && (darwin || linux)
 
 package duckdb
 
@@ -7,6 +7,7 @@ package duckdb
 #cgo darwin,amd64 LDFLAGS: -lc++ -L${SRCDIR}/deps/darwin_amd64
 #cgo darwin,arm64 LDFLAGS: -lc++ -L${SRCDIR}/deps/darwin_arm64
 #cgo linux,amd64 LDFLAGS: -lstdc++ -lm -ldl -L${SRCDIR}/deps/linux_amd64
+#cgo linux,arm64 LDFLAGS: -lstdc++ -lm -ldl -L${SRCDIR}/deps/linux_arm64
 #include <duckdb.h>
 */
 import "C"

--- a/cgo_static.go
+++ b/cgo_static.go
@@ -1,4 +1,4 @@
-//go:build !duckdb_use_lib && (darwin || (linux && (amd64 || arm64)))
+//go:build !(duckdb_use_lib || duckdb_from_source) && (darwin || (linux && (amd64 || arm64)))
 
 package duckdb
 

--- a/cgo_static.go
+++ b/cgo_static.go
@@ -1,4 +1,4 @@
-//go:build !(duckdb_use_lib || duckdb_from_source) && (darwin || linux)
+//go:build !(duckdb_use_lib || duckdb_from_source) && (darwin || (linux && (amd64 || arm64)))
 
 package duckdb
 

--- a/cgo_static.go
+++ b/cgo_static.go
@@ -1,4 +1,4 @@
-//go:build !(duckdb_use_lib || duckdb_from_source) && (darwin || (linux && (amd64 || arm64)))
+//go:build !duckdb_use_lib && (darwin || (linux && (amd64 || arm64)))
 
 package duckdb
 

--- a/deps/linux_arm64/vendor.go
+++ b/deps/linux_arm64/vendor.go
@@ -1,0 +1,3 @@
+// Package linux_arm64 is required to provide support for vendoring modules
+// DO NOT REMOVE
+package linux_arm64


### PR DESCRIPTION
This commit adds automatic build support for ARM64 Linux binaries. This should make it easier for people using low power ARM devices to use DuckDB with Go, but without waiting for long builds or dealing with the complexity of cross-compiling with CGo.