### PR TITLE
TIMESTAMP_TZ support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ defer db.Close()
 
 Please refer to the [database/sql](https://godoc.org/database/sql) documentation for further usage instructions.
 
-## A Note on Memory Allocation
+## Memory Allocation
 
 DuckDB lives in-process. Therefore, all its memory lives in the driver. All allocations live in the host process, which
 is the Go application. Especially for long-running applications, it is crucial to call the corresponding `Close`-functions as specified
@@ -178,3 +178,12 @@ LD_LIBRARY_PATH=/path/to/libs ./main
 CGO_ENABLED=1 CGO_LDFLAGS="-L/path/to/libs" go build -tags=duckdb_use_lib main.go
 DYLD_LIBRARY_PATH=/path/to/libs ./main
 ```
+
+## Notes
+
+`TIMESTAMP vs. TIMESTAMP_TZ`
+
+In the C API, DuckDB stores both `TIMESTAMP` and `TIMESTAMP_TZ` as `duckdb_timestamp`, which holds the number of 
+microseconds elapsed since January 1, 1970 UTC. When passing a `time.Time` with a different location to go-duckdb, 
+it'll transform it with `UnixMicro()`, even when using `TIMESTAMP_TZ`. Scanning that value later returns the time in `UTC`, 
+not in its original timezone, even when using `TIMESTAMP_TZ`.

--- a/README.md
+++ b/README.md
@@ -183,7 +183,8 @@ DYLD_LIBRARY_PATH=/path/to/libs ./main
 
 `TIMESTAMP vs. TIMESTAMP_TZ`
 
-In the C API, DuckDB stores both `TIMESTAMP` and `TIMESTAMP_TZ` as `duckdb_timestamp`, which holds the number of 
-microseconds elapsed since January 1, 1970 UTC. When passing a `time.Time` with a different location to go-duckdb, 
-it'll transform it with `UnixMicro()`, even when using `TIMESTAMP_TZ`. Scanning that value later returns the time in `UTC`, 
-not in its original timezone, even when using `TIMESTAMP_TZ`.
+In the C API, DuckDB stores both `TIMESTAMP` and `TIMESTAMP_TZ` as `duckdb_timestamp`, which holds the number of
+microseconds elapsed since January 1, 1970 UTC (i.e., an instant without offset information). 
+When passing a `time.Time` to go-duckdb, go-duckdb transforms it to an instant with `UnixMicro()`, 
+even when using `TIMESTAMP_TZ`. Later, scanning either type of value returns an instant, as SQL types do not model 
+time zone information for individual values.

--- a/duckdb_test.go
+++ b/duckdb_test.go
@@ -626,6 +626,31 @@ func TestBlob(t *testing.T) {
 	})
 }
 
+func TestTimestampTZ(t *testing.T) {
+
+	t.Parallel()
+	db := openDB(t)
+	defer db.Close()
+
+	_, err := db.Exec("CREATE TABLE IF NOT EXISTS tbl (tz TIMESTAMPTZ)")
+	require.NoError(t, err)
+
+	IST, err := time.LoadLocation("Asia/Kolkata")
+	require.NoError(t, err)
+
+	const longForm = "2006-01-02 15:04:05 MST"
+	ts, err := time.ParseInLocation(longForm, "2016-01-17 20:04:05 IST", IST)
+	require.NoError(t, err)
+
+	_, err = db.Exec("INSERT INTO tbl (tz) VALUES(?)", ts)
+	require.NoError(t, err)
+
+	var tz time.Time
+	err = db.QueryRow("SELECT tz FROM tbl").Scan(&tz)
+	require.NoError(t, err)
+	require.Equal(t, ts.UTC(), tz)
+}
+
 func TestBoolean(t *testing.T) {
 	t.Parallel()
 	db := openDB(t)

--- a/rows.go
+++ b/rows.go
@@ -95,15 +95,22 @@ func scanValue(vector C.duckdb_vector, rowIdx C.idx_t) (any, error) {
 }
 
 func scan(vector C.duckdb_vector, rowIdx C.idx_t) (any, error) {
+
+	// FIXME: implement support for these types:
+	// DUCKDB_TYPE_UHUGEINT
+	// DUCKDB_TYPE_UNION
+	// DUCKDB_TYPE_BIT
+	// DUCKDB_TYPE_TIME_TZ
+
 	validity := C.duckdb_vector_get_validity(vector)
 	if !C.duckdb_validity_row_is_valid(validity, rowIdx) {
 		return nil, nil
 	}
 
-	ty := C.duckdb_vector_get_column_type(vector)
-	defer C.duckdb_destroy_logical_type(&ty)
+	columnType := C.duckdb_vector_get_column_type(vector)
+	defer C.duckdb_destroy_logical_type(&columnType)
 
-	typeId := C.duckdb_get_type_id(ty)
+	typeId := C.duckdb_get_type_id(columnType)
 	switch typeId {
 	case C.DUCKDB_TYPE_INVALID:
 		return nil, errInvalidType
@@ -139,31 +146,33 @@ func scan(vector C.duckdb_vector, rowIdx C.idx_t) (any, error) {
 	case C.DUCKDB_TYPE_INTERVAL:
 		return scanInterval(vector, rowIdx)
 	case C.DUCKDB_TYPE_HUGEINT:
-		hi := get[C.duckdb_hugeint](vector, rowIdx)
-		return hugeIntToNative(hi), nil
+		hugeInt := get[C.duckdb_hugeint](vector, rowIdx)
+		return hugeIntToNative(hugeInt), nil
 	case C.DUCKDB_TYPE_VARCHAR:
 		return scanString(vector, rowIdx), nil
-	case C.DUCKDB_TYPE_ENUM:
-		return scanENUM(ty, vector, rowIdx)
 	case C.DUCKDB_TYPE_BLOB:
 		return scanBlob(vector, rowIdx), nil
 	case C.DUCKDB_TYPE_DECIMAL:
-		return scanDecimal(ty, vector, rowIdx)
+		return scanDecimal(columnType, vector, rowIdx)
 	case C.DUCKDB_TYPE_TIMESTAMP_S:
 		return time.Unix(int64(get[C.duckdb_timestamp](vector, rowIdx).micros), 0).UTC(), nil
 	case C.DUCKDB_TYPE_TIMESTAMP_MS:
 		return time.UnixMilli(int64(get[C.duckdb_timestamp](vector, rowIdx).micros)).UTC(), nil
 	case C.DUCKDB_TYPE_TIMESTAMP_NS:
 		return time.Unix(0, int64(get[C.duckdb_timestamp](vector, rowIdx).micros)).UTC(), nil
+	case C.DUCKDB_TYPE_ENUM:
+		return scanENUM(columnType, vector, rowIdx)
 	case C.DUCKDB_TYPE_LIST:
 		return scanList(vector, rowIdx)
 	case C.DUCKDB_TYPE_STRUCT:
-		return scanStruct(ty, vector, rowIdx)
+		return scanStruct(columnType, vector, rowIdx)
 	case C.DUCKDB_TYPE_MAP:
-		return scanMap(ty, vector, rowIdx)
+		return scanMap(columnType, vector, rowIdx)
 	case C.DUCKDB_TYPE_UUID:
-		hi := get[C.duckdb_hugeint](vector, rowIdx)
-		return hugeIntToUUID(hi), nil
+		hugeInt := get[C.duckdb_hugeint](vector, rowIdx)
+		return hugeIntToUUID(hugeInt), nil
+	case C.DUCKDB_TYPE_TIMESTAMP_TZ:
+		return time.UnixMicro(int64(get[C.duckdb_timestamp](vector, rowIdx).micros)).UTC(), nil
 	default:
 		return nil, fmt.Errorf("unsupported type %d", typeId)
 	}


### PR DESCRIPTION
This PR adds support for `TIMESTAMP_TZ`. I assume that we treated them equally in the C API in a previous go-duckdb version. Therefore, the latest release broke compatibility.

Fixes #172.

@hawkfish, could you maybe review my attempt at a `README.md` section to outline the behavior?