### PR TITLE
Initialise column types during appender creation

### DIFF
--- a/appender.go
+++ b/appender.go
@@ -46,7 +46,7 @@ type colInfo struct {
 	fn     SetColValue
 
 	// The type of the column.
-	ddbType C.duckdb_type
+	duckdbType C.duckdb_type
 	// The number of fields in a STRUCT column.
 	numFields int
 	// Recursively stores the child colInfos for nested types.
@@ -54,12 +54,12 @@ type colInfo struct {
 }
 
 func (c *colInfo) duckDBTypeToString() string {
-	if c.ddbType == C.DUCKDB_TYPE_LIST {
+	if c.duckdbType == C.DUCKDB_TYPE_LIST {
 		s := c.colInfos[0].duckDBTypeToString()
 		return "[]" + s
 	}
 
-	if c.ddbType == C.DUCKDB_TYPE_STRUCT {
+	if c.duckdbType == C.DUCKDB_TYPE_STRUCT {
 		s := "{"
 		for i := 0; i < c.numFields; i++ {
 			if i > 0 {
@@ -72,7 +72,7 @@ func (c *colInfo) duckDBTypeToString() string {
 		return s
 	}
 
-	return typeIdMap[c.ddbType]
+	return typeIdMap[c.duckdbType]
 }
 
 // Appender holds the DuckDB appender. It allows efficient bulk loading into a DuckDB database.
@@ -93,12 +93,12 @@ type Appender struct {
 
 // NewAppenderFromConn returns a new Appender from a DuckDB driver connection.
 func NewAppenderFromConn(driverConn driver.Conn, schema, table string) (*Appender, error) {
-	dbConn, ok := driverConn.(*conn)
+	c, ok := driverConn.(*conn)
 	if !ok {
 		return nil, fmt.Errorf("not a duckdb driver connection")
 	}
 
-	if dbConn.closed {
+	if c.closed {
 		panic("database/sql/driver: misuse of duckdb driver: Appender after Close")
 	}
 
@@ -112,7 +112,7 @@ func NewAppenderFromConn(driverConn driver.Conn, schema, table string) (*Appende
 	defer C.free(unsafe.Pointer(cTable))
 
 	var appender C.duckdb_appender
-	state := C.duckdb_appender_create(*dbConn.con, cSchema, cTable, &appender)
+	state := C.duckdb_appender_create(*c.con, cSchema, cTable, &appender)
 
 	if state == C.DuckDBError {
 		// We'll destroy the error message when destroying the appender.
@@ -122,7 +122,7 @@ func NewAppenderFromConn(driverConn driver.Conn, schema, table string) (*Appende
 	}
 
 	return &Appender{
-		c:        dbConn,
+		c:        c,
 		schema:   schema,
 		table:    table,
 		appender: &appender,
@@ -245,13 +245,13 @@ func mallocCStringSlice(count int) (unsafe.Pointer, []*C.char) {
 	return csPtr, slice
 }
 
-func initPrimitive[T any](ddbType C.duckdb_type) (colInfo, C.duckdb_logical_type) {
-	t := C.duckdb_create_logical_type(ddbType)
+func initPrimitive[T any](duckdbType C.duckdb_type) (colInfo, C.duckdb_logical_type) {
+	t := C.duckdb_create_logical_type(duckdbType)
 	info := colInfo{
 		fn: func(a *Appender, info *colInfo, rowIdx C.idx_t, val any) {
 			setPrimitive[T](info, rowIdx, val.(T))
 		},
-		ddbType: ddbType,
+		duckdbType: duckdbType,
 	}
 	return info, t
 }
@@ -290,7 +290,7 @@ func (a *Appender) initColInfos(v reflect.Type, colIdx int) (colInfo, C.duckdb_l
 			fn: func(a *Appender, info *colInfo, rowIdx C.idx_t, val any) {
 				setCString(info, rowIdx, val.(string))
 			},
-			ddbType: C.DUCKDB_TYPE_VARCHAR,
+			duckdbType: C.DUCKDB_TYPE_VARCHAR,
 		}
 		return info, t
 
@@ -305,7 +305,7 @@ func (a *Appender) initColInfos(v reflect.Type, colIdx int) (colInfo, C.duckdb_l
 					blob := val.([]byte)
 					setCString(info, rowIdx, string(blob[:]))
 				},
-				ddbType: C.DUCKDB_TYPE_BLOB,
+				duckdbType: C.DUCKDB_TYPE_BLOB,
 			}
 			return info, t
 		}
@@ -319,8 +319,8 @@ func (a *Appender) initColInfos(v reflect.Type, colIdx int) (colInfo, C.duckdb_l
 			fn: func(a *Appender, info *colInfo, rowIdx C.idx_t, val any) {
 				setList(a, info, rowIdx, val)
 			},
-			ddbType:  C.DUCKDB_TYPE_LIST,
-			colInfos: []colInfo{childInfo},
+			duckdbType: C.DUCKDB_TYPE_LIST,
+			colInfos:   []colInfo{childInfo},
 		}
 		return info, t
 
@@ -332,7 +332,7 @@ func (a *Appender) initColInfos(v reflect.Type, colIdx int) (colInfo, C.duckdb_l
 			fn: func(a *Appender, info *colInfo, rowIdx C.idx_t, val any) {
 				setPrimitive[C.duckdb_hugeint](info, rowIdx, uuidToHugeInt(val.(UUID)))
 			},
-			ddbType: C.DUCKDB_TYPE_UUID,
+			duckdbType: C.DUCKDB_TYPE_UUID,
 		}
 		return info, t
 
@@ -345,7 +345,7 @@ func (a *Appender) initColInfos(v reflect.Type, colIdx int) (colInfo, C.duckdb_l
 				fn: func(a *Appender, info *colInfo, rowIdx C.idx_t, val any) {
 					setTime(info, rowIdx, val.(time.Time))
 				},
-				ddbType: C.DUCKDB_TYPE_TIMESTAMP,
+				duckdbType: C.DUCKDB_TYPE_TIMESTAMP,
 			}
 			return info, t
 		}
@@ -357,9 +357,9 @@ func (a *Appender) initColInfos(v reflect.Type, colIdx int) (colInfo, C.duckdb_l
 			fn: func(a *Appender, info *colInfo, rowIdx C.idx_t, val any) {
 				setStruct(a, info, rowIdx, val)
 			},
-			ddbType:   C.DUCKDB_TYPE_STRUCT,
-			colInfos:  make([]colInfo, numFields),
-			numFields: numFields,
+			duckdbType: C.DUCKDB_TYPE_STRUCT,
+			colInfos:   make([]colInfo, numFields),
+			numFields:  numFields,
 		}
 
 		// We recurse into the child numFields. To create the resulting duckdb_logical_type,
@@ -398,7 +398,7 @@ func (a *Appender) initColInfos(v reflect.Type, colIdx int) (colInfo, C.duckdb_l
 }
 
 func (c *colInfo) getChildVectors(vector C.duckdb_vector) {
-	switch c.ddbType {
+	switch c.duckdbType {
 	case C.DUCKDB_TYPE_LIST:
 		childVector := C.duckdb_list_vector_get_child(vector)
 		c.colInfos[0].vector = childVector
@@ -439,7 +439,7 @@ func setNull(info *colInfo, rowIdx C.idx_t) {
 	C.duckdb_validity_set_row_invalid(mask, rowIdx)
 
 	// Set the validity for all child vectors of a STRUCT.
-	if typeIdMap[info.ddbType] == "struct" {
+	if typeIdMap[info.duckdbType] == "struct" {
 		for i := 0; i < info.numFields; i++ {
 			setNull(&info.colInfos[i], rowIdx)
 		}

--- a/appender.go
+++ b/appender.go
@@ -288,7 +288,7 @@ func (a *Appender) initColInfos(v reflect.Type, colIdx int) (colInfo, C.duckdb_l
 		t := C.duckdb_create_logical_type(C.DUCKDB_TYPE_VARCHAR)
 		info := colInfo{
 			fn: func(a *Appender, info *colInfo, rowIdx C.idx_t, val any) {
-				setCString(info, rowIdx, val.(string))
+				setCString(info, rowIdx, val.(string), len(val.(string)))
 			},
 			duckdbType: C.DUCKDB_TYPE_VARCHAR,
 		}
@@ -303,7 +303,7 @@ func (a *Appender) initColInfos(v reflect.Type, colIdx int) (colInfo, C.duckdb_l
 			info := colInfo{
 				fn: func(a *Appender, info *colInfo, rowIdx C.idx_t, val any) {
 					blob := val.([]byte)
-					setCString(info, rowIdx, string(blob[:]))
+					setCString(info, rowIdx, string(blob[:]), len(blob))
 				},
 				duckdbType: C.DUCKDB_TYPE_BLOB,
 			}
@@ -452,9 +452,9 @@ func setPrimitive[T any](info *colInfo, rowIdx C.idx_t, value T) {
 	xs[rowIdx] = value
 }
 
-func setCString(info *colInfo, rowIdx C.idx_t, value string) {
+func setCString(info *colInfo, rowIdx C.idx_t, value string, len int) {
 	str := C.CString(value)
-	C.duckdb_vector_assign_string_element(info.vector, rowIdx, str)
+	C.duckdb_vector_assign_string_element_len(info.vector, rowIdx, str, C.idx_t(len))
 	C.free(unsafe.Pointer(str))
 }
 

--- a/appender.go
+++ b/appender.go
@@ -15,8 +15,6 @@ import (
 	"unsafe"
 )
 
-const errNote = "NOTE: this is based on types initialized from the first row of appended data. Please confirm this matches the schema."
-
 var typeIdMap = map[C.duckdb_type]string{
 	C.DUCKDB_TYPE_BOOLEAN:   "bool",
 	C.DUCKDB_TYPE_TINYINT:   "int8",
@@ -113,7 +111,6 @@ func NewAppenderFromConn(driverConn driver.Conn, schema, table string) (*Appende
 
 	var appender C.duckdb_appender
 	state := C.duckdb_appender_create(*c.con, cSchema, cTable, &appender)
-
 	if state == C.DuckDBError {
 		// We'll destroy the error message when destroying the appender.
 		err := errors.New(C.GoString(C.duckdb_appender_error(appender)))
@@ -121,19 +118,40 @@ func NewAppenderFromConn(driverConn driver.Conn, schema, table string) (*Appende
 		return nil, err
 	}
 
-	return &Appender{
+	a := &Appender{
 		c:        c,
 		schema:   schema,
 		table:    table,
 		appender: &appender,
 		currSize: 0,
-	}, nil
+	}
+
+	columnCount := int(C.duckdb_appender_column_count(appender))
+	a.colInfos = make([]colInfo, columnCount)
+	a.colTypesPtr, a.colTypes = mallocLogicalTypeSlice(columnCount)
+
+	// Get the column types.
+	for i := 0; i < columnCount; i++ {
+		a.colTypes[i] = C.duckdb_appender_column_type(appender, C.idx_t(i))
+	}
+
+	// Get the column infos.
+	for i := 0; i < columnCount; i++ {
+		info, err := a.initColInfos(a.colTypes[i], i)
+		if err != nil {
+			a.destroyColumnTypes()
+			return a, err
+		}
+		a.colInfos[i] = info
+	}
+
+	return a, nil
 }
 
 // Error returns the last DuckDB appender error.
 func (a *Appender) Error() error {
-	dbErr := C.GoString(C.duckdb_appender_error(*a.appender))
-	return errors.New(dbErr)
+	err := C.GoString(C.duckdb_appender_error(*a.appender))
+	return errors.New(err)
 }
 
 // Flush the appender to the underlying table and clear the internal cache.
@@ -171,12 +189,7 @@ func (a *Appender) Close() error {
 		err = a.appendChunks()
 	}
 
-	// Free the column types.
-	for i := range a.colInfos {
-		C.duckdb_destroy_logical_type(&a.colTypes[i])
-	}
-	C.free(a.colTypesPtr)
-
+	a.destroyColumnTypes()
 	if state := C.duckdb_appender_destroy(a.appender); state == C.DuckDBError {
 		return a.Error()
 	}
@@ -191,15 +204,9 @@ func (a *Appender) AppendRow(args ...driver.Value) error {
 	}
 
 	var err error
-	if len(a.colTypes) == 0 {
-		// Initialize the chunk on the first call.
-		if err = a.initColTypes(args); err != nil {
-			return err
-		}
-		err = a.appendChunk(len(args))
-
-	} else if a.currSize == C.duckdb_vector_size() || len(a.chunks) == 0 {
-		// The current chunk is full, create a new one.
+	if a.currSize == C.duckdb_vector_size() || len(a.chunks) == 0 {
+		// The current chunk is full, or there are no chunks yet.
+		// In either case, create a new chunk.
 		err = a.appendChunk(len(args))
 	}
 
@@ -209,21 +216,11 @@ func (a *Appender) AppendRow(args ...driver.Value) error {
 	return a.appendRowArray(args)
 }
 
-// Create an array of DuckDB types from a list of Go types.
-func (a *Appender) initColTypes(args []driver.Value) error {
-	a.colInfos = make([]colInfo, len(args))
-	a.colTypesPtr, a.colTypes = mallocLogicalTypeSlice(len(args))
-
-	for i, val := range args {
-		if val == nil {
-			return fmt.Errorf("the first row cannot contain null values (column %d)", i)
-		}
-
-		v := reflect.ValueOf(val)
-		a.colInfos[i], a.colTypes[i] = a.initColInfos(v.Type(), i)
+func (a *Appender) destroyColumnTypes() {
+	for i := range a.colTypes {
+		C.duckdb_destroy_logical_type(&a.colTypes[i])
 	}
-
-	return nil
+	C.free(a.colTypesPtr)
 }
 
 func mallocLogicalTypeSlice(count int) (unsafe.Pointer, []C.duckdb_logical_type) {
@@ -236,85 +233,89 @@ func mallocLogicalTypeSlice(count int) (unsafe.Pointer, []C.duckdb_logical_type)
 	return ctPtr, slice
 }
 
-func mallocCStringSlice(count int) (unsafe.Pointer, []*C.char) {
-	var dummy *C.char
-	size := C.size_t(unsafe.Sizeof(dummy))
+func initPrimitive[T any](duckdbType C.duckdb_type) colInfo {
 
-	csPtr := unsafe.Pointer(C.malloc(C.size_t(count) * size))
-	slice := (*[1 << 30]*C.char)(csPtr)[:count:count]
-	return csPtr, slice
-}
-
-func initPrimitive[T any](duckdbType C.duckdb_type) (colInfo, C.duckdb_logical_type) {
-	t := C.duckdb_create_logical_type(duckdbType)
 	info := colInfo{
 		fn: func(a *Appender, info *colInfo, rowIdx C.idx_t, val any) {
 			setPrimitive[T](info, rowIdx, val.(T))
 		},
 		duckdbType: duckdbType,
 	}
-	return info, t
+	return info
 }
 
-func (a *Appender) initColInfos(v reflect.Type, colIdx int) (colInfo, C.duckdb_logical_type) {
-	switch v.Kind() {
-	case reflect.Uint8:
-		return initPrimitive[uint8](C.DUCKDB_TYPE_UTINYINT)
-	case reflect.Int8:
-		return initPrimitive[int8](C.DUCKDB_TYPE_TINYINT)
-	case reflect.Uint16:
-		return initPrimitive[uint16](C.DUCKDB_TYPE_USMALLINT)
-	case reflect.Int16:
-		return initPrimitive[int16](C.DUCKDB_TYPE_SMALLINT)
-	case reflect.Uint32:
-		return initPrimitive[uint32](C.DUCKDB_TYPE_UINTEGER)
-	case reflect.Int32:
-		return initPrimitive[int32](C.DUCKDB_TYPE_INTEGER)
-	case reflect.Uint64:
-		return initPrimitive[uint64](C.DUCKDB_TYPE_UBIGINT)
-	case reflect.Int64:
-		return initPrimitive[int64](C.DUCKDB_TYPE_BIGINT)
-	case reflect.Uint:
-		return initPrimitive[uint32](C.DUCKDB_TYPE_UINTEGER)
-	case reflect.Int:
-		return initPrimitive[int32](C.DUCKDB_TYPE_INTEGER)
-	case reflect.Float32:
-		return initPrimitive[float32](C.DUCKDB_TYPE_FLOAT)
-	case reflect.Float64:
-		return initPrimitive[float64](C.DUCKDB_TYPE_DOUBLE)
-	case reflect.Bool:
-		return initPrimitive[bool](C.DUCKDB_TYPE_BOOLEAN)
-	case reflect.String:
-		t := C.duckdb_create_logical_type(C.DUCKDB_TYPE_VARCHAR)
+func (a *Appender) initColInfos(logicalType C.duckdb_logical_type, colIdx int) (colInfo, error) {
+
+	duckdbType := C.duckdb_get_type_id(logicalType)
+
+	switch duckdbType {
+	case C.DUCKDB_TYPE_UTINYINT:
+		return initPrimitive[uint8](C.DUCKDB_TYPE_UTINYINT), nil
+	case C.DUCKDB_TYPE_TINYINT:
+		return initPrimitive[int8](C.DUCKDB_TYPE_TINYINT), nil
+	case C.DUCKDB_TYPE_USMALLINT:
+		return initPrimitive[uint16](C.DUCKDB_TYPE_USMALLINT), nil
+	case C.DUCKDB_TYPE_SMALLINT:
+		return initPrimitive[int16](C.DUCKDB_TYPE_SMALLINT), nil
+	case C.DUCKDB_TYPE_UINTEGER:
+		return initPrimitive[uint32](C.DUCKDB_TYPE_UINTEGER), nil
+	case C.DUCKDB_TYPE_INTEGER:
+		return initPrimitive[int32](C.DUCKDB_TYPE_INTEGER), nil
+	case C.DUCKDB_TYPE_UBIGINT:
+		return initPrimitive[uint64](C.DUCKDB_TYPE_UBIGINT), nil
+	case C.DUCKDB_TYPE_BIGINT:
+		return initPrimitive[int64](C.DUCKDB_TYPE_BIGINT), nil
+	case C.DUCKDB_TYPE_FLOAT:
+		return initPrimitive[float32](C.DUCKDB_TYPE_FLOAT), nil
+	case C.DUCKDB_TYPE_DOUBLE:
+		return initPrimitive[float64](C.DUCKDB_TYPE_DOUBLE), nil
+	case C.DUCKDB_TYPE_BOOLEAN:
+		return initPrimitive[bool](C.DUCKDB_TYPE_BOOLEAN), nil
+	case C.DUCKDB_TYPE_VARCHAR:
 		info := colInfo{
 			fn: func(a *Appender, info *colInfo, rowIdx C.idx_t, val any) {
 				setCString(info, rowIdx, val.(string), len(val.(string)))
 			},
 			duckdbType: C.DUCKDB_TYPE_VARCHAR,
 		}
-		return info, t
+		return info, nil
+	case C.DUCKDB_TYPE_BLOB:
+		info := colInfo{
+			fn: func(a *Appender, info *colInfo, rowIdx C.idx_t, val any) {
+				blob := val.([]byte)
+				setCString(info, rowIdx, string(blob[:]), len(blob))
+			},
+			duckdbType: C.DUCKDB_TYPE_BLOB,
+		}
+		return info, nil
+	case C.DUCKDB_TYPE_TIMESTAMP:
+		info := colInfo{
+			fn: func(a *Appender, info *colInfo, rowIdx C.idx_t, val any) {
+				setTime(info, rowIdx, val.(time.Time))
+			},
+			duckdbType: C.DUCKDB_TYPE_TIMESTAMP,
+		}
+		return info, nil
+	case C.DUCKDB_TYPE_UUID:
+		// The callback function casts the value via uuidToHugeInt. Thus, we do not
+		// use initPrimitive here.
+		info := colInfo{
+			fn: func(a *Appender, info *colInfo, rowIdx C.idx_t, val any) {
+				setPrimitive[C.duckdb_hugeint](info, rowIdx, uuidToHugeInt(val.(UUID)))
+			},
+			duckdbType: C.DUCKDB_TYPE_UUID,
+		}
+		return info, nil
 
-	case reflect.Slice:
-		// Check if it's []byte since that is equivalent to the DuckDB BLOB type.
-		// If so, we can use the same setter as for VARCHAR;
-		// otherwise it will not match the table set up by the user.
-		if v.Elem().Kind() == reflect.Uint8 {
-			t := C.duckdb_create_logical_type(C.DUCKDB_TYPE_BLOB)
-			info := colInfo{
-				fn: func(a *Appender, info *colInfo, rowIdx C.idx_t, val any) {
-					blob := val.([]byte)
-					setCString(info, rowIdx, string(blob[:]), len(blob))
-				},
-				duckdbType: C.DUCKDB_TYPE_BLOB,
-			}
-			return info, t
+	case C.DUCKDB_TYPE_LIST:
+		// We recurse into the child.
+		childType := C.duckdb_list_type_child_type(logicalType)
+		childInfo, err := a.initColInfos(childType, colIdx)
+		C.duckdb_destroy_logical_type(&childType)
+		if err != nil {
+			return colInfo{}, err
 		}
 
-		// Otherwise, it's a LIST. We recurse into the child element type.
-		childInfo, childType := a.initColInfos(v.Elem(), colIdx)
-		defer C.duckdb_destroy_logical_type(&childType)
-
-		t := C.duckdb_create_list_type(childType)
 		info := colInfo{
 			fn: func(a *Appender, info *colInfo, rowIdx C.idx_t, val any) {
 				setList(a, info, rowIdx, val)
@@ -322,36 +323,10 @@ func (a *Appender) initColInfos(v reflect.Type, colIdx int) (colInfo, C.duckdb_l
 			duckdbType: C.DUCKDB_TYPE_LIST,
 			colInfos:   []colInfo{childInfo},
 		}
-		return info, t
+		return info, nil
 
-	case reflect.TypeOf(UUID{}).Kind():
-		// The callback function casts the value via uuidToHugeInt. Thus, we do not
-		// use initPrimitive here.
-		t := C.duckdb_create_logical_type(C.DUCKDB_TYPE_UUID)
-		info := colInfo{
-			fn: func(a *Appender, info *colInfo, rowIdx C.idx_t, val any) {
-				setPrimitive[C.duckdb_hugeint](info, rowIdx, uuidToHugeInt(val.(UUID)))
-			},
-			duckdbType: C.DUCKDB_TYPE_UUID,
-		}
-		return info, t
-
-	case reflect.Struct:
-		// Check if it's time.Time since that is equivalent to the DuckDB TIMESTAMP type.
-		// If so, we can use setTime; otherwise it will not match the table set up by the user.
-		if (v == reflect.TypeOf(time.Time{})) {
-			t := C.duckdb_create_logical_type(C.DUCKDB_TYPE_TIMESTAMP)
-			info := colInfo{
-				fn: func(a *Appender, info *colInfo, rowIdx C.idx_t, val any) {
-					setTime(info, rowIdx, val.(time.Time))
-				},
-				duckdbType: C.DUCKDB_TYPE_TIMESTAMP,
-			}
-			return info, t
-		}
-
-		// Otherwise, it's a STRUCT.
-		numFields := v.NumField()
+	case C.DUCKDB_TYPE_STRUCT:
+		numFields := int(C.duckdb_struct_type_child_count(logicalType))
 
 		info := colInfo{
 			fn: func(a *Appender, info *colInfo, rowIdx C.idx_t, val any) {
@@ -362,38 +337,27 @@ func (a *Appender) initColInfos(v reflect.Type, colIdx int) (colInfo, C.duckdb_l
 			numFields:  numFields,
 		}
 
-		// We recurse into the child numFields. To create the resulting duckdb_logical_type,
-		// we create an array of the field's types, and an array of their names.
-		typesPtr, types := mallocLogicalTypeSlice(numFields)
-		namesPtr, names := mallocCStringSlice(numFields)
-
+		// Recurse into the children.
 		for i := 0; i < numFields; i++ {
-			childInfo, t := a.initColInfos(v.Field(i).Type, i)
+			childType := C.duckdb_struct_type_child_type(logicalType, C.idx_t(i))
+			childInfo, err := a.initColInfos(childType, i)
+			C.duckdb_destroy_logical_type(&childType)
+
+			if err != nil {
+				return colInfo{}, err
+			}
+
 			info.colInfos[i] = childInfo
-
-			types[i] = t
-			names[i] = C.CString(v.Field(i).Name)
 		}
 
-		t := C.duckdb_create_struct_type(
-			(*C.duckdb_logical_type)(typesPtr), // array of child types
-			(**C.char)(namesPtr),               // array of child names
-			C.idx_t(numFields),                 // number of children
-		)
+		return info, nil
 
-		for i := 0; i < numFields; i++ {
-			C.duckdb_destroy_logical_type(&types[i])
-			C.free(unsafe.Pointer(names[i]))
-		}
-		C.free(typesPtr)
-		C.free(namesPtr)
-
-		return info, t
-
-	case reflect.Map:
-		panic(fmt.Sprintf("%T: the appender does not support maps", v))
 	default:
-		panic(fmt.Sprintf("could not append unsupported parameter %T", v))
+		alias := C.duckdb_logical_type_get_alias(logicalType)
+		err := errors.New(fmt.Sprintf("the appender does not support the column type of column %d: %s",
+			colIdx, string(C.GoString(alias))))
+		C.free(unsafe.Pointer(alias))
+		return colInfo{}, err
 	}
 }
 
@@ -414,6 +378,7 @@ func (c *colInfo) getChildVectors(vector C.duckdb_vector) {
 
 func (a *Appender) appendChunk(colCount int) error {
 	a.currSize = 0
+
 	// duckdb_create_data_chunk takes an array of duckdb_logical_type and a column count.
 	colTypesPtr := (*C.duckdb_logical_type)(a.colTypesPtr)
 	dataChunk := C.duckdb_create_data_chunk(colTypesPtr, C.idx_t(colCount))
@@ -562,7 +527,7 @@ func (a *Appender) appendRowArray(args []driver.Value) error {
 		}
 
 		if err := info.typeMatch(reflect.TypeOf(v)); err != nil {
-			return fmt.Errorf("type mismatch for column %d: \n%s \n%s", i, err.Error(), errNote)
+			return fmt.Errorf("type mismatch for column %d: \n%s", i, err.Error())
 		}
 		info.fn(a, &info, a.currSize, v)
 	}

--- a/appender.go
+++ b/appender.go
@@ -268,6 +268,7 @@ func initCString[T string | []byte](duckdbType C.duckdb_type) colInfo {
 		fn: func(a *Appender, info *colInfo, rowIdx C.idx_t, val any) {
 			if isNull[T](val) {
 				setNull(info, rowIdx)
+				return
 			}
 
 			var v string

--- a/appender.go
+++ b/appender.go
@@ -542,7 +542,6 @@ func goTypeToString(v reflect.Type) string {
 	case "uint":
 		return "uint64"
 	case "time.Time":
-		// TODO: necessary?
 		return "time.Time"
 	}
 

--- a/appender.go
+++ b/appender.go
@@ -376,8 +376,9 @@ func (a *Appender) initColInfos(logicalType C.duckdb_logical_type, colIdx int) (
 		if !found {
 			name = "unknown type"
 		}
+		// Use 1-based indexing for readability, as we're talking about columns.
 		err := errors.New(
-			fmt.Sprintf("the appender does not support the column type of column %d: %s", colIdx, name))
+			fmt.Sprintf("the appender does not support the column type of column %d: %s", colIdx+1, name))
 		return colInfo{}, err
 	}
 }
@@ -548,7 +549,8 @@ func (a *Appender) appendRowArray(args []driver.Value) error {
 		}
 
 		if err := info.typeMatch(reflect.TypeOf(v)); err != nil {
-			return fmt.Errorf("type mismatch for column %d: \n%s", i, err.Error())
+			// Use 1-based indexing for readability, as we're talking about columns.
+			return fmt.Errorf("type mismatch for column %d: \n%s", i+1, err.Error())
 		}
 		info.fn(a, &info, a.currSize, v)
 	}

--- a/appender_test.go
+++ b/appender_test.go
@@ -1031,5 +1031,5 @@ func TestAppenderUnsupportedType(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = NewAppenderFromConn(con, "", "test")
-	require.ErrorContains(t, err, "does not support the column type of column 0: MAP")
+	require.ErrorContains(t, err, "does not support the column type of column 1: MAP")
 }

--- a/appender_test.go
+++ b/appender_test.go
@@ -880,12 +880,12 @@ func TestAppenderBlob(t *testing.T) {
 	defer con.Close()
 	defer connector.Close()
 
-	data := []byte{0x01, 0x02, 0x03, 0x04}
+	data := []byte{0x01, 0x02, 0x00, 0x03, 0x04}
 	err := appender.AppendRow(data)
 	require.NoError(t, err)
 
 	// Treat []uint8 the same as []byte.
-	uint8Slice := []uint8{0x01, 0x02, 0x03, 0x04}
+	uint8Slice := []uint8{0x01, 0x02, 0x00, 0x03, 0x04}
 	err = appender.AppendRow(uint8Slice)
 	require.NoError(t, err)
 

--- a/appender_test.go
+++ b/appender_test.go
@@ -82,17 +82,19 @@ func castList[T any](val []any) []T {
 	return res
 }
 
-func castMapListToStruct[T any](val []any) []T {
+func castMapListToStruct[T any](t *testing.T, val []any) []T {
 	res := make([]T, len(val))
 	for i, v := range val {
-		mapstructure.Decode(v, &res[i])
+		err := mapstructure.Decode(v, &res[i])
+		require.NoError(t, err)
 	}
 	return res
 }
 
-func castMapToStruct[T any](val any) T {
+func castMapToStruct[T any](t *testing.T, val any) T {
 	var res T
-	mapstructure.Decode(val, &res)
+	err := mapstructure.Decode(val, &res)
+	require.NoError(t, err)
 	return res
 }
 
@@ -433,14 +435,14 @@ func TestAppenderNested(t *testing.T) {
 		strRes = fmt.Sprintf("%v", r.tripleNestedIntList)
 		require.Equal(t, strRes, "[[[1 2 3] [4 5 6]] [[7 8 9] [10 11 12]]]")
 
-		require.Equal(t, rows[i].simpleStruct, castMapToStruct[simpleStruct](r.simpleStruct))
-		require.Equal(t, rows[i].wrappedStruct, castMapToStruct[wrappedStruct](r.wrappedStruct))
-		require.Equal(t, rows[i].doubleWrappedStruct, castMapToStruct[doubleWrappedStruct](r.doubleWrappedStruct))
+		require.Equal(t, rows[i].simpleStruct, castMapToStruct[simpleStruct](t, r.simpleStruct))
+		require.Equal(t, rows[i].wrappedStruct, castMapToStruct[wrappedStruct](t, r.wrappedStruct))
+		require.Equal(t, rows[i].doubleWrappedStruct, castMapToStruct[doubleWrappedStruct](t, r.doubleWrappedStruct))
 
-		require.Equal(t, rows[i].structList, castMapListToStruct[simpleStruct](r.structList))
-		require.Equal(t, rows[i].structWithList, castMapToStruct[structWithList](r.structWithList))
-		require.Equal(t, rows[i].mix, castMapToStruct[mixedStruct](r.mix))
-		require.Equal(t, rows[i].mixList, castMapListToStruct[mixedStruct](r.mixList))
+		require.Equal(t, rows[i].structList, castMapListToStruct[simpleStruct](t, r.structList))
+		require.Equal(t, rows[i].structWithList, castMapToStruct[structWithList](t, r.structWithList))
+		require.Equal(t, rows[i].mix, castMapToStruct[mixedStruct](t, r.mix))
+		require.Equal(t, rows[i].mixList, castMapListToStruct[mixedStruct](t, r.mixList))
 
 		i++
 	}

--- a/appender_test.go
+++ b/appender_test.go
@@ -1014,3 +1014,22 @@ func TestAppenderUint8SliceTinyInt(t *testing.T) {
 	}
 	require.Equal(t, 3, i)
 }
+
+func TestAppenderUnsupportedType(t *testing.T) {
+
+	connector, err := NewConnector("", nil)
+	defer connector.Close()
+	require.NoError(t, err)
+
+	// Create the table that we'll append to.
+	db := sql.OpenDB(connector)
+	_, err = db.Exec(`CREATE TABLE test AS SELECT MAP() AS m`)
+	require.NoError(t, err)
+
+	con, err := connector.Connect(context.Background())
+	defer con.Close()
+	require.NoError(t, err)
+
+	_, err = NewAppenderFromConn(con, "", "test")
+	require.ErrorContains(t, err, "does not support the column type of column 0: MAP")
+}


### PR DESCRIPTION
As discussed in #168, this PR adds support for initializing the column types of a data chunk when creating an appender.

The PR builds on https://github.com/marcboeker/go-duckdb/pull/167. I'll undraft it once #167 is merged.