### PR TITLE
Use staticlib

### DIFF
--- a/cgo_source.go
+++ b/cgo_source.go
@@ -1,4 +1,4 @@
-//go:build !duckdb_use_lib && (duckdb_from_source || !(darwin || (linux && (amd64 || arm64))))
+//go:build !(duckdb_use_lib || duckdb_use_staticlib) && (duckdb_from_source || !(darwin || (linux && (amd64 || arm64))))
 
 package duckdb
 

--- a/cgo_static.go
+++ b/cgo_static.go
@@ -1,4 +1,4 @@
-//go:build !(duckdb_use_lib || duckdb_from_source) && (darwin || (linux && (amd64 || arm64)))
+//go:build !(duckdb_use_lib || duckdb_from_source || duckdb_use_staticlib) && (darwin || (linux && (amd64 || arm64)))
 
 package duckdb
 

--- a/cgo_staticlib.go
+++ b/cgo_staticlib.go
@@ -1,0 +1,9 @@
+//go:build duckdb_use_staticlib
+
+package duckdb
+
+/*
+#cgo LDFLAGS: -lduckdb_static
+#include <duckdb.h>
+*/
+import "C"


### PR DESCRIPTION
Adds the ability to compile everything statically with an installed duckdb libs.

I tend to compile similar to the following,  but I mostly need the parquet extension:

export CGO_LDFLAGS="-lduckdb_static -lduckdb_re2 -lduckdb_pg_query -lduckdb_fmt -lduckdb_utf8proc -lduckdb_hyperloglog -lduckdb_miniz -lduckdb_fastpforlib -licu_extension -lparquet_extension -lvisualizer_extension -ljemalloc_extension -lduckdb_mbedtls -lduckdb_fsst -ldl -lm -lstdc++"

go build --tags=duckdb_use_staticlib cmd/test_duck.go