### PR TITLE
Appender: string appender errors should be returned

### DIFF
--- a/appender.go
+++ b/appender.go
@@ -131,10 +131,7 @@ func (a *Appender) AppendRowArray(args []driver.Value) error {
 			rv = C.duckdb_append_blob(*a.appender, unsafe.Pointer(&v[0]), C.uint64_t(len(v)))
 		case string:
 			str := C.CString(v)
-			if rv = C.duckdb_append_varchar(*a.appender, str); rv == C.DuckDBError {
-				C.free(unsafe.Pointer(str))
-				return fmt.Errorf("couldn't append parameter %d (type %T)", i, v)
-			}
+			rv = C.duckdb_append_varchar(*a.appender, str)
 			C.free(unsafe.Pointer(str))
 		case time.Time:
 			var dt C.duckdb_timestamp


### PR DESCRIPTION
This change lets the error case of string appending fall through to the main error handler after the switch.

The solved issue is that with the previous version, the appender error for strings was not returned, thus impossible to troubleshoot.
