### PR TITLE
Memory leak fixes in the connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ connector, err := duckdb.NewConnector("test.db", nil)
 if err != nil {
   ...
 }
+defer connector.Close()
+
 conn, err := connector.Connect(context.Background())
 if err != nil {
   ...
@@ -108,6 +110,8 @@ connector, err := duckdb.NewConnector("", nil)
 if err != nil {
   ...
 }
+defer connector.Close()
+
 conn, err := connector.Connect(context.Background())
 if err != nil {
   ...

--- a/README.md
+++ b/README.md
@@ -18,120 +18,152 @@ go get github.com/marcboeker/go-duckdb
 
 ## Usage
 
-`go-duckdb` hooks into the `database/sql` interface provided by the Go stdlib. To open a connection, simply specify the driver type as `duckdb`:
+`go-duckdb` hooks into the `database/sql` interface provided by the Go `stdlib`. To open a connection, simply specify the driver type as `duckdb`.
 
 ```go
 db, err := sql.Open("duckdb", "")
+if err != nil {
+    ...
+}
+defer db.Close()
 ```
 
-This creates an in-memory instance of DuckDB. If you would like to store the data on the filesystem, you need to specify the path where to store the database:
+This creates an in-memory instance of DuckDB. To open a persistent database, you need to specify a filepath to the database file. If
+the file does not exist, then DuckDB creates it.
+
 
 ```go
 db, err := sql.Open("duckdb", "/path/to/foo.db")
+if err != nil {
+	...
+}
+defer db.Close()
 ```
 
-If you want to set specific [config options for DuckDB](https://duckdb.org/docs/sql/configuration), you can add them as query style parameters in the form of `name=value` to the DSN, like:
+If you want to set specific [config options for DuckDB](https://duckdb.org/docs/sql/configuration), you can add them as query style parameters in the form of `name=value` pairs to the DSN.
 
 ```go
 db, err := sql.Open("duckdb", "/path/to/foo.db?access_mode=read_only&threads=4")
+if err != nil {
+    ...
+}
+defer db.Close()
 ```
 
-Alternatively, you can also use `sql.OpenDB` when you want to perform some initialization before the connection is created and returned from the connection pool on call to `db.Conn`.
-Here's an example that installs and loads the JSON extension for each connection:
+Alternatively, you can use [sql.OpenDB](https://cs.opensource.google/go/go/+/go1.21.6:src/database/sql/sql.go;l=781). That way, you can perform initialization steps in a callback function before opening the database.
+Here's an example that installs and loads the JSON extension when opening a database with `sql.OpenDB(connector)`.
 
 ```go
 connector, err := duckdb.NewConnector("/path/to/foo.db?access_mode=read_only&threads=4", func(execer driver.Execer) error {
-  bootQueries := []string{
-    "INSTALL 'json'",
-    "LOAD 'json'",
-  }
-
-  for _, qry := range bootQueries {
-    _, err = execer.Exec(qry, nil)
-    if err != nil {
-      return err
+    bootQueries := []string{
+        "INSTALL 'json'",
+        "LOAD 'json'",
     }
-  }
-  return nil
+
+    for _, query := range bootQueries {
+        _, err = execer.Exec(query, nil)
+        if err != nil {
+            ...
+        }
+    }
+    return nil
 })
 if err != nil {
-  return nil, err
+    ...
 }
 
 db := sql.OpenDB(connector)
-db.SetMaxOpenConns(poolsize)
-...
+defer db.Close()
 ```
 
-Please refer to the [database/sql](https://godoc.org/database/sql) GoDoc for further usage instructions.
+Please refer to the [database/sql](https://godoc.org/database/sql) documentation for further usage instructions.
+
+## A Note on Memory Allocation
+
+DuckDB lives in-process. Therefore, all its memory lives in the driver. All allocations live in the host process, which
+is the Go application. Especially for long-running applications, it is crucial to call the corresponding `Close`-functions as specified
+in [database/sql](https://godoc.org/database/sql). The following is a list of examples.
+```go
+db, err := sql.Open("duckdb", "")
+defer db.Close()
+
+conn, err := db.Conn(context.Background())
+defer conn.Close()
+
+rows, err := conn.QueryContext(context.Background(), "SELECT 42")
+// alternatively, rows.Next() has to return false
+rows.Close()
+
+appender, err := NewAppenderFromConn(conn, "", "test")
+defer appender.Close()
+
+// if not passed to sql.OpenDB
+connector, err := NewConnector("", nil)
+defer connector.Close()
+```
 
 ## DuckDB Appender API
 
-If you want to use the [DuckDB Appender API](https://duckdb.org/docs/data/appender.html), you can obtain a new Appender by supplying a DuckDB connection to `NewAppenderFromConn()`.
+If you want to use the [DuckDB Appender API](https://duckdb.org/docs/data/appender.html), you can obtain a new `Appender` by passing a DuckDB connection to `NewAppenderFromConn()`.
 
 ```go
 connector, err := duckdb.NewConnector("test.db", nil)
 if err != nil {
-  ...
+	...
 }
 defer connector.Close()
 
 conn, err := connector.Connect(context.Background())
 if err != nil {
-  ...
+	...
 }
 defer conn.Close()
 
-// Retrieve appender from connection (note that you have to create the table 'test' beforehand).
-appender, err := NewAppenderFromConn(conn, "", "test")
+// obtain an appender from the connection
+// NOTE: the table 'test_tbl' must exist in test.db
+appender, err := NewAppenderFromConn(conn, "", "test_tbl")
 if err != nil {
-  ...
+	...
 }
 defer appender.Close()
 
 err = appender.AppendRow(...)
 if err != nil {
-  ...
-}
-
-// Optional, if you want to access the appended rows immediately.
-err = appender.Flush()
-if err != nil {
-  ...
+	...
 }
 ```
 
 ## DuckDB Apache Arrow Interface
 
-If you want to use the [DuckDB Arrow Interface](https://duckdb.org/docs/api/c/api#arrow-interface), you can obtain a new Arrow by supplying a DuckDB connection to `NewArrowFromConn()`.
+If you want to use the [DuckDB Arrow Interface](https://duckdb.org/docs/api/c/api#arrow-interface), you can obtain a new `Arrow` by passing a DuckDB connection to `NewArrowFromConn()`.
 
 ```go
 connector, err := duckdb.NewConnector("", nil)
 if err != nil {
-  ...
+	...
 }
 defer connector.Close()
 
 conn, err := connector.Connect(context.Background())
 if err != nil {
-  ...
+	...
 }
 defer conn.Close()
 
-// Retrieve Arrow from connection.
-ar, err := duckdb.NewArrowFromConn(conn)
-if err != nil {
-  ...
+// obtain the Arrow from the connection
+arrow, err := duckdb.NewArrowFromConn(conn)
+if err != nil w
+	...
 }
 
-rdr, err := ar.QueryContext(context.Background(), "SELECT * FROM generate_series(1, 10)")
+rdr, err := arrow.QueryContext(context.Background(), "SELECT * FROM generate_series(1, 10)")
 if err != nil {
-  ...
+	...
 }
 defer rdr.Release()
 
 for rdr.Next() {
-  // Process records.
+  // process records
 }
 ```
 

--- a/arrow.go
+++ b/arrow.go
@@ -210,7 +210,7 @@ func (a *Arrow) execute(s *stmt, args []driver.NamedValue) (*C.duckdb_arrow, err
 		panic("database/sql/driver: misuse of duckdb driver: executeArrow after Close")
 	}
 
-	if err := s.start(args); err != nil {
+	if err := s.bind(args); err != nil {
 		return nil, err
 	}
 

--- a/arrow_test.go
+++ b/arrow_test.go
@@ -22,6 +22,7 @@ func TestArrow(t *testing.T) {
 	t.Run("select series", func(t *testing.T) {
 		c, err := NewConnector("", nil)
 		require.NoError(t, err)
+		defer c.Close()
 
 		conn, err := c.Connect(context.Background())
 		require.NoError(t, err)
@@ -46,6 +47,7 @@ func TestArrow(t *testing.T) {
 	t.Run("select long series", func(t *testing.T) {
 		c, err := NewConnector("", nil)
 		require.NoError(t, err)
+		defer c.Close()
 
 		conn, err := c.Connect(context.Background())
 		require.NoError(t, err)

--- a/duckdb_test.go
+++ b/duckdb_test.go
@@ -979,6 +979,7 @@ func TestTypeNamesAndScanTypes(t *testing.T) {
 			err = rows.Scan(&val)
 			require.NoError(t, err)
 			require.Equal(t, test.value, val)
+			require.Equal(t, rows.Next(), false)
 		})
 	}
 }

--- a/duckdb_test.go
+++ b/duckdb_test.go
@@ -62,6 +62,17 @@ func TestOpen(t *testing.T) {
 	})
 }
 
+func TestConnector_Close(t *testing.T) {
+	t.Parallel()
+
+	connector, err := NewConnector("", nil)
+	require.NoError(t, err)
+
+	// check that multiple close calls don't cause panics or errors
+	require.NoError(t, connector.Close())
+	require.NoError(t, connector.Close())
+}
+
 func TestConnPool(t *testing.T) {
 	db := openDB(t)
 	db.SetMaxOpenConns(2) // set connection pool size greater than 1

--- a/duckdb_test.go
+++ b/duckdb_test.go
@@ -56,7 +56,7 @@ func TestOpen(t *testing.T) {
 	t.Run("with invalid config", func(t *testing.T) {
 		_, err := sql.Open("duckdb", "?threads=NaN")
 
-		if !errors.Is(err, errPrepareConfig) {
+		if !errors.Is(err, errSetConfig) {
 			t.Fatal("invalid config should not be accepted")
 		}
 	})

--- a/result.go
+++ b/result.go
@@ -1,7 +1,7 @@
 package duckdb
 
 type result struct {
-	ra int64
+	rowsAffected int64
 }
 
 func (r result) LastInsertId() (int64, error) {
@@ -9,5 +9,5 @@ func (r result) LastInsertId() (int64, error) {
 }
 
 func (r result) RowsAffected() (int64, error) {
-	return r.ra, nil
+	return r.rowsAffected, nil
 }

--- a/statement.go
+++ b/statement.go
@@ -44,10 +44,12 @@ func (s *stmt) NumInput() int {
 	return int(paramCount)
 }
 
-func (s *stmt) start(args []driver.NamedValue) error {
+func (s *stmt) bind(args []driver.NamedValue) error {
 	if s.NumInput() != len(args) {
 		return fmt.Errorf("incorrect argument count for command: have %d want %d", len(args), s.NumInput())
 	}
+
+	// FIXME (feature): we can't pass nested types as parameters (bind_value) yet
 
 	for i, v := range args {
 		switch v := v.Value.(type) {
@@ -190,7 +192,7 @@ func (s *stmt) execute(ctx context.Context, args []driver.NamedValue) (*C.duckdb
 		panic("database/sql/driver: misuse of duckdb driver: ExecContext or QueryContext with active Rows")
 	}
 
-	if err := s.start(args); err != nil {
+	if err := s.bind(args); err != nil {
 		return nil, err
 	}
 
@@ -219,12 +221,13 @@ func (s *stmt) execute(ctx context.Context, args []driver.NamedValue) (*C.duckdb
 	var res C.duckdb_result
 	if state := C.duckdb_execute_pending(pendingRes, &res); state == C.DuckDBError {
 		if ctx.Err() != nil {
+			C.duckdb_destroy_result(&res)
 			return nil, ctx.Err()
 		}
 
-		dbErr := C.GoString(C.duckdb_result_error(&res))
+		err := C.GoString(C.duckdb_result_error(&res))
 		C.duckdb_destroy_result(&res)
-		return nil, errors.New(dbErr)
+		return nil, errors.New(err)
 	}
 
 	return &res, nil


### PR DESCRIPTION
This PR builds on the work of #151. See also my comment [here](https://github.com/marcboeker/go-duckdb/pull/151#issuecomment-1910100578).

Changes in this PR:
- the `Connector` now exposes its `Close` method (done by @levakin). This PR contains the respective commits of #151.
   - explicitly calling `c.(io.Closer).Close()` is crucial to avoid memory leaks in the database object
   - exposing `Close` simplifies closing the `Connector` for users, reducing the risk of leaks and increasing usability
- maybe this is a lack in my understanding of Go, but I changed `db *C.duckdb_database` to `db C.duckdb_database` in the `Connector` because it is already a pointer (`typedef struct _duckdb_database {void *__db;} * duckdb_database;`). Or was there a reason to store it as a pointer?
- I added `C.duckdb_destroy_config(&config)` to more places to avoid leaks
- The following two places were leaking, as they never freed the `C.CString`, to the best of my knowledge
   - `C.duckdb_set_config(config, C.CString("duckdb_api"), C.CString("go"))`
   - `C.duckdb_set_config(config, C.CString(k), C.CString(v[0]))`
   - @levakin added `setConfig`, and I added explicit calls to `C.free`
- we do not have to keep the config-object alive after opening a DuckDB database

cc @marcboeker @levakin 