### PR TITLE
interrupt query on ctx cancel/timeout

### DIFF
--- a/duckdb_test.go
+++ b/duckdb_test.go
@@ -1100,6 +1100,22 @@ func TestParquetExtension(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestQueryTimeout(t *testing.T) {
+	db := openDB(t)
+	defer db.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	now := time.Now()
+	_, err := db.ExecContext(ctx, "CREATE TABLE test AS SELECT * FROM range(10000000) t1, range(1000000) t2;")
+	require.True(t, errors.Is(err, context.DeadlineExceeded))
+
+	// a very defensive time check, but should be good enough
+	// the query takes much longer than 10 seconds
+	require.Less(t, time.Since(now), 10*time.Second)
+}
+
 func openDB(t *testing.T) *sql.DB {
 	db, err := sql.Open("duckdb", "")
 	require.NoError(t, err)

--- a/duckdb_test.go
+++ b/duckdb_test.go
@@ -1104,12 +1104,12 @@ func TestQueryTimeout(t *testing.T) {
 	db := openDB(t)
 	defer db.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*250)
 	defer cancel()
 
 	now := time.Now()
 	_, err := db.ExecContext(ctx, "CREATE TABLE test AS SELECT * FROM range(10000000) t1, range(1000000) t2;")
-	require.True(t, errors.Is(err, context.DeadlineExceeded))
+	require.ErrorIs(t, err, context.DeadlineExceeded)
 
 	// a very defensive time check, but should be good enough
 	// the query takes much longer than 10 seconds

--- a/statement.go
+++ b/statement.go
@@ -207,6 +207,8 @@ func (s *stmt) execute(ctx context.Context, args []driver.NamedValue) (*C.duckdb
 		select {
 		// if context is cancelled or deadline exceeded, don't execute further
 		case <-ctx.Done():
+			// also need to interrupt to cancel the query
+			C.duckdb_interrupt(*s.c.con)
 			return nil, ctx.Err()
 		default:
 			// continue


### PR DESCRIPTION
It seems we need to interrupt the query as well when context is cancelled or timed out to properly stop the query. 
Ref : https://discord.com/channels/909674491309850675/921073327009853451/1087993635997491241