### PR TITLE
Use build tags for Arrow implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ examples:
 
 .PHONY: test
 test:
-	go test -v -race -count=1 -tags="duckdb_arrow" .
+	go test -v -race -count=1 .
 
 .PHONY: deps.header
 deps.header:

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ examples:
 
 .PHONY: test
 test:
-	go test -v -race -count=1 .
+	go test -v -race -count=1 -tags="duckdb_arrow" .
 
 .PHONY: deps.header
 deps.header:

--- a/README.md
+++ b/README.md
@@ -131,13 +131,7 @@ if err != nil {
 
 ## DuckDB Apache Arrow Interface
 
-To use the [DuckDB Arrow Interface](https://duckdb.org/docs/api/c/api#arrow-interface), you need to build your binary with the `duckdb_arrow` build tag.
-
-```sh
-go build -tags="duckdb_arrow"
-```
-
-Then, you can obtain a new `Arrow` by passing a DuckDB connection to `NewArrowFromConn()`.
+If you want to use the [DuckDB Arrow Interface](https://duckdb.org/docs/api/c/api#arrow-interface), you can obtain a new `Arrow` by passing a DuckDB connection to `NewArrowFromConn()`.
 
 ```go
 connector, err := duckdb.NewConnector("", nil)
@@ -167,6 +161,12 @@ defer rdr.Release()
 for rdr.Next() {
   // process records
 }
+```
+
+The Arrow interface is a heavy dependency. If you do not need it, you can disable it by passing `-tags=no_duckdb_arrow` to `go build`. This will be made opt-in in V2.
+
+```sh
+go build -tags="no_duckdb_arrow"
 ```
 
 ## Vendoring

--- a/README.md
+++ b/README.md
@@ -131,7 +131,13 @@ if err != nil {
 
 ## DuckDB Apache Arrow Interface
 
-If you want to use the [DuckDB Arrow Interface](https://duckdb.org/docs/api/c/api#arrow-interface), you can obtain a new `Arrow` by passing a DuckDB connection to `NewArrowFromConn()`.
+To use the [DuckDB Arrow Interface](https://duckdb.org/docs/api/c/api#arrow-interface), you need to build your binary with the `duckdb_arrow` build tag.
+
+```sh
+go build -tags="duckdb_arrow"
+```
+
+Then, you can obtain a new `Arrow` by passing a DuckDB connection to `NewArrowFromConn()`.
 
 ```go
 connector, err := duckdb.NewConnector("", nil)

--- a/arrow.go
+++ b/arrow.go
@@ -1,3 +1,5 @@
+//go:build duckdb_arrow
+
 package duckdb
 
 /*

--- a/arrow.go
+++ b/arrow.go
@@ -1,4 +1,4 @@
-//go:build duckdb_arrow
+//go:build !no_duckdb_arrow
 
 package duckdb
 

--- a/arrow_test.go
+++ b/arrow_test.go
@@ -1,3 +1,5 @@
+//go:build duckdb_arrow
+
 package duckdb
 
 import (

--- a/arrow_test.go
+++ b/arrow_test.go
@@ -1,4 +1,4 @@
-//go:build duckdb_arrow
+//go:build !no_duckdb_arrow
 
 package duckdb
 


### PR DESCRIPTION
Closes #204.

I tested the build flags on my project and saw around ~2MB shaved off the final binary, which is a solid success. Including the `duckdb_arrow` build tag reverted it back to the old size, so it seems that the tag is working.

I'm not too sure what the breaking change policy is for this library, so I'm happy to make appropriate changes. However, I strongly believe features like this should be opt-in, rather than opt-out.