### PR TITLE
Query cancellation fix

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -235,7 +235,7 @@ func (s *stmt) execute(ctx context.Context, args []driver.NamedValue) (*C.duckdb
 		C.duckdb_destroy_result(&res)
 		return nil, errors.New(dbErr)
 	}
-	
+
 	return &res, nil
 }
 

--- a/statement.go
+++ b/statement.go
@@ -230,10 +230,12 @@ func (s *stmt) execute(ctx context.Context, args []driver.NamedValue) (*C.duckdb
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
+
 		dbErr := C.GoString(C.duckdb_result_error(&res))
 		C.duckdb_destroy_result(&res)
 		return nil, errors.New(dbErr)
 	}
+	
 	return &res, nil
 }
 


### PR DESCRIPTION
Hey @marcboeker 

Found one tricky issue in the query cancellation that we had discussed previously. 
It is easy to reproduce when query completes quickly like in case of in-memory DB and checkpoint query. Example below:

```
func main() {
	db, err := sql.Open("duckdb", "")
	if err != nil {
		log.Fatal(err)
	}
	defer db.Close()

	conn, err := db.Conn(context.Background())
	if err != nil {
		log.Fatal(err)
	}

	var wg sync.WaitGroup
	wg.Add(100)
	for i := 0; i < 100; i++ {
		v := i
		go func() {
			ctx, cancel := context.WithCancel(context.Background())
			defer cancel()
			defer wg.Done()
			_, err = conn.ExecContext(ctx, "CHECKPOINT;")
			if err != nil {
				log.Printf("err %v", err)
			}
			fmt.Printf("iteration %v done\n", v)
		}()
	}
	wg.Wait()
}
```