### PR TITLE
Appender fixes

### DIFF
--- a/appender.go
+++ b/appender.go
@@ -13,6 +13,8 @@ import (
 	"unsafe"
 )
 
+type UUID [16]byte
+
 // Appender holds the DuckDB appender. It allows to load bulk data into a DuckDB database.
 type Appender struct {
 	c        *conn
@@ -165,7 +167,7 @@ func (a *Appender) initializeChunkTypes(args []driver.Value) {
 			tmpChunkTypes[i] = C.duckdb_create_logical_type(C.DUCKDB_TYPE_BOOLEAN)
 		case []byte:
 			tmpChunkTypes[i] = C.duckdb_create_logical_type(C.DUCKDB_TYPE_BLOB)
-		case [16]byte:
+		case UUID:
 			tmpChunkTypes[i] = C.duckdb_create_logical_type(C.DUCKDB_TYPE_UUID)
 		case string:
 			tmpChunkTypes[i] = C.duckdb_create_logical_type(C.DUCKDB_TYPE_VARCHAR)
@@ -242,7 +244,7 @@ func (a *Appender) appendRowArray(args []driver.Value) error {
 			set[bool](a.chunkVectors[i], a.currentRow, v)
 		case []byte:
 			set[[]byte](a.chunkVectors[i], a.currentRow, v)
-		case [16]byte:
+		case UUID:
 			set[C.duckdb_hugeint](a.chunkVectors[i], a.currentRow, uuidToHugeInt(v))
 		case string:
 			str := C.CString(v)

--- a/appender.go
+++ b/appender.go
@@ -13,8 +13,6 @@ import (
 	"unsafe"
 )
 
-type UUID [16]byte
-
 // Appender holds the DuckDB appender. It allows to load bulk data into a DuckDB database.
 type Appender struct {
 	c        *conn

--- a/appender_test.go
+++ b/appender_test.go
@@ -38,7 +38,7 @@ func createAppenderTable(db *sql.DB, t *testing.T) *sql.Result {
 	return &res
 }
 
-const numAppenderTestRows = 100000
+const numAppenderTestRows = 10000
 
 func randInt(lo int64, hi int64) int64 {
 	return rand.Int63n(hi-lo+1) + lo

--- a/appender_test.go
+++ b/appender_test.go
@@ -14,21 +14,21 @@ import (
 const (
 	testAppenderTableDDL = `
   CREATE TABLE test(
-    id BIGINT,
-	uuid UUID,
-    uint8 UTINYINT,
-    int8 TINYINT,
-    uint16 USMALLINT,
-    int16 SMALLINT,
+		id BIGINT,
+		uuid UUID,
+		uint8 UTINYINT,
+		int8 TINYINT,
+		uint16 USMALLINT,
+		int16 SMALLINT,
 		uint32 UINTEGER,
-    int32 INTEGER,
-    uint64 UBIGINT,
-    int64 BIGINT,
+		int32 INTEGER,
+		uint64 UBIGINT,
+		int64 BIGINT,
 		timestamp TIMESTAMP,
-    float REAL,
-    double DOUBLE,
-    string VARCHAR,
-    bool BOOLEAN
+		float REAL,
+		double DOUBLE,
+		string VARCHAR,
+		bool BOOLEAN
   )`
 )
 

--- a/appender_test.go
+++ b/appender_test.go
@@ -68,7 +68,7 @@ func TestAppender(t *testing.T) {
 
 	type dataRow struct {
 		ID        int
-		UUID      [16]byte
+		UUID      UUID
 		UInt8     uint8
 		Int8      int8
 		UInt16    uint16
@@ -98,7 +98,7 @@ func TestAppender(t *testing.T) {
 		return dataRow{
 			ID:        i,
 			UInt8:     uint8(randInt(0, 255)),
-			UUID:      uuidBytes,
+			UUID:      UUID(uuidBytes),
 			Int8:      int8(randInt(-128, 127)),
 			UInt16:    uint16(randInt(0, 65535)),
 			Int16:     int16(randInt(-32768, 32767)),

--- a/types.go
+++ b/types.go
@@ -24,6 +24,17 @@ func hugeIntToUUID(hi C.duckdb_hugeint) []byte {
 	return uuid[:]
 }
 
+func uuidToHugeInt(uuid [16]byte) C.duckdb_hugeint {
+	var dt C.duckdb_hugeint
+	// We need to flip the sign bit of the signed hugeint to transform it to UUID bytes
+	upper := binary.BigEndian.Uint64(uuid[:8])
+	// flip the sign bit
+	upper = upper ^ (1 << 63)
+	dt.upper = C.int64_t(upper)
+	dt.lower = C.uint64_t(binary.BigEndian.Uint64(uuid[8:]))
+	return dt
+}
+
 func hugeIntToNative(hi C.duckdb_hugeint) *big.Int {
 	i := big.NewInt(int64(hi.upper))
 	i.Lsh(i, 64)

--- a/types.go
+++ b/types.go
@@ -26,7 +26,6 @@ func hugeIntToUUID(hi C.duckdb_hugeint) []byte {
 
 func uuidToHugeInt(uuid [16]byte) C.duckdb_hugeint {
 	var dt C.duckdb_hugeint
-	// We need to flip the sign bit of the signed hugeint to transform it to UUID bytes
 	upper := binary.BigEndian.Uint64(uuid[:8])
 	// flip the sign bit
 	upper = upper ^ (1 << 63)

--- a/types.go
+++ b/types.go
@@ -13,6 +13,8 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
+type UUID [16]byte
+
 // duckdb_hugeint is composed of (lower, upper) components.
 // The value is computed as: upper * 2^64 + lower
 

--- a/types.go
+++ b/types.go
@@ -24,7 +24,7 @@ func hugeIntToUUID(hi C.duckdb_hugeint) []byte {
 	return uuid[:]
 }
 
-func uuidToHugeInt(uuid [16]byte) C.duckdb_hugeint {
+func uuidToHugeInt(uuid UUID) C.duckdb_hugeint {
 	var dt C.duckdb_hugeint
 	upper := binary.BigEndian.Uint64(uuid[:8])
 	// flip the sign bit


### PR DESCRIPTION
Discovered following issues post the changes to internal implementation of the appender API. Raising a fix for these.

1. It was necessary to call `appender.Flush` otherwise results are not saved. As per `ReadMe` and API documentation, `Flush` should be an optional step.
2. It was not possible to call `appender.Flush` multiple times. 
3. Previously it was possible to insert `UUID` via `appendString` and duckDB would ensure that it is casted internally. But the data chunks need to be appended with the right datatype. Using `[16]byte` to determine if arg is an UUID(which is not very ideal). Other option could be to introduce some other internal datatype to represent UUID. I will be happy to discuss alternatives.