### PR TITLE
Improve setting global vs. local config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ connector, err := duckdb.NewConnector("/path/to/foo.db?access_mode=read_only&thr
     }
 
     for _, query := range bootQueries {
-        _, err := execer.ExecContext(context.Background(), query, nil)
+        _, err = execer.ExecContext(context.Background(), query, nil)
         if err != nil {
             ...
         }

--- a/README.md
+++ b/README.md
@@ -50,14 +50,14 @@ Alternatively, you can use [sql.OpenDB](https://cs.opensource.google/go/go/+/go1
 Here's an example that installs and loads the JSON extension when opening a database with `sql.OpenDB(connector)`.
 
 ```go
-connector, err := duckdb.NewConnector("/path/to/foo.db?access_mode=read_only&threads=4", func(execer driver.Execer) error {
+connector, err := duckdb.NewConnector("/path/to/foo.db?access_mode=read_only&threads=4", func(execer driver.ExecerContext) error {
     bootQueries := []string{
         "INSTALL 'json'",
         "LOAD 'json'",
     }
 
     for _, query := range bootQueries {
-        _, err = execer.Exec(query, nil)
+        _, err := execer.ExecContext(context.Background(), query, nil)
         if err != nil {
             ...
         }

--- a/duckdb.go
+++ b/duckdb.go
@@ -154,7 +154,7 @@ func setConfig(config C.duckdb_config, name string, option string) error {
 	state := C.duckdb_set_config(config, cName, cOption)
 	if state == C.DuckDBError {
 		C.duckdb_destroy_config(&config)
-		return fmt.Errorf("%w: affected config option %s=%s", errSetConfig, name, option)
+		return fmt.Errorf("%w: %s=%s is not a global config option or does not exist", errSetConfig, name, option)
 	}
 
 	return nil
@@ -164,5 +164,5 @@ var (
 	errOpen         = errors.New("could not open database")
 	errParseDSN     = errors.New("could not parse DSN for database")
 	errCreateConfig = errors.New("could not create config for database")
-	errSetConfig    = errors.New("could not set config for database")
+	errSetConfig    = errors.New("could not set config option for database")
 )


### PR DESCRIPTION
This PR adds a clearer error message about setting local config options in the global config object (DSN). As for better documentation on the DuckDB side, [I've opened this issue.](https://github.com/duckdb/duckdb-web/issues/2452)

### Changes
- error message updates
- more tests, also for the boot queries
- removed deprecated function in `README`

Fixes #176.