### PR TITLE
Return constraint violation error in the appender

### DIFF
--- a/appender.go
+++ b/appender.go
@@ -103,10 +103,11 @@ func (a *Appender) Flush() error {
 		return getError(errAppenderFlush, invalidatedAppenderError(err))
 	}
 
-	if state := C.duckdb_appender_flush(a.duckdbAppender); state == C.DuckDBError {
-		return getError(errAppenderFlush, invalidatedAppenderError(nil))
+	state := C.duckdb_appender_flush(a.duckdbAppender)
+	if state == C.DuckDBError {
+		err := duckdbError(C.duckdb_appender_error(a.duckdbAppender))
+		return getError(errAppenderFlush, invalidatedAppenderError(err))
 	}
-
 	return nil
 }
 
@@ -128,6 +129,7 @@ func (a *Appender) Close() error {
 	state := C.duckdb_appender_destroy(&a.duckdbAppender)
 
 	if err != nil || state == C.DuckDBError {
+		// We destroyed the appender, so we cannot retrieve the duckdb error.
 		return getError(errAppenderClose, invalidatedAppenderError(err))
 	}
 	return nil

--- a/errors.go
+++ b/errors.go
@@ -68,10 +68,8 @@ var (
 	errAppenderDoubleClose      = errors.New("could not close appender: already closed")
 	errAppenderAppendRow        = errors.New("could not append row")
 	errAppenderAppendAfterClose = errors.New("could not append row: appender already closed")
-	// FIXME: not covered by tests. Should be triggered by appending a constraint violation, see #210.
-	errAppenderClose = errors.New("could not close appender")
-	// FIXME: not covered by tests. Should be triggered by appending a constraint violation, see #210.
-	errAppenderFlush = errors.New("could not flush appender")
+	errAppenderClose            = errors.New("could not close appender")
+	errAppenderFlush            = errors.New("could not flush appender")
 
 	// Errors not covered in tests.
 	errConnect      = errors.New("could not connect to database")

--- a/errors_test.go
+++ b/errors_test.go
@@ -128,6 +128,28 @@ func TestErrAppender(t *testing.T) {
 		require.NoError(t, con.Close())
 		require.NoError(t, c.Close())
 	})
+
+	t.Run(errAppenderFlush.Error(), func(t *testing.T) {
+		c, con, a := prepareAppender(t, `CREATE TABLE test (c1 INTEGER PRIMARY KEY)`)
+		require.NoError(t, a.AppendRow(int32(1)))
+		require.NoError(t, a.AppendRow(int32(1)))
+		err := a.Flush()
+		testError(t, err, errAppenderFlush.Error())
+		err = a.Close()
+		testError(t, err, errAppenderClose.Error())
+		require.NoError(t, con.Close())
+		require.NoError(t, c.Close())
+	})
+
+	t.Run(errAppenderClose.Error(), func(t *testing.T) {
+		c, con, a := prepareAppender(t, `CREATE TABLE test (c1 INTEGER PRIMARY KEY)`)
+		require.NoError(t, a.AppendRow(int32(1)))
+		require.NoError(t, a.AppendRow(int32(1)))
+		err := a.Close()
+		testError(t, err, errAppenderClose.Error())
+		require.NoError(t, con.Close())
+		require.NoError(t, c.Close())
+	})
 }
 
 func TestErrAppend(t *testing.T) {


### PR DESCRIPTION
- add tests to cover constraint violations in `Flush` and `Close`
- ensure that we also return the duckdb error

Fixes #210.