### PR TITLE
Fixed heap corruption in windows using duckdb.dll

### DIFF
--- a/duckdb.go
+++ b/duckdb.go
@@ -56,7 +56,7 @@ func createConnector(dataSourceName string, connInitFn func(execer driver.Execer
 
 	// Check for config options.
 	if len(parsedDSN.RawQuery) == 0 {
-		errMsg := C.CString("")
+		var errMsg *C.char
 		defer C.duckdb_free(unsafe.Pointer(errMsg))
 
 		if state := C.duckdb_open_ext(connectionString, &db, nil, &errMsg); state == C.DuckDBError {
@@ -68,7 +68,7 @@ func createConnector(dataSourceName string, connInitFn func(execer driver.Execer
 			return nil, err
 		}
 
-		errMsg := C.CString("")
+		var errMsg *C.char
 		defer C.duckdb_free(unsafe.Pointer(errMsg))
 
 		if state := C.duckdb_open_ext(connectionString, &db, config, &errMsg); state == C.DuckDBError {


### PR DESCRIPTION
**Problem**

There is heap corruption in windows using duckdb.dll caused by freeing memory in wrong module. On successfully opening a connection to duckdb, go-duckdb attempts to free the errMsg empty cgo string allocated in the golang executable by calling the duckdb_free(...) cgo wrapper func for duckdb.dll. This causes heap corruption and immediately panics. On connection error, duckdb.dll allocates the string for the error message so duckdb_free(...) correctly frees the memory.

Issue https://github.com/marcboeker/go-duckdb/issues/24 appears to report this heap corruption.

**Fix**

duckdb_free(...) ultimately calls free(...) in duckdb.dll which safely handles null pointers (observed and documented) so easy fix was to just not allocate an empty string using C.String and leave it as null. Error messages continue to be allocated normally on connection error.