### PR TITLE
fix: support negative decimals

### DIFF
--- a/duckdb_test.go
+++ b/duckdb_test.go
@@ -380,9 +380,13 @@ func TestDecimal(t *testing.T) {
 	t.Run("multiple decimal types", func(t *testing.T) {
 		rows, err := db.Query(`SELECT * FROM (VALUES
 			(1.23::DECIMAL(3, 2)),
+			(-1.23::DECIMAL(3, 2)),
 			(123.45::DECIMAL(5, 2)),
+			(-123.45::DECIMAL(5, 2)),
 			(123456789.01::DECIMAL(11, 2)),
+			(-123456789.01::DECIMAL(11, 2)),
 			(1234567890123456789.234::DECIMAL(22, 3)),
+			(-1234567890123456789.234::DECIMAL(22, 3)),
 		) v
 		ORDER BY v ASC`)
 		require.NoError(t, err)
@@ -390,14 +394,20 @@ func TestDecimal(t *testing.T) {
 
 		bigNumber, success := new(big.Int).SetString("1234567890123456789234", 10)
 		require.True(t, success, "failed to parse big number")
+		bigNumberNegative, success := new(big.Int).SetString("-1234567890123456789234", 10)
+		require.True(t, success, "failed to parse big number")
 		tests := []struct {
 			input string
 			want  Decimal
 		}{
 			{input: "1.23::DECIMAL(3, 2)", want: Decimal{Value: big.NewInt(123), Width: 3, Scale: 2}},
+			{input: "-1.23::DECIMAL(3, 2)", want: Decimal{Value: big.NewInt(-123), Width: 3, Scale: 2}},
 			{input: "123.45::DECIMAL(5, 2)", want: Decimal{Value: big.NewInt(12345), Width: 5, Scale: 2}},
+			{input: "-123.45::DECIMAL(5, 2)", want: Decimal{Value: big.NewInt(-12345), Width: 5, Scale: 2}},
 			{input: "123456789.01::DECIMAL(11, 2)", want: Decimal{Value: big.NewInt(12345678901), Width: 11, Scale: 2}},
+			{input: "-123456789.01::DECIMAL(11, 2)", want: Decimal{Value: big.NewInt(-12345678901), Width: 11, Scale: 2}},
 			{input: "1234567890123456789.234::DECIMAL(22, 3)", want: Decimal{Value: bigNumber, Width: 22, Scale: 3}},
+			{input: "-1234567890123456789.234::DECIMAL(22, 3)", want: Decimal{Value: bigNumberNegative, Width: 22, Scale: 3}},
 		}
 		for _, tc := range tests {
 			row := db.QueryRow(fmt.Sprintf("SELECT %s", tc.input))
@@ -421,10 +431,15 @@ func TestDecimal(t *testing.T) {
 			want  float64
 		}{
 			{input: "1.23::DECIMAL(3, 2)", want: 1.23},
+			{input: "-1.23::DECIMAL(3, 2)", want: -1.23},
 			{input: "123.45::DECIMAL(5, 2)", want: 123.45},
+			{input: "-123.45::DECIMAL(5, 2)", want: -123.45},
 			{input: "123456789.01::DECIMAL(11, 2)", want: 123456789.01},
+			{input: "-123456789.01::DECIMAL(11, 2)", want: -123456789.01},
 			{input: "1234567890123456789.234::DECIMAL(22, 3)", want: 1234567890123456789.234},
+			{input: "-1234567890123456789.234::DECIMAL(22, 3)", want: -1234567890123456789.234},
 			{input: "123456789.01234567890123456789::DECIMAL(29, 20)", want: 123456789.01234567890123456789},
+			{input: "-123456789.01234567890123456789::DECIMAL(29, 20)", want: -123456789.01234567890123456789},
 		}
 		for _, tc := range tests {
 			row := db.QueryRow(fmt.Sprintf("SELECT %s", tc.input))


### PR DESCRIPTION
Just hit this problem and noticed we never tested for negative values 🫠. Each decimal we test also has a negative equivalent now.

The problem itself wasn't difficult to pinpoint as instead of e.g. -123 one got 65413, so something was off with signed/unsigned.