### PR TITLE
DO NOT MERGE! Pick DuckDB PR #10268 into v0.9.2, then rebuild go-duckdb@v1.5.6 with that patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,8 @@ deps.linux.amd64:
 
 	git clone -b v${DUCKDB_VERSION} --depth 1 https://github.com/michaelmdresser/duckdb.git
 	cd duckdb && \
-	CFLAGS="-O3" CXXFLAGS="-O3" make -j 2 && \
-	BUILD_SHELL=0 BUILD_UNITTESTS=0 make -j 2 && \
+	CFLAGS="-O3" CXXFLAGS="-O3" make -j 8 && \
+	BUILD_SHELL=0 BUILD_UNITTESTS=0 make -j 8 && \
 	mkdir -p lib && \
 	for f in `find . -name '*.o'`; do cp $$f lib; done && \
 	cd lib && \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DUCKDB_VERSION=0.9.2
+DUCKDB_VERSION="0.9.2/pick-10268"
 
 .PHONY: install
 install:
@@ -17,14 +17,14 @@ FILES := $(wildcard $(SRC_DIR)/*)
 
 .PHONY: deps.header
 deps.header:
-	git clone -b v${DUCKDB_VERSION} --depth 1 https://github.com/duckdb/duckdb.git
+	git clone -b v${DUCKDB_VERSION} --depth 1 https://github.com/michaelmdresser/duckdb.git
 	cp duckdb/src/include/duckdb.h duckdb.h
 
 .PHONY: deps.darwin.amd64
 deps.darwin.amd64:
 	if [ "$(shell uname -s | tr '[:upper:]' '[:lower:]')" != "darwin" ]; then echo "Error: must run build on darwin"; false; fi
 
-	git clone -b v${DUCKDB_VERSION} --depth 1 https://github.com/duckdb/duckdb.git
+	git clone -b v${DUCKDB_VERSION} --depth 1 https://github.com/michaelmdresser/duckdb.git
 	cd duckdb && \
 	CFLAGS="-target x86_64-apple-macos11 -O3" CXXFLAGS="-target x86_64-apple-macos11 -O3" BUILD_SHELL=0 BUILD_UNITTESTS=0 make -j 2 && \
 	mkdir -p lib && \
@@ -38,7 +38,7 @@ deps.darwin.amd64:
 deps.darwin.arm64:
 	if [ "$(shell uname -s | tr '[:upper:]' '[:lower:]')" != "darwin" ]; then echo "Error: must run build on darwin"; false; fi
 
-	git clone -b v${DUCKDB_VERSION} --depth 1 https://github.com/duckdb/duckdb.git
+	git clone -b v${DUCKDB_VERSION} --depth 1 https://github.com/michaelmdresser/duckdb.git
 	cd duckdb && \
 	CFLAGS="-target arm64-apple-macos11 -O3" CXXFLAGS="-target arm64-apple-macos11 -O3" BUILD_SHELL=0 BUILD_UNITTESTS=0 make -j 2 && \
 	mkdir -p lib && \
@@ -52,7 +52,7 @@ deps.darwin.arm64:
 deps.linux.amd64:
 	if [ "$(shell uname -s | tr '[:upper:]' '[:lower:]')" != "linux" ]; then echo "Error: must run build on linux"; false; fi
 
-	git clone -b v${DUCKDB_VERSION} --depth 1 https://github.com/duckdb/duckdb.git
+	git clone -b v${DUCKDB_VERSION} --depth 1 https://github.com/michaelmdresser/duckdb.git
 	cd duckdb && \
 	CFLAGS="-O3" CXXFLAGS="-O3" make -j 2 && \
 	BUILD_SHELL=0 BUILD_UNITTESTS=0 make -j 2 && \
@@ -67,7 +67,7 @@ deps.linux.amd64:
 deps.linux.arm64:
 	if [ "$(shell uname -s | tr '[:upper:]' '[:lower:]')" != "linux" ]; then echo "Error: must run build on linux"; false; fi
 
-	git clone -b v${DUCKDB_VERSION} --depth 1 https://github.com/duckdb/duckdb.git
+	git clone -b v${DUCKDB_VERSION} --depth 1 https://github.com/michaelmdresser/duckdb.git
 	cd duckdb && \
 	CC="aarch64-linux-gnu-gcc" CXX="aarch64-linux-gnu-g++" CFLAGS="-O3" CXXFLAGS="-O3" BUILD_SHELL=0 BUILD_UNITTESTS=0 make -j 2 && \
 	mkdir -p lib && \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DUCKDB_VERSION="0.9.2/pick-10268"
+DUCKDB_VERSION=0.9.2/pick-10268
 
 .PHONY: install
 install:


### PR DESCRIPTION
This PR is the result of the below methodology. Critically, the goal is to produce a version of go-duckdb@v1.5.6 which also contains this DuckDB PR: https://github.com/duckdb/duckdb/pull/10268. Only for Linux AMD64 because I don't have a build box for anything else right now.

---

This error is corrupting DB state:

    2024-02-01T21:05:00.108991889Z ERR error querying via querysvc error querying Disks: query Failure: INTERNAL Error: ListC
    olumnData::ScanCount - internal list scan offset is out of range
    2024-02-01T21:05:00.109051339Z WRN got error savings.QueryUnclaimedVolumes failed with err: error querying assets: error
    querying DB: error querying via querysvc error querying Disks: query Failure: INTERNAL Error: ListColumnData::ScanCount -
     internal list scan offset is out of range for metric unclaimedVolumes%%Development, not adding to cache

Resulting in lots of these:

    Original error: "FATAL Error: Failed: database has been invalidated because of a previous fatal error. The database must
    be restarted prior to being used again.

DuckDB issue:
<https://github.com/duckdb/duckdb/issues/10212>
DuckDB fix PR:
<https://github.com/duckdb/duckdb/pull/10268>

The fix PR is not included in v0.9.2, and the next version of DuckDB is not
yet released. We are going to cherry-pick it into a custom v0.9.2 build.

Fix commit: 14d587c
v0.9.2 commit  3c695d7  checked out with fix picked on top:

    git checkout  3c695d7
    git cherry-pick 14d587c
    git checkout -b "v0.9.2/pick-10268"
    git push --set-upstream origin "v0.9.2/pick-10268"

<https://github.com/michaelmdresser/duckdb/tree/v0.9.2/pick-10268>

To build:

    make -j 12

We are using v1.5.6 of go-duckdb right now, which is commit 1095769
Using my fork of go-duckdb

    git checkout 1095769
    git checkout -b "v1.5.6/v0.9.2/pick-10268"
    git push --set-upstream origin "v1.5.6/v0.9.2/pick-10268"

Modifying the Makefile of go-duckdb to use my local ddb
Hacked the `DUCKDB_VERSION` in the makefile to point at my branch and updated
all git clones to reference my repo

    DUCKDB_VERSION=0.9.2/pick-10268
    
    	git clone -b v${DUCKDB_VERSION} --depth 1 https://github.com/michaelmdresser/duckdb.git

Also bumped the -j to 8 for linux amd64 build

Then run make stuff in mmdgo-duckdb

    make deps.header
    rm -rf duckdb
    make deps.linux.amd64

