### PR TITLE
Replacement scan

### DIFF
--- a/replacement_scan.go
+++ b/replacement_scan.go
@@ -17,18 +17,19 @@ type ReplacementScanCallback func(tableName string) (string, []any, error)
 
 func RegisterReplacementScan(connector *Connector, cb ReplacementScanCallback) {
 	handle := cgo.NewHandle(cb)
-	C.duckdb_add_replacement_scan(connector.db, C.duckdb_replacement_callback_t(C.replacement_scan_cb), unsafe.Pointer(handle), C.duckdb_delete_callback_t(C.replacement_scan_destroy_data))
+	C.duckdb_add_replacement_scan(connector.db, C.duckdb_replacement_callback_t(C.replacement_scan_cb), unsafe.Pointer(&handle), C.duckdb_delete_callback_t(C.replacement_scan_destroy_data))
 }
 
 //export replacement_scan_destroy_data
 func replacement_scan_destroy_data(data unsafe.Pointer) {
-	h := cgo.Handle(data)
+	h := *(*cgo.Handle)(data)
 	h.Delete()
 }
 
 //export replacement_scan_cb
 func replacement_scan_cb(info C.duckdb_replacement_scan_info, table_name *C.cchar_t, data *C.void) {
-	scanner := cgo.Handle(unsafe.Pointer(data)).Value().(ReplacementScanCallback)
+	h := *(*cgo.Handle)(unsafe.Pointer(data))
+	scanner := h.Value().(ReplacementScanCallback)
 	tFunc, params, err := scanner(C.GoString(table_name))
 	if err != nil {
 		errstr := C.CString(err.Error())

--- a/replacement_scan.go
+++ b/replacement_scan.go
@@ -19,12 +19,11 @@ var replacementScanState struct {
 	callback ReplacementScanCallback
 }
 
-func RegisterReplacementScan(connector *Connector, cb ReplacementScanCallback) error {
+func RegisterReplacementScan(connector *Connector, cb ReplacementScanCallback) {
 	replacementScanState.mtx.Lock()
 	replacementScanState.callback = cb
 	replacementScanState.mtx.Unlock()
 	C.duckdb_add_replacement_scan(connector.db, C.duckdb_replacement_callback_t(C.replacement_scan_cb), nil, C.duckdb_delete_callback_t(C.free))
-	return nil
 }
 
 //export replacement_scan_cb

--- a/replacement_scan.go
+++ b/replacement_scan.go
@@ -8,29 +8,23 @@ package duckdb
 */
 import "C"
 import (
-	"sync"
 	"unsafe"
 )
 
 type ReplacementScanCallback func(tableName string) (string, []any, error)
 
 var replacementScanState struct {
-	mtx      sync.Mutex
 	callback ReplacementScanCallback
 }
 
 func RegisterReplacementScan(connector *Connector, cb ReplacementScanCallback) {
-	replacementScanState.mtx.Lock()
 	replacementScanState.callback = cb
-	replacementScanState.mtx.Unlock()
 	C.duckdb_add_replacement_scan(connector.db, C.duckdb_replacement_callback_t(C.replacement_scan_cb), nil, C.duckdb_delete_callback_t(C.free))
 }
 
 //export replacement_scan_cb
 func replacement_scan_cb(info C.duckdb_replacement_scan_info, table_name *C.cchar_t, data *C.void) {
-	replacementScanState.mtx.Lock()
 	scanner := replacementScanState.callback
-	replacementScanState.mtx.Unlock()
 
 	tFunc, params, err := scanner(C.GoString(table_name))
 	if err != nil {
@@ -51,7 +45,7 @@ func replacement_scan_cb(info C.duckdb_replacement_scan_info, table_name *C.ccha
 			val := C.duckdb_create_varchar(str)
 			C.duckdb_replacement_scan_add_parameter(info, val)
 			C.free(unsafe.Pointer(str))
-			C.free(unsafe.Pointer(val))
+			C.duckdb_destroy_value(&val)
 		case int64:
 			val := C.duckdb_create_int64(C.int64_t(x))
 			C.duckdb_replacement_scan_add_parameter(info, val)

--- a/replacement_scan.go
+++ b/replacement_scan.go
@@ -1,0 +1,65 @@
+package duckdb
+
+/*
+   #include <stdlib.h>
+   #include <duckdb.h>
+   void replacement_scan_cb(duckdb_replacement_scan_info info, const char *table_name, void *data);
+   typedef const char cchar_t;
+*/
+import "C"
+import (
+	"sync"
+	"unsafe"
+)
+
+type ReplacementScanCallback func(tableName string) (string, []any, error)
+
+var replacementScanFnMxt sync.Mutex
+var replacementScanCallback ReplacementScanCallback
+
+func RegisterReplacementScan(connector *Connector, cb ReplacementScanCallback) error {
+	replacementScanFnMxt.Lock()
+	replacementScanCallback = cb
+	replacementScanFnMxt.Unlock()
+	C.duckdb_add_replacement_scan(connector.db, C.duckdb_replacement_callback_t(C.replacement_scan_cb), nil, C.duckdb_delete_callback_t(C.free))
+	return nil
+}
+
+//export replacement_scan_cb
+func replacement_scan_cb(info C.duckdb_replacement_scan_info, table_name *C.cchar_t, data *C.void) {
+	replacementScanFnMxt.Lock()
+	scanner := replacementScanCallback
+	replacementScanFnMxt.Unlock()
+
+	tFunc, params, err := scanner(C.GoString(table_name))
+	if err != nil {
+		errstr := C.CString(err.Error())
+		C.duckdb_replacement_scan_set_error(info, errstr)
+		C.free(unsafe.Pointer(errstr))
+		return
+	}
+
+	fNameStr := C.CString(tFunc)
+	C.duckdb_replacement_scan_set_function_name(info, fNameStr)
+	defer C.free(unsafe.Pointer(fNameStr))
+
+	for _, v := range params {
+		switch x := v.(type) {
+		case string:
+			str := C.CString(x)
+			val := C.duckdb_create_varchar(str)
+			C.duckdb_replacement_scan_add_parameter(info, val)
+			C.free(unsafe.Pointer(str))
+			C.free(unsafe.Pointer(val))
+		case int64:
+			val := C.duckdb_create_int64(C.int64_t(x))
+			C.duckdb_replacement_scan_add_parameter(info, val)
+			C.duckdb_destroy_value(&val)
+		default:
+			errstr := C.CString("invalid type")
+			C.duckdb_replacement_scan_set_error(info, errstr)
+			C.free(unsafe.Pointer(errstr))
+			return
+		}
+	}
+}

--- a/replacement_scan_test.go
+++ b/replacement_scan_test.go
@@ -13,9 +13,7 @@ func TestReplacementScan(t *testing.T) {
 		return nil
 	})
 
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer connector.Close()
 
 	var rangeRows = 100
@@ -24,11 +22,8 @@ func TestReplacementScan(t *testing.T) {
 	})
 
 	db := sql.OpenDB(connector)
-
 	rows, err := db.Query("select * from any_table")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer rows.Close()
 
 	for i := 0; rows.Next(); i++ {

--- a/replacement_scan_test.go
+++ b/replacement_scan_test.go
@@ -19,7 +19,7 @@ func TestReplacementScan(t *testing.T) {
 	defer connector.Close()
 
 	var rangeRows = 3
-	_ = RegisterReplacementScan(connector, func(tableName string) (string, []any, error) {
+	RegisterReplacementScan(connector, func(tableName string) (string, []any, error) {
 		return "range", []any{int64(rangeRows)}, nil
 	})
 

--- a/replacement_scan_test.go
+++ b/replacement_scan_test.go
@@ -3,6 +3,7 @@ package duckdb
 import (
 	"database/sql"
 	"database/sql/driver"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
@@ -34,7 +35,7 @@ func TestReplacementScan(t *testing.T) {
 		rangeRows--
 	}
 	if rows.Err() != nil {
-		t.Fatal(rows.Err())
+		require.NoError(t, rows.Err())
 	}
 
 	if rangeRows != 0 {

--- a/replacement_scan_test.go
+++ b/replacement_scan_test.go
@@ -18,7 +18,7 @@ func TestReplacementScan(t *testing.T) {
 	}
 	defer connector.Close()
 
-	var rangeRows = 3
+	var rangeRows = 100
 	RegisterReplacementScan(connector, func(tableName string) (string, []any, error) {
 		return "range", []any{int64(rangeRows)}, nil
 	})
@@ -31,15 +31,19 @@ func TestReplacementScan(t *testing.T) {
 	}
 	defer rows.Close()
 
-	for rows.Next() {
+	for i := 0; rows.Next(); i++ {
+		var val int
+		require.NoError(t, rows.Scan(&val))
+		if val != i {
+			require.Fail(t, "expected %d, got %d", i, val)
+		}
 		rangeRows--
 	}
 	if rows.Err() != nil {
 		require.NoError(t, rows.Err())
 	}
-
 	if rangeRows != 0 {
-		t.Fatalf("expected 0 rows, got %d", rangeRows)
+		require.Fail(t, "expected 0, got %d", rangeRows)
 	}
 
 }

--- a/replacement_scan_test.go
+++ b/replacement_scan_test.go
@@ -11,11 +11,11 @@ func TestReplacementScan(t *testing.T) {
 	connector, err := NewConnector("", func(execer driver.ExecerContext) error {
 		return nil
 	})
-	defer connector.Close()
 
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer connector.Close()
 
 	var rangeRows = 3
 	_ = RegisterReplacementScan(connector, func(tableName string) (string, []any, error) {
@@ -35,7 +35,9 @@ func TestReplacementScan(t *testing.T) {
 	}
 	if rows.Err() != nil {
 		t.Fatal(rows.Err())
-	} else if rangeRows != 0 {
+	}
+
+	if rangeRows != 0 {
 		t.Fatalf("expected 0 rows, got %d", rangeRows)
 	}
 


### PR DESCRIPTION
Simple implementation of replacement scan API in duckdb. 

Registers a callback function that gets called when a query refer to a table that not exists in duckdb as per https://duckdb.org/docs/api/c/replacement_scans.

Currently limited to supporting int64 and string as table function arguments, but this seems like a limitation in duckdb C API. 