### PR TITLE
Unify Appender error handling

### DIFF
--- a/appender_test.go
+++ b/appender_test.go
@@ -21,6 +21,11 @@ type simpleStruct struct {
 	B string
 }
 
+type wrappedSimpleStruct struct {
+	A string
+	B simpleStruct
+}
+
 type wrappedStruct struct {
 	N string
 	M simpleStruct
@@ -112,26 +117,36 @@ func randString(n int) string {
 	return string(b)
 }
 
+func cleanupAppender(t *testing.T, c *Connector, con driver.Conn, a *Appender) {
+	require.NoError(t, a.Close())
+	require.NoError(t, con.Close())
+	require.NoError(t, c.Close())
+}
+
 func prepareAppender(t *testing.T, createTbl string) (*Connector, driver.Conn, *Appender) {
-	connector, err := NewConnector("", nil)
+	c, err := NewConnector("", nil)
 	require.NoError(t, err)
 
-	// Create the table that we'll append to.
-	db := sql.OpenDB(connector)
-	_, err = db.Exec(createTbl)
+	_, err = sql.OpenDB(c).Exec(createTbl)
 	require.NoError(t, err)
 
-	con, err := connector.Connect(context.Background())
+	con, err := c.Connect(context.Background())
 	require.NoError(t, err)
 
-	appender, err := NewAppenderFromConn(con, "", "test")
+	a, err := NewAppenderFromConn(con, "", "test")
 	require.NoError(t, err)
 
-	return connector, con, appender
+	return c, con, a
+}
+
+func TestAppenderClose(t *testing.T) {
+	c, con, a := prepareAppender(t, `CREATE TABLE test (i INTEGER)`)
+	require.NoError(t, a.AppendRow(int32(42)))
+	cleanupAppender(t, c, con, a)
 }
 
 func TestAppenderPrimitive(t *testing.T) {
-	connector, con, appender := prepareAppender(t, `
+	c, con, a := prepareAppender(t, `
 		CREATE TABLE test (
 			id BIGINT,
 			uint8 UTINYINT,
@@ -148,10 +163,8 @@ func TestAppenderPrimitive(t *testing.T) {
 			string VARCHAR,
 			bool BOOLEAN
 	  	)`)
-	defer con.Close()
-	defer connector.Close()
 
-	type dataRow struct {
+	type row struct {
 		ID        int64
 		UInt8     uint8
 		Int8      int8
@@ -168,14 +181,14 @@ func TestAppenderPrimitive(t *testing.T) {
 		Bool      bool
 	}
 
-	rows := make([]dataRow, numAppenderTestRows)
+	rowsToAppend := make([]row, numAppenderTestRows)
 	for i := 0; i < numAppenderTestRows; i++ {
 		u64 := rand.Uint64()
-		// go sql doesn't support uint64 values with high bit set (see for example https://github.com/lib/pq/issues/72)
+		// Go SQL does not support uint64 values with their high bit set (see for example https://github.com/lib/pq/issues/72).
 		if u64 > 9223372036854775807 {
 			u64 = 9223372036854775807
 		}
-		rows[i] = dataRow{
+		rowsToAppend[i] = row{
 			ID:        int64(i),
 			UInt8:     uint8(randInt(0, 255)),
 			Int8:      int8(randInt(-128, 127)),
@@ -192,46 +205,37 @@ func TestAppenderPrimitive(t *testing.T) {
 			Bool:      rand.Int()%2 == 0,
 		}
 
-		err := appender.AppendRow(
-			rows[i].ID,
-			rows[i].UInt8,
-			rows[i].Int8,
-			rows[i].UInt16,
-			rows[i].Int16,
-			rows[i].UInt32,
-			rows[i].Int32,
-			rows[i].UInt64,
-			rows[i].Int64,
-			rows[i].Timestamp,
-			rows[i].Float,
-			rows[i].Double,
-			rows[i].String,
-			rows[i].Bool,
-		)
-		require.NoError(t, err)
+		require.NoError(t, a.AppendRow(
+			rowsToAppend[i].ID,
+			rowsToAppend[i].UInt8,
+			rowsToAppend[i].Int8,
+			rowsToAppend[i].UInt16,
+			rowsToAppend[i].Int16,
+			rowsToAppend[i].UInt32,
+			rowsToAppend[i].Int32,
+			rowsToAppend[i].UInt64,
+			rowsToAppend[i].Int64,
+			rowsToAppend[i].Timestamp,
+			rowsToAppend[i].Float,
+			rowsToAppend[i].Double,
+			rowsToAppend[i].String,
+			rowsToAppend[i].Bool,
+		))
 
 		if i%1000 == 0 {
-			err := appender.Flush()
-			require.NoError(t, err)
+			require.NoError(t, a.Flush())
 		}
 	}
-
-	err := appender.Close()
-	require.NoError(t, err)
+	require.NoError(t, a.Flush())
 
 	// Verify results.
-	db := sql.OpenDB(connector)
-	res, err := db.QueryContext(
-		context.Background(), `
-			SELECT * FROM test ORDER BY id`,
-	)
+	res, err := sql.OpenDB(c).QueryContext(context.Background(), `SELECT * FROM test ORDER BY id`)
 	require.NoError(t, err)
-	defer res.Close()
 
 	i := 0
 	for res.Next() {
-		r := dataRow{}
-		err := res.Scan(
+		r := row{}
+		require.NoError(t, res.Scan(
 			&r.ID,
 			&r.UInt8,
 			&r.Int8,
@@ -246,69 +250,54 @@ func TestAppenderPrimitive(t *testing.T) {
 			&r.Double,
 			&r.String,
 			&r.Bool,
-		)
-		require.NoError(t, err)
-		require.Equal(t, rows[i], r)
+		))
+		require.Equal(t, rowsToAppend[i], r)
 		i++
 	}
 
 	require.Equal(t, numAppenderTestRows, i)
+	require.NoError(t, res.Close())
+	cleanupAppender(t, c, con, a)
 }
 
 func TestAppenderList(t *testing.T) {
-	connector, con, appender := prepareAppender(t, `
+	c, con, a := prepareAppender(t, `
 	CREATE TABLE test (
 		string_list VARCHAR[],
 		int_list INTEGER[]
 	)`)
-	defer con.Close()
-	defer connector.Close()
 
-	rows := make([]nestedDataRow, 10)
+	rowsToAppend := make([]nestedDataRow, 10)
 	for i := 0; i < 10; i++ {
-		rows[i].stringList = []string{"a", "b", "c"}
-		rows[i].intList = []int32{1, 2, 3}
+		rowsToAppend[i].stringList = []string{"a", "b", "c"}
+		rowsToAppend[i].intList = []int32{1, 2, 3}
 	}
 
-	for _, row := range rows {
-		err := appender.AppendRow(
-			row.stringList,
-			row.intList,
-		)
-		require.NoError(t, err)
+	for _, row := range rowsToAppend {
+		require.NoError(t, a.AppendRow(row.stringList, row.intList))
 	}
-	err := appender.Close()
-	require.NoError(t, err)
+	require.NoError(t, a.Flush())
 
 	// Verify results.
-	db := sql.OpenDB(connector)
-	res, err := db.QueryContext(
-		context.Background(),
-		`SELECT * FROM test`,
-	)
+	res, err := sql.OpenDB(c).QueryContext(context.Background(), `SELECT * FROM test`)
 	require.NoError(t, err)
-	defer res.Close()
 
 	i := 0
 	for res.Next() {
 		var r resultRow
-		err := res.Scan(
-			&r.stringList,
-			&r.intList,
-		)
-		require.NoError(t, err)
-
-		require.Equal(t, rows[i].stringList, castList[string](r.stringList))
-		require.Equal(t, rows[i].intList, castList[int32](r.intList))
-
+		require.NoError(t, res.Scan(&r.stringList, &r.intList))
+		require.Equal(t, rowsToAppend[i].stringList, castList[string](r.stringList))
+		require.Equal(t, rowsToAppend[i].intList, castList[int32](r.intList))
 		i++
 	}
 
 	require.Equal(t, 10, i)
+	require.NoError(t, res.Close())
+	cleanupAppender(t, c, con, a)
 }
 
 func TestAppenderNested(t *testing.T) {
-	connector, con, appender := prepareAppender(t, `
+	c, con, a := prepareAppender(t, `
 		CREATE TABLE test (
 			id BIGINT,
 			string_list VARCHAR[],
@@ -339,8 +328,6 @@ func TestAppenderNested(t *testing.T) {
 			)[]
 		)
 	`)
-	defer con.Close()
-	defer connector.Close()
 
 	ms := mixedStruct{
 		A: struct {
@@ -354,34 +341,33 @@ func TestAppenderNested(t *testing.T) {
 			{[]int32{1, 2, 3}},
 		},
 	}
-
-	rows := make([]nestedDataRow, 10)
+	rowsToAppend := make([]nestedDataRow, 10)
 	for i := 0; i < 10; i++ {
-		rows[i].ID = int64(i)
-		rows[i].stringList = []string{"a", "b", "c"}
-		rows[i].intList = []int32{1, 2, 3}
-		rows[i].nestedIntList = [][]int32{{1, 2, 3}, {4, 5, 6}}
-		rows[i].tripleNestedIntList = [][][]int32{
+		rowsToAppend[i].ID = int64(i)
+		rowsToAppend[i].stringList = []string{"a", "b", "c"}
+		rowsToAppend[i].intList = []int32{1, 2, 3}
+		rowsToAppend[i].nestedIntList = [][]int32{{1, 2, 3}, {4, 5, 6}}
+		rowsToAppend[i].tripleNestedIntList = [][][]int32{
 			{{1, 2, 3}, {4, 5, 6}},
 			{{7, 8, 9}, {10, 11, 12}},
 		}
-		rows[i].simpleStruct = simpleStruct{A: 1, B: "foo"}
-		rows[i].wrappedStruct = wrappedStruct{"wrapped", simpleStruct{1, "foo"}}
-		rows[i].doubleWrappedStruct = doubleWrappedStruct{
+		rowsToAppend[i].simpleStruct = simpleStruct{A: 1, B: "foo"}
+		rowsToAppend[i].wrappedStruct = wrappedStruct{"wrapped", simpleStruct{1, "foo"}}
+		rowsToAppend[i].doubleWrappedStruct = doubleWrappedStruct{
 			"so much nesting",
 			wrappedStruct{
 				"wrapped",
 				simpleStruct{1, "foo"},
 			},
 		}
-		rows[i].structList = []simpleStruct{{1, "a"}, {2, "b"}, {3, "c"}}
-		rows[i].structWithList.L = []int32{6, 7, 8}
-		rows[i].mix = ms
-		rows[i].mixList = []mixedStruct{ms, ms}
+		rowsToAppend[i].structList = []simpleStruct{{1, "a"}, {2, "b"}, {3, "c"}}
+		rowsToAppend[i].structWithList.L = []int32{6, 7, 8}
+		rowsToAppend[i].mix = ms
+		rowsToAppend[i].mixList = []mixedStruct{ms, ms}
 	}
 
-	for _, row := range rows {
-		err := appender.AppendRow(
+	for _, row := range rowsToAppend {
+		require.NoError(t, a.AppendRow(
 			row.ID,
 			row.stringList,
 			row.intList,
@@ -393,26 +379,18 @@ func TestAppenderNested(t *testing.T) {
 			row.structList,
 			row.structWithList,
 			row.mix,
-			row.mixList,
-		)
-		require.NoError(t, err)
+			row.mixList))
 	}
-	err := appender.Close()
-	require.NoError(t, err)
+	require.NoError(t, a.Flush())
 
 	// Verify results.
-	db := sql.OpenDB(connector)
-	res, err := db.QueryContext(
-		context.Background(),
-		`SELECT * FROM test ORDER BY id`,
-	)
+	res, err := sql.OpenDB(c).QueryContext(context.Background(), `SELECT * FROM test ORDER BY id`)
 	require.NoError(t, err)
-	defer res.Close()
 
 	i := 0
 	for res.Next() {
 		var r resultRow
-		err := res.Scan(
+		require.NoError(t, res.Scan(
 			&r.ID,
 			&r.stringList,
 			&r.intList,
@@ -425,67 +403,48 @@ func TestAppenderNested(t *testing.T) {
 			&r.structWithList,
 			&r.mix,
 			&r.mixList,
-		)
-		require.NoError(t, err)
+		))
 
-		require.Equal(t, rows[i].ID, r.ID)
-		require.Equal(t, rows[i].stringList, castList[string](r.stringList))
-		require.Equal(t, rows[i].intList, castList[int32](r.intList))
+		require.Equal(t, rowsToAppend[i].ID, r.ID)
+		require.Equal(t, rowsToAppend[i].stringList, castList[string](r.stringList))
+		require.Equal(t, rowsToAppend[i].intList, castList[int32](r.intList))
 
 		strRes := fmt.Sprintf("%v", r.nestedIntList)
 		require.Equal(t, strRes, "[[1 2 3] [4 5 6]]")
 		strRes = fmt.Sprintf("%v", r.tripleNestedIntList)
 		require.Equal(t, strRes, "[[[1 2 3] [4 5 6]] [[7 8 9] [10 11 12]]]")
 
-		require.Equal(t, rows[i].simpleStruct, castMapToStruct[simpleStruct](t, r.simpleStruct))
-		require.Equal(t, rows[i].wrappedStruct, castMapToStruct[wrappedStruct](t, r.wrappedStruct))
-		require.Equal(t, rows[i].doubleWrappedStruct, castMapToStruct[doubleWrappedStruct](t, r.doubleWrappedStruct))
+		require.Equal(t, rowsToAppend[i].simpleStruct, castMapToStruct[simpleStruct](t, r.simpleStruct))
+		require.Equal(t, rowsToAppend[i].wrappedStruct, castMapToStruct[wrappedStruct](t, r.wrappedStruct))
+		require.Equal(t, rowsToAppend[i].doubleWrappedStruct, castMapToStruct[doubleWrappedStruct](t, r.doubleWrappedStruct))
 
-		require.Equal(t, rows[i].structList, castMapListToStruct[simpleStruct](t, r.structList))
-		require.Equal(t, rows[i].structWithList, castMapToStruct[structWithList](t, r.structWithList))
-		require.Equal(t, rows[i].mix, castMapToStruct[mixedStruct](t, r.mix))
-		require.Equal(t, rows[i].mixList, castMapListToStruct[mixedStruct](t, r.mixList))
+		require.Equal(t, rowsToAppend[i].structList, castMapListToStruct[simpleStruct](t, r.structList))
+		require.Equal(t, rowsToAppend[i].structWithList, castMapToStruct[structWithList](t, r.structWithList))
+		require.Equal(t, rowsToAppend[i].mix, castMapToStruct[mixedStruct](t, r.mix))
+		require.Equal(t, rowsToAppend[i].mixList, castMapListToStruct[mixedStruct](t, r.mixList))
 
 		i++
 	}
 
 	require.Equal(t, 10, i)
+	require.NoError(t, res.Close())
+	cleanupAppender(t, c, con, a)
 }
 
 func TestAppenderNullList(t *testing.T) {
-	connector, con, appender := prepareAppender(t, `CREATE TABLE test (int_slice VARCHAR[][][])`)
-	defer con.Close()
-	defer connector.Close()
+	c, con, a := prepareAppender(t, `CREATE TABLE test (int_slice VARCHAR[][][])`)
 
-	// An empty list must also initialize the logical types.
-	err := appender.AppendRow([][][]string{{{}}})
-	require.NoError(t, err)
-
-	err = appender.AppendRow([][][]string{{{"1", "2", "3"}, {"4", "5", "6"}}})
-	require.NoError(t, err)
-
-	err = appender.AppendRow([][][]string{{{"1"}, nil}})
-	require.NoError(t, err)
-
-	err = appender.AppendRow(nil)
-	require.NoError(t, err)
-
-	err = appender.AppendRow([][][]string{nil, {{"2"}}})
-	require.NoError(t, err)
-
-	err = appender.AppendRow([][][]string{{nil, {"3"}}, {{"4"}}})
-	require.NoError(t, err)
-
-	err = appender.Close()
-	require.NoError(t, err)
+	require.NoError(t, a.AppendRow([][][]string{{{}}}))
+	require.NoError(t, a.AppendRow([][][]string{{{"1", "2", "3"}, {"4", "5", "6"}}}))
+	require.NoError(t, a.AppendRow([][][]string{{{"1"}, nil}}))
+	require.NoError(t, a.AppendRow(nil))
+	require.NoError(t, a.AppendRow([][][]string{nil, {{"2"}}}))
+	require.NoError(t, a.AppendRow([][][]string{{nil, {"3"}}, {{"4"}}}))
+	require.NoError(t, a.Flush())
 
 	// Verify results.
-	db := sql.OpenDB(connector)
-	res, err := db.QueryContext(
-		context.Background(),
-		`SELECT int_slice FROM test`)
+	res, err := sql.OpenDB(c).QueryContext(context.Background(), `SELECT int_slice FROM test`)
 	require.NoError(t, err)
-	defer res.Close()
 
 	var strResult []string
 	strResult = append(strResult, "[[[]]]")
@@ -499,9 +458,7 @@ func TestAppenderNullList(t *testing.T) {
 	for res.Next() {
 		var strS string
 		var intS []any
-		err := res.Scan(
-			&intS,
-		)
+		err = res.Scan(&intS)
 		if err != nil {
 			strS = "<nil>"
 		} else {
@@ -511,32 +468,24 @@ func TestAppenderNullList(t *testing.T) {
 		require.Equal(t, strResult[i], strS, fmt.Sprintf("row %d: expected %v, got %v", i, strResult[i], strS))
 		i++
 	}
+
+	require.NoError(t, res.Close())
+	cleanupAppender(t, c, con, a)
 }
 
 func TestAppenderNullStruct(t *testing.T) {
-	connector, con, appender := prepareAppender(t, `
+	c, con, a := prepareAppender(t, `
 	CREATE TABLE test (
 		simple_struct STRUCT(A INT, B VARCHAR)
 	)`)
-	defer con.Close()
-	defer connector.Close()
 
-	err := appender.AppendRow(simpleStruct{1, "hello"})
-	require.NoError(t, err)
-
-	err = appender.AppendRow(nil)
-	require.NoError(t, err)
-
-	err = appender.Close()
-	require.NoError(t, err)
+	require.NoError(t, a.AppendRow(simpleStruct{1, "hello"}))
+	require.NoError(t, a.AppendRow(nil))
+	require.NoError(t, a.Flush())
 
 	// Verify results.
-	db := sql.OpenDB(connector)
-	res, err := db.QueryContext(
-		context.Background(),
-		`SELECT simple_struct FROM test`)
+	res, err := sql.OpenDB(c).QueryContext(context.Background(), `SELECT simple_struct FROM test`)
 	require.NoError(t, err)
-	defer res.Close()
 
 	i := 0
 	for res.Next() {
@@ -547,13 +496,15 @@ func TestAppenderNullStruct(t *testing.T) {
 		} else if i == 1 {
 			require.Equal(t, nil, row)
 		}
-
 		i++
 	}
+
+	require.NoError(t, res.Close())
+	cleanupAppender(t, c, con, a)
 }
 
 func TestAppenderNestedNullStruct(t *testing.T) {
-	connector, con, appender := prepareAppender(t, `
+	c, con, a := prepareAppender(t, `
 	CREATE TABLE test (
 		double_wrapped_struct STRUCT(
 				X VARCHAR,
@@ -566,41 +517,27 @@ func TestAppenderNestedNullStruct(t *testing.T) {
 				)
 			)
 	)`)
-	defer con.Close()
-	defer connector.Close()
 
-	err := appender.AppendRow(doubleWrappedStruct{
+	require.NoError(t, a.AppendRow(doubleWrappedStruct{
 		"so much nesting",
 		wrappedStruct{
 			"wrapped",
 			simpleStruct{1, "foo"},
 		},
-	})
-	require.NoError(t, err)
-
-	// We propagate the NULL to all nested children.
-	err = appender.AppendRow(nil)
-	require.NoError(t, err)
-
-	err = appender.AppendRow(doubleWrappedStruct{
+	}))
+	require.NoError(t, a.AppendRow(nil))
+	require.NoError(t, a.AppendRow(doubleWrappedStruct{
 		"now we are done nesting NULLs",
 		wrappedStruct{
 			"unwrap",
 			simpleStruct{21, "bar"},
 		},
-	})
-	require.NoError(t, err)
-
-	err = appender.Close()
-	require.NoError(t, err)
+	}))
+	require.NoError(t, a.Flush())
 
 	// Verify results.
-	db := sql.OpenDB(connector)
-	res, err := db.QueryContext(
-		context.Background(),
-		`SELECT double_wrapped_struct FROM test`)
+	res, err := sql.OpenDB(c).QueryContext(context.Background(), `SELECT double_wrapped_struct FROM test`)
 	require.NoError(t, err)
-	defer res.Close()
 
 	i := 0
 	for res.Next() {
@@ -611,42 +548,26 @@ func TestAppenderNestedNullStruct(t *testing.T) {
 		} else {
 			require.NoError(t, err)
 		}
-
 		i++
 	}
+
+	require.NoError(t, res.Close())
+	cleanupAppender(t, c, con, a)
 }
 
 func TestAppenderNullIntAndString(t *testing.T) {
-	connector, con, appender := prepareAppender(t, `CREATE TABLE test (id BIGINT, str VARCHAR)`)
-	defer con.Close()
-	defer connector.Close()
+	c, con, a := prepareAppender(t, `CREATE TABLE test (id BIGINT, str VARCHAR)`)
 
-	err := appender.AppendRow(int64(32), "hello")
-	require.NoError(t, err)
-
-	err = appender.AppendRow(nil, nil)
-	require.NoError(t, err)
-
-	err = appender.AppendRow(nil, "half valid thingy")
-	require.NoError(t, err)
-
-	err = appender.AppendRow(int64(60), nil)
-	require.NoError(t, err)
-
-	err = appender.AppendRow(int64(42), "valid again")
-	require.NoError(t, err)
-
-	err = appender.Close()
-	require.NoError(t, err)
+	require.NoError(t, a.AppendRow(int64(32), "hello"))
+	require.NoError(t, a.AppendRow(nil, nil))
+	require.NoError(t, a.AppendRow(nil, "half valid thingy"))
+	require.NoError(t, a.AppendRow(int64(60), nil))
+	require.NoError(t, a.AppendRow(int64(42), "valid again"))
+	require.NoError(t, a.Flush())
 
 	// Verify results.
-	db := sql.OpenDB(connector)
-	res, err := db.QueryContext(
-		context.Background(),
-		`SELECT * FROM test`,
-	)
+	res, err := sql.OpenDB(c).QueryContext(context.Background(), `SELECT * FROM test`)
 	require.NoError(t, err)
-	defer res.Close()
 
 	i := 0
 	for res.Next() {
@@ -667,291 +588,90 @@ func TestAppenderNullIntAndString(t *testing.T) {
 			require.Equal(t, id, 42)
 			require.Equal(t, str, "valid again")
 		}
-
 		i++
 	}
-}
 
-func TestAppenderNestedListMismatch(t *testing.T) {
-	connector, con, appender := prepareAppender(t, `CREATE TABLE test(int_slice INT[][][])`)
-	defer con.Close()
-	defer connector.Close()
-
-	err := appender.AppendRow([][][]int32{{{}}})
-	require.NoError(t, err)
-
-	err = appender.AppendRow([]int32{1, 2, 3})
-	require.Error(t, err, "expected: [][][]int32, actual: []int32")
-
-	err = appender.AppendRow(1)
-	require.ErrorContains(t, err, "expected: [][][]int32, actual: int64")
-
-	err = appender.AppendRow([][]int32{{1, 2, 3}, {4, 5, 6}})
-	require.ErrorContains(t, err, "expected: [][][]int32, actual: [][]int32")
-
-	err = appender.Close()
-	require.NoError(t, err)
-}
-
-func TestAppenderListMismatch(t *testing.T) {
-	connector, con, appender := prepareAppender(t, `CREATE TABLE test(intSlice INT[])`)
-	defer con.Close()
-	defer connector.Close()
-
-	err := appender.AppendRow([]int32{})
-	require.NoError(t, err)
-
-	err = appender.AppendRow([]string{"foo", "bar", "baz"})
-	require.ErrorContains(t, err, "expected: []int32, actual: []string")
-
-	err = appender.AppendRow(
-		[][]int32{{1, 2, 3}, {4, 5, 6}},
-	)
-	require.ErrorContains(t, err, "expected: []int32, actual: [][]int32")
-
-	err = appender.Close()
-	require.NoError(t, err)
-}
-
-func TestAppenderStructMismatch(t *testing.T) {
-	connector, con, appender := prepareAppender(t, `
-		CREATE TABLE test (
-			simple_struct STRUCT(A INT, B VARCHAR)
-		)`)
-	defer con.Close()
-	defer connector.Close()
-
-	err := appender.AppendRow(simpleStruct{1, "hello"})
-	require.NoError(t, err)
-
-	err = appender.AppendRow(1)
-	require.ErrorContains(t, err, "expected: {int32, string}, actual: int64")
-
-	err = appender.AppendRow("hello")
-	require.ErrorContains(t, err, "expected: {int32, string}, actual: string")
-
-	type other struct {
-		S string
-		I int
-	}
-	err = appender.AppendRow(other{"hello", 1})
-	require.ErrorContains(t, err, "expected: {int32, string}, actual: {string, int64}")
-
-	err = appender.AppendRow(
-		wrappedStruct{
-			"hello there",
-			simpleStruct{A: 0, B: "one billion ducks"},
-		},
-	)
-	require.ErrorContains(t, err, "expected: {int32, string}, actual: {string, {int32, string}}")
-
-	err = appender.Close()
-	require.NoError(t, err)
-}
-
-func TestAppenderWrappedStructMismatch(t *testing.T) {
-	connector, con, appender := prepareAppender(t, `
-		CREATE TABLE test (
-			wrapped_struct STRUCT(N VARCHAR, M STRUCT(A INT, B VARCHAR)),
-		)`)
-	defer con.Close()
-	defer connector.Close()
-
-	err := appender.AppendRow(
-		wrappedStruct{
-			"it's me again",
-			simpleStruct{A: 0, B: "one billion ducks"},
-		},
-	)
-	require.NoError(t, err)
-
-	err = appender.AppendRow(simpleStruct{1, "hello"})
-	require.ErrorContains(t, err, "expected: {string, {int32, string}}, actual: {int32, string}")
-
-	err = appender.Close()
-	require.NoError(t, err)
-}
-
-func TestAppenderMismatchStructWithList(t *testing.T) {
-	connector, con, appender := prepareAppender(t, `CREATE TABLE test (struct_with_list STRUCT(L INT[]))`)
-	defer con.Close()
-	defer connector.Close()
-
-	err := appender.AppendRow(structWithList{L: []int32{1, 2, 3}})
-	require.NoError(t, err)
-
-	err = appender.AppendRow([]int32{1, 2, 3})
-	require.ErrorContains(t, err, "expected: {[]int32}, actual: []int32")
-
-	l := struct{ L []string }{L: []string{"a", "b", "c"}}
-	err = appender.AppendRow(l)
-	require.ErrorContains(t, err, "expected: {[]int32}, actual: {[]string}")
-
-	err = appender.Close()
-	require.NoError(t, err)
-}
-
-func TestAppenderMismatchStruct(t *testing.T) {
-	connector, con, appender := prepareAppender(t, `
-		CREATE TABLE test (
-			mix STRUCT(A STRUCT(L VARCHAR[]), B STRUCT(L INT[])[])
-		)`)
-	defer con.Close()
-	defer connector.Close()
-
-	err := appender.AppendRow(
-		mixedStruct{
-			A: struct {
-				L []string
-			}{
-				L: []string{"a", "b", "c"},
-			},
-			B: []struct {
-				L []int32
-			}{
-				{[]int32{1, 2, 3}},
-			},
-		},
-	)
-	require.NoError(t, err)
-
-	err = appender.AppendRow(simpleStruct{1, "hello"})
-	require.ErrorContains(t, err, "expected: {{[]string}, []{[]int32}}, actual: {int32, string}")
-
-	err = appender.Close()
-	require.NoError(t, err)
-}
-
-func TestAppenderMismatch(t *testing.T) {
-	connector, con, appender := prepareAppender(t, `CREATE TABLE test (id BIGINT, str VARCHAR)`)
-	defer con.Close()
-	defer connector.Close()
-
-	err := appender.AppendRow("hello")
-	require.ErrorContains(t, err, "type mismatch")
-
-	err = appender.AppendRow(false)
-	require.ErrorContains(t, err, "type mismatch")
-
-	err = appender.Close()
-	require.ErrorContains(t, err, "duckdb has returned an error while appending, all data has been invalidated.")
+	require.NoError(t, res.Close())
+	cleanupAppender(t, c, con, a)
 }
 
 func TestAppenderUUID(t *testing.T) {
-	connector, con, appender := prepareAppender(t, `CREATE TABLE test (id UUID)`)
-	defer con.Close()
-	defer connector.Close()
+	c, con, a := prepareAppender(t, `CREATE TABLE test (id UUID)`)
 
 	id := UUID(uuid.New())
-	err := appender.AppendRow(id)
-	require.NoError(t, err)
-
-	err = appender.Close()
-	require.NoError(t, err)
+	require.NoError(t, a.AppendRow(id))
+	require.NoError(t, a.Flush())
 
 	// Verify results.
-	db := sql.OpenDB(connector)
-	row := db.QueryRowContext(context.Background(), `SELECT id FROM test`)
+	row := sql.OpenDB(c).QueryRowContext(context.Background(), `SELECT id FROM test`)
 
 	var res UUID
-	err = row.Scan(&res)
-	require.NoError(t, err)
+	require.NoError(t, row.Scan(&res))
 	require.Equal(t, id, res)
+	cleanupAppender(t, c, con, a)
 }
 
 func TestAppenderTime(t *testing.T) {
-	connector, con, appender := prepareAppender(t, `CREATE TABLE test (timestamp TIMESTAMP)`)
-	defer con.Close()
-	defer connector.Close()
+	c, con, a := prepareAppender(t, `CREATE TABLE test (timestamp TIMESTAMP)`)
 
 	ts := time.Date(2022, time.January, 1, 12, 0, 0, 0, time.UTC)
-	err := appender.AppendRow(ts)
-	require.NoError(t, err)
-
-	err = appender.Close()
-	require.NoError(t, err)
+	require.NoError(t, a.AppendRow(ts))
+	require.NoError(t, a.Flush())
 
 	// Verify results.
-	db := sql.OpenDB(connector)
-	row := db.QueryRowContext(context.Background(), `SELECT timestamp FROM test`)
+	row := sql.OpenDB(c).QueryRowContext(context.Background(), `SELECT timestamp FROM test`)
 
 	var res time.Time
-	err = row.Scan(&res)
-	require.NoError(t, err)
+	require.NoError(t, row.Scan(&res))
 	require.Equal(t, ts, res)
+	cleanupAppender(t, c, con, a)
 }
 
 func TestAppenderBlob(t *testing.T) {
-	connector, con, appender := prepareAppender(t, `CREATE TABLE test (data BLOB)`)
-	defer con.Close()
-	defer connector.Close()
+	c, con, a := prepareAppender(t, `CREATE TABLE test (data BLOB)`)
 
 	data := []byte{0x01, 0x02, 0x00, 0x03, 0x04}
-	err := appender.AppendRow(data)
-	require.NoError(t, err)
+	require.NoError(t, a.AppendRow(data))
 
 	// Treat []uint8 the same as []byte.
 	uint8Slice := []uint8{0x01, 0x02, 0x00, 0x03, 0x04}
-	err = appender.AppendRow(uint8Slice)
-	require.NoError(t, err)
-
-	err = appender.Close()
-	require.NoError(t, err)
+	require.NoError(t, a.AppendRow(uint8Slice))
+	require.NoError(t, a.Flush())
 
 	// Verify results.
-	db := sql.OpenDB(connector)
-	res, err := db.QueryContext(
-		context.Background(),
-		`SELECT data FROM test`,
-	)
+	res, err := sql.OpenDB(c).QueryContext(context.Background(), `SELECT data FROM test`)
 	require.NoError(t, err)
-	defer res.Close()
 
 	i := 0
 	for res.Next() {
 		var b []byte
-		err = res.Scan(
-			&b,
-		)
-		require.NoError(t, err)
+		require.NoError(t, res.Scan(&b))
 		require.Equal(t, data, b)
 		i++
 	}
+
 	require.Equal(t, 2, i)
+	require.NoError(t, res.Close())
+	cleanupAppender(t, c, con, a)
 }
 
 func TestAppenderBlobTinyInt(t *testing.T) {
-	connector, con, appender := prepareAppender(t, `
+	c, con, a := prepareAppender(t, `
 	CREATE TABLE test (
 		data UTINYINT[]
 	)`)
-	defer con.Close()
-	defer connector.Close()
 
-	err := appender.AppendRow(nil)
-	require.NoError(t, err)
+	require.NoError(t, a.AppendRow(nil))
 
 	// We treat the byte slice as a list, as that's the type we set when creating the appender.
-	err = appender.AppendRow([]byte{0x01, 0x02, 0x03, 0x04})
-	require.NoError(t, err)
-
-	err = appender.AppendRow([]byte{0x01, 0x00, 0x03, 0x04, 0x01, 0x00, 0x03, 0x04, 0x01, 0x00, 0x03, 0x04, 0x01, 0x00, 0x03, 0x04})
-	require.NoError(t, err)
-
-	err = appender.AppendRow([]byte{})
-	require.NoError(t, err)
-
-	err = appender.Close()
-	require.NoError(t, err)
+	require.NoError(t, a.AppendRow([]byte{0x01, 0x02, 0x03, 0x04}))
+	require.NoError(t, a.AppendRow([]byte{0x01, 0x00, 0x03, 0x04, 0x01, 0x00, 0x03, 0x04, 0x01, 0x00, 0x03, 0x04, 0x01, 0x00, 0x03, 0x04}))
+	require.NoError(t, a.AppendRow([]byte{}))
+	require.NoError(t, a.Flush())
 
 	// Verify results.
-	db := sql.OpenDB(connector)
-	res, err := db.QueryContext(
-		context.Background(),
-		`SELECT CASE WHEN data IS NULL THEN 'NULL' ELSE data::VARCHAR END FROM test`,
-	)
+	res, err := sql.OpenDB(c).QueryContext(context.Background(), `SELECT CASE WHEN data IS NULL THEN 'NULL' ELSE data::VARCHAR END FROM test`)
 	require.NoError(t, err)
-	defer res.Close()
 
 	expected := []string{
 		"NULL",
@@ -963,44 +683,30 @@ func TestAppenderBlobTinyInt(t *testing.T) {
 	i := 0
 	for res.Next() {
 		var str string
-		err = res.Scan(
-			&str,
-		)
-		require.NoError(t, err)
+		require.NoError(t, res.Scan(&str))
 		require.Equal(t, expected[i], str)
 		i++
 	}
+
 	require.Equal(t, 4, i)
+	require.NoError(t, res.Close())
+	cleanupAppender(t, c, con, a)
 }
 
 func TestAppenderUint8SliceTinyInt(t *testing.T) {
-	connector, con, appender := prepareAppender(t, `
+	c, con, a := prepareAppender(t, `
 	CREATE TABLE test (
 		data UTINYINT[]
 	)`)
-	defer con.Close()
-	defer connector.Close()
 
-	err := appender.AppendRow(nil)
-	require.NoError(t, err)
-
-	err = appender.AppendRow([]uint8{0x01, 0x00, 0x03, 0x04, 8, 9, 7, 6, 5, 4, 3, 2, 1, 0})
-	require.NoError(t, err)
-
-	err = appender.AppendRow([]uint8{})
-	require.NoError(t, err)
-
-	err = appender.Close()
-	require.NoError(t, err)
+	require.NoError(t, a.AppendRow(nil))
+	require.NoError(t, a.AppendRow([]uint8{0x01, 0x00, 0x03, 0x04, 8, 9, 7, 6, 5, 4, 3, 2, 1, 0}))
+	require.NoError(t, a.AppendRow([]uint8{}))
+	require.NoError(t, a.Flush())
 
 	// Verify results.
-	db := sql.OpenDB(connector)
-	res, err := db.QueryContext(
-		context.Background(),
-		`SELECT CASE WHEN data IS NULL THEN 'NULL' ELSE data::VARCHAR END FROM test`,
-	)
+	res, err := sql.OpenDB(c).QueryContext(context.Background(), `SELECT CASE WHEN data IS NULL THEN 'NULL' ELSE data::VARCHAR END FROM test`)
 	require.NoError(t, err)
-	defer res.Close()
 
 	expected := []string{
 		"NULL",
@@ -1011,31 +717,12 @@ func TestAppenderUint8SliceTinyInt(t *testing.T) {
 	i := 0
 	for res.Next() {
 		var str string
-		err = res.Scan(
-			&str,
-		)
-		require.NoError(t, err)
+		require.NoError(t, res.Scan(&str))
 		require.Equal(t, expected[i], str)
 		i++
 	}
+
 	require.Equal(t, 3, i)
-}
-
-func TestAppenderUnsupportedType(t *testing.T) {
-	connector, err := NewConnector("", nil)
-	require.NoError(t, err)
-
-	// Create the table that we'll append to.
-	db := sql.OpenDB(connector)
-	_, err = db.Exec(`CREATE TABLE test AS SELECT MAP() AS m`)
-	require.NoError(t, err)
-
-	con, err := connector.Connect(context.Background())
-	require.NoError(t, err)
-
-	_, err = NewAppenderFromConn(con, "", "test")
-	require.ErrorContains(t, err, "does not support the column type of column 1: MAP")
-
-	con.Close()
-	connector.Close()
+	require.NoError(t, res.Close())
+	cleanupAppender(t, c, con, a)
 }

--- a/duckdb.go
+++ b/duckdb.go
@@ -64,7 +64,7 @@ func NewConnector(dsn string, connInitFn func(execer driver.ExecerContext) error
 	defer C.duckdb_free(unsafe.Pointer(outError))
 
 	if state := C.duckdb_open_ext(connStr, &db, config, &outError); state == C.DuckDBError {
-		return nil, getError(errOpen, getDuckDBError(outError))
+		return nil, getError(errOpen, duckdbError(outError))
 	}
 
 	return &Connector{

--- a/errors.go
+++ b/errors.go
@@ -13,16 +13,51 @@ func getError(errDriver error, err error) error {
 	return fmt.Errorf("%s: %w: %s", driverErrMsg, errDriver, err.Error())
 }
 
-func getDuckDBError(err *C.char) error {
-	return errors.New(C.GoString(err))
+func duckdbError(err *C.char) error {
+	return fmt.Errorf("%s: %w", duckdbErrMsg, errors.New(C.GoString(err)))
 }
 
-const driverErrMsg = "database/sql/driver"
+func castError(actual string, expected string) error {
+	return fmt.Errorf("%s: cannot cast %s to %s", castErrMsg, actual, expected)
+}
+
+func columnError(err error, colIdx int) error {
+	return fmt.Errorf("%w: %s: %d", err, columnErrMsg, colIdx)
+}
+
+func unsupportedTypeError(name string) error {
+	return fmt.Errorf("%s: %s", unsupportedTypeErrMsg, name)
+}
+
+func invalidatedAppenderError(err error) error {
+	if err == nil {
+		return fmt.Errorf(invalidatedAppenderMsg)
+	}
+	return fmt.Errorf("%w: %s", err, invalidatedAppenderMsg)
+}
+
+const (
+	driverErrMsg           = "database/sql/driver"
+	duckdbErrMsg           = "duckdb error"
+	castErrMsg             = "cast error"
+	columnErrMsg           = "column index"
+	unsupportedTypeErrMsg  = "unsupported data type"
+	invalidatedAppenderMsg = "appended data has been invalidated due to corrupt row"
+)
 
 var (
 	errParseDSN  = errors.New("could not parse DSN for database")
 	errOpen      = errors.New("could not open database")
 	errSetConfig = errors.New("could not set invalid or local option for global database config")
+
+	errAppenderInvalidCon       = errors.New("could not create appender: not a DuckDB driver connection")
+	errAppenderClosedCon        = errors.New("could not create appender: appender creation on a closed connection")
+	errAppenderCreation         = errors.New("could not create appender")
+	errAppenderDoubleClose      = errors.New("could not close appender: already closed")
+	errAppenderAppendRow        = errors.New("could not append row")
+	errAppenderAppendAfterClose = errors.New("could not append row: appender already closed")
+	errAppenderClose            = errors.New("could not close appender")
+	errAppenderFlush            = errors.New("could not flush appender")
 
 	// Errors not covered in tests.
 	errConnect      = errors.New("could not connect to database")

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,28 +1,249 @@
 package duckdb
 
 import (
+	"context"
 	"database/sql"
+	"database/sql/driver"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-var testErrOpenMap = map[string]string{
-	errParseDSN.Error():  ":mem ory:",
-	errOpen.Error():      "?readonly",
-	errSetConfig.Error(): "?threads=NaN",
+func testErrorInternal(t *testing.T, actual error, contains []string) {
+	for _, msg := range contains {
+		require.Contains(t, actual.Error(), msg)
+	}
+
+	levels := strings.Count(actual.Error(), driverErrMsg)
+	require.Equal(t, 1, levels)
+}
+
+func testError(t *testing.T, actual error, contains ...string) {
+	testErrorInternal(t, actual, contains)
 }
 
 func TestErrOpen(t *testing.T) {
-	for errMsg, dsn := range testErrOpenMap {
-		t.Run(errMsg, func(t *testing.T) {
-			_, err := sql.Open("duckdb", dsn)
-			require.Contains(t, err.Error(), errMsg)
-		})
-	}
+	t.Run(errParseDSN.Error(), func(t *testing.T) {
+		_, err := sql.Open("duckdb", ":mem ory:")
+		testError(t, err, errParseDSN.Error())
+	})
+
+	t.Run(errOpen.Error(), func(t *testing.T) {
+		_, err := sql.Open("duckdb", "?readonly")
+		testError(t, err, errOpen.Error(), duckdbErrMsg)
+	})
+
+	t.Run(errSetConfig.Error(), func(t *testing.T) {
+		_, err := sql.Open("duckdb", "?threads=NaN")
+		testError(t, err, errSetConfig.Error())
+	})
 
 	t.Run("local config option", func(t *testing.T) {
 		_, err := sql.Open("duckdb", "?schema=main")
-		require.Contains(t, err.Error(), errSetConfig.Error())
+		testError(t, err, errSetConfig.Error())
 	})
+}
+
+func TestErrAppender(t *testing.T) {
+	t.Run(errAppenderInvalidCon.Error(), func(t *testing.T) {
+		var con driver.Conn
+		_, err := NewAppenderFromConn(con, "", "test")
+		testError(t, err, errAppenderInvalidCon.Error())
+	})
+
+	t.Run(errAppenderClosedCon.Error(), func(t *testing.T) {
+		c, err := NewConnector("", nil)
+		require.NoError(t, err)
+
+		con, err := c.Connect(context.Background())
+		require.NoError(t, err)
+		require.NoError(t, con.Close())
+
+		_, err = NewAppenderFromConn(con, "", "test")
+		testError(t, err, errAppenderClosedCon.Error())
+		require.NoError(t, c.Close())
+	})
+
+	t.Run(errAppenderCreation.Error(), func(t *testing.T) {
+		c, err := NewConnector("", nil)
+		require.NoError(t, err)
+
+		con, err := c.Connect(context.Background())
+		require.NoError(t, err)
+
+		_, err = NewAppenderFromConn(con, "", "does_not_exist")
+		testError(t, err, errAppenderCreation.Error(), duckdbErrMsg)
+		require.NoError(t, con.Close())
+		require.NoError(t, c.Close())
+	})
+
+	t.Run(errAppenderDoubleClose.Error(), func(t *testing.T) {
+		c, err := NewConnector("", nil)
+		require.NoError(t, err)
+
+		_, err = sql.OpenDB(c).Exec(`CREATE TABLE tbl (i INTEGER)`)
+		require.NoError(t, err)
+
+		con, err := c.Connect(context.Background())
+		require.NoError(t, err)
+
+		a, err := NewAppenderFromConn(con, "", "tbl")
+		require.NoError(t, err)
+		cleanupAppender(t, c, con, a)
+
+		err = a.Close()
+		testError(t, err, errAppenderDoubleClose.Error())
+	})
+
+	t.Run(unsupportedTypeErrMsg, func(t *testing.T) {
+		c, err := NewConnector("", nil)
+		require.NoError(t, err)
+
+		_, err = sql.OpenDB(c).Exec(`CREATE TABLE test AS SELECT MAP() AS m`)
+		require.NoError(t, err)
+
+		con, err := c.Connect(context.Background())
+		require.NoError(t, err)
+
+		_, err = NewAppenderFromConn(con, "", "test")
+		testError(t, err, errAppenderCreation.Error(), unsupportedTypeErrMsg)
+
+		require.NoError(t, con.Close())
+		require.NoError(t, c.Close())
+	})
+
+	t.Run(errAppenderClose.Error(), func(t *testing.T) {
+		c, con, a := prepareAppender(t, `CREATE TABLE test (a VARCHAR, b VARCHAR)`)
+		require.NoError(t, a.AppendRow("hello"))
+		err := a.Close()
+
+		testError(t, err, errAppenderClose.Error(), duckdbErrMsg, invalidatedAppenderMsg)
+		require.NoError(t, con.Close())
+		require.NoError(t, c.Close())
+	})
+
+	t.Run(errAppenderFlush.Error(), func(t *testing.T) {
+		c, con, a := prepareAppender(t, `CREATE TABLE test (a VARCHAR, b VARCHAR)`)
+		require.NoError(t, a.AppendRow("hello"))
+		err := a.Flush()
+
+		testError(t, err, errAppenderFlush.Error(), duckdbErrMsg, invalidatedAppenderMsg)
+		cleanupAppender(t, c, con, a)
+	})
+
+	t.Run(errAppenderAppendAfterClose.Error(), func(t *testing.T) {
+		c, con, a := prepareAppender(t, `CREATE TABLE test (str VARCHAR)`)
+		require.NoError(t, a.Close())
+		err := a.AppendRow("hello")
+		testError(t, err, errAppenderAppendAfterClose.Error())
+		require.NoError(t, con.Close())
+		require.NoError(t, c.Close())
+	})
+}
+
+func TestErrAppend(t *testing.T) {
+	c, con, a := prepareAppender(t, `CREATE TABLE test (id BIGINT, str VARCHAR)`)
+
+	err := a.AppendRow("hello", "world")
+	testError(t, err, errAppenderAppendRow.Error(), castErrMsg)
+	err = a.AppendRow(false, 42)
+	testError(t, err, errAppenderAppendRow.Error(), castErrMsg)
+
+	cleanupAppender(t, c, con, a)
+}
+
+func TestErrAppendSimpleStruct(t *testing.T) {
+	c, con, a := prepareAppender(t, `
+		CREATE TABLE test (
+			simple_struct STRUCT(A INT, B VARCHAR)
+		)`)
+
+	err := a.AppendRow(1)
+	testError(t, err, errAppenderAppendRow.Error(), castErrMsg)
+	err = a.AppendRow("hello")
+	testError(t, err, errAppenderAppendRow.Error(), castErrMsg)
+
+	type other struct {
+		S string
+		I int
+	}
+	err = a.AppendRow(other{"hello", 1})
+	testError(t, err, errAppenderAppendRow.Error(), castErrMsg)
+
+	err = a.AppendRow(
+		wrappedSimpleStruct{
+			"hello there",
+			simpleStruct{A: 0, B: "one billion ducks"},
+		},
+	)
+	testError(t, err, errAppenderAppendRow.Error(), castErrMsg)
+
+	err = a.AppendRow(
+		wrappedStruct{
+			"hello there",
+			simpleStruct{A: 0, B: "one billion ducks"},
+		},
+	)
+	testError(t, err, errAppenderAppendRow.Error(), castErrMsg)
+
+	cleanupAppender(t, c, con, a)
+}
+
+func TestErrAppendStruct(t *testing.T) {
+	c, con, a := prepareAppender(t, `
+		CREATE TABLE test (
+			mix STRUCT(A STRUCT(L VARCHAR[]), B STRUCT(L INT[])[])
+		)`)
+
+	err := a.AppendRow(simpleStruct{1, "hello"})
+	testError(t, err, errAppenderAppendRow.Error(), castErrMsg)
+	cleanupAppender(t, c, con, a)
+}
+
+func TestErrAppendList(t *testing.T) {
+	c, con, a := prepareAppender(t, `CREATE TABLE test(intSlice INT[])`)
+
+	err := a.AppendRow([]string{"foo", "bar", "baz"})
+	testError(t, err, errAppenderAppendRow.Error(), castErrMsg)
+	err = a.AppendRow([][]int32{{1, 2, 3}, {4, 5, 6}})
+	testError(t, err, errAppenderAppendRow.Error(), castErrMsg)
+
+	cleanupAppender(t, c, con, a)
+}
+
+func TestErrAppendStructWithList(t *testing.T) {
+	c, con, a := prepareAppender(t, `CREATE TABLE test (struct_with_list STRUCT(L INT[]))`)
+
+	err := a.AppendRow([]int32{1, 2, 3})
+	testError(t, err, errAppenderAppendRow.Error(), castErrMsg)
+	l := struct{ L []string }{L: []string{"a", "b", "c"}}
+	testError(t, a.AppendRow(l), errAppenderAppendRow.Error(), castErrMsg)
+
+	cleanupAppender(t, c, con, a)
+}
+
+func TestErrAppendNestedStruct(t *testing.T) {
+	c, con, a := prepareAppender(t, `
+		CREATE TABLE test (
+			wrapped_simple_struct STRUCT(A VARCHAR, B STRUCT(A INT, B VARCHAR)),
+		)`)
+
+	err := a.AppendRow(simpleStruct{1, "hello"})
+	testError(t, err, errAppenderAppendRow.Error(), castErrMsg)
+
+	cleanupAppender(t, c, con, a)
+}
+
+func TestErrAppendNestedList(t *testing.T) {
+	c, con, a := prepareAppender(t, `CREATE TABLE test(int_slice INT[][][])`)
+
+	err := a.AppendRow([]int32{1, 2, 3})
+	testError(t, err, errAppenderAppendRow.Error(), castErrMsg)
+	err = a.AppendRow(1)
+	testError(t, err, errAppenderAppendRow.Error(), castErrMsg)
+	err = a.AppendRow([][]int32{{1, 2, 3}, {4, 5, 6}})
+	testError(t, err, errAppenderAppendRow.Error(), castErrMsg)
+
+	cleanupAppender(t, c, con, a)
 }


### PR DESCRIPTION
This is the first follow-up PR to https://github.com/marcboeker/go-duckdb/pull/187.

It focuses on unifying the error handling in the `Appender`. Additionally, errors in the `Appender` no longer kill the application (`panic`) and have a unified format.

I'm happy that even with the introduction of new tests, this PR decreases the overall code size of the `Appender` and its tests. 😄 Sorry for the big PR - I've tried to keep the complexity low. Many changes are repetitive (using new functions) and structural.

### Other changes
- unified variable name refactoring according to their type definitions and methods (e.g., `connector -> c`, `appender -> a`, `appender *C.duckdb_appender -> duckdbAppender C.duckdb_appender`).
- added missing `C.duckdb_appender_destroy(&duckdbAppender)` when the appender's column type initialization fails to avoid leaks.
- removed duplicate code in `appender_test.go` by introducing a new function: `cleanupAppender`.
- moved error-tests from `appender_test.go` to `errors_test.go`.