### PR TITLE
destroy config when closing connector

### DIFF
--- a/duckdb_test.go
+++ b/duckdb_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math/big"
 	"os"
 	"reflect"
@@ -56,10 +57,22 @@ func TestOpen(t *testing.T) {
 	t.Run("with invalid config", func(t *testing.T) {
 		_, err := sql.Open("duckdb", "?threads=NaN")
 
-		if !errors.Is(err, errPrepareConfig) {
+		if !errors.Is(err, errSetConfig) {
 			t.Fatal("invalid config should not be accepted")
 		}
 	})
+}
+
+func TestConnector_Close(t *testing.T) {
+	t.Parallel()
+
+	connector, err := NewConnector("", nil)
+	require.NoError(t, err)
+
+	require.NoError(t, connector.(io.Closer).Close())
+
+	// check that multiple close calls don't cause panics or errors
+	require.NoError(t, connector.(io.Closer).Close())
 }
 
 func TestConnPool(t *testing.T) {


### PR DESCRIPTION
This PR delegates destroy config call to Close method of the Connector.
This changes were extracted from the #151 
cc @taniabogatsch @marcboeker 