### PR TITLE
feat(appender): Allow typed nils in first row, dereference pointers

### DIFF
--- a/appender.go
+++ b/appender.go
@@ -257,6 +257,10 @@ func initPrimitive[T any](ddbType C.duckdb_type) (colInfo, C.duckdb_logical_type
 }
 
 func (a *Appender) initColInfos(v reflect.Type, colIdx int) (colInfo, C.duckdb_logical_type) {
+	if v.Kind() == reflect.Ptr {
+		return a.initColInfos(v.Elem(), colIdx)
+	}
+
 	switch v.Kind() {
 	case reflect.Uint8:
 		return initPrimitive[uint8](C.DUCKDB_TYPE_UTINYINT)
@@ -556,7 +560,7 @@ func (c *colInfo) typeMatch(v reflect.Type) error {
 func (a *Appender) appendRowArray(args []driver.Value) error {
 	for i, v := range args {
 		info := a.colInfos[i]
-		if v == nil {
+		if v == nil || (reflect.ValueOf(v).Kind() == reflect.Ptr && reflect.ValueOf(v).IsNil()) {
 			setNull(&info, a.currSize)
 			continue
 		}


### PR DESCRIPTION
Removes the requirement of having non-null columns in the first row, by using typed nils (and dereferencing pointers if necessary)

The check for typed nils (using reflection) may be considered an expensive one, I would prefer if `initColTypes` was exported, then it can be called separately (optionally) with concrete types if caller knows the first row _may_ contain nulls, then we can remove the typed nils and the check for it (and close this PR without merging)