### PR TITLE
Initial DataChunk API support

### DIFF
--- a/appender.go
+++ b/appender.go
@@ -139,7 +139,7 @@ func (a *Appender) AppendRow(args ...driver.Value) error {
 
 func (a *Appender) addDataChunk() error {
 	var chunk DataChunk
-	if err := chunk.InitFromTypes(a.ptr, a.types); err != nil {
+	if err := chunk.initFromTypes(a.ptr, a.types); err != nil {
 		return err
 	}
 	a.chunks = append(a.chunks, chunk)
@@ -177,7 +177,7 @@ func (a *Appender) appendDataChunks() error {
 	var err error
 
 	for _, chunk := range a.chunks {
-		if err = chunk.SetSize(); err != nil {
+		if err = chunk.setSize(); err != nil {
 			break
 		}
 		state = C.duckdb_append_data_chunk(a.duckdbAppender, chunk.data)
@@ -187,14 +187,14 @@ func (a *Appender) appendDataChunks() error {
 		}
 	}
 
-	a.destroyDataChunks()
+	a.closeDataChunks()
 	a.rowCount = 0
 	return err
 }
 
-func (a *Appender) destroyDataChunks() {
+func (a *Appender) closeDataChunks() {
 	for _, chunk := range a.chunks {
-		chunk.Destroy()
+		chunk.close()
 	}
 	a.chunks = a.chunks[:0]
 }

--- a/appender.go
+++ b/appender.go
@@ -19,13 +19,14 @@ type Appender struct {
 	duckdbAppender C.duckdb_appender
 	closed         bool
 
-	chunks      []C.duckdb_data_chunk
-	currSize    C.idx_t
-	colTypes    []C.duckdb_logical_type
-	colTypesPtr unsafe.Pointer
-
-	// The vector storage of each column in the data chunk.
-	vectors []vector
+	// The appender storage before flushing any data.
+	chunks []DataChunk
+	// The column types of the table to append to.
+	types []C.duckdb_logical_type
+	// A pointer to the allocated memory of the column types.
+	ptr unsafe.Pointer
+	// The number of appended rows.
+	rowCount int
 }
 
 // NewAppenderFromConn returns a new Appender from a DuckDB driver connection.
@@ -62,29 +63,24 @@ func NewAppenderFromConn(driverConn driver.Conn, schema, table string) (*Appende
 		schema:         schema,
 		table:          table,
 		duckdbAppender: duckdbAppender,
-		currSize:       0,
+		rowCount:       0,
 	}
-
-	columnCount := int(C.duckdb_appender_column_count(duckdbAppender))
-	a.colTypesPtr, a.colTypes = a.mallocTypeSlice(columnCount)
 
 	// Get the column types.
+	columnCount := int(C.duckdb_appender_column_count(duckdbAppender))
+	a.ptr, a.types = mallocTypeSlice(columnCount)
 	for i := 0; i < columnCount; i++ {
-		a.colTypes[i] = C.duckdb_appender_column_type(duckdbAppender, C.idx_t(i))
-	}
+		a.types[i] = C.duckdb_appender_column_type(duckdbAppender, C.idx_t(i))
 
-	// Get the vector storage of each column.
-	a.vectors = make([]vector, columnCount)
-	var err error
-	for i := 0; i < columnCount; i++ {
-		if err = a.vectors[i].init(a.colTypes[i], i); err != nil {
-			break
+		// Ensure that we only create an appender for supported column types.
+		duckdbType := C.duckdb_get_type_id(a.types[i])
+		name, found := unsupportedAppenderTypeMap[duckdbType]
+		if found {
+			err := columnError(unsupportedTypeError(name), i+1)
+			destroyTypeSlice(a.ptr, a.types)
+			C.duckdb_appender_destroy(&duckdbAppender)
+			return nil, getError(errAppenderCreation, err)
 		}
-	}
-	if err != nil {
-		a.destroyColumnTypes()
-		C.duckdb_appender_destroy(&duckdbAppender)
-		return nil, getError(errAppenderCreation, err)
 	}
 
 	return a, nil
@@ -94,11 +90,6 @@ func NewAppenderFromConn(driverConn driver.Conn, schema, table string) (*Appende
 // Does not close the appender, even if it returns an error. Unless you have a good reason to call this,
 // call Close when you are done with the appender.
 func (a *Appender) Flush() error {
-	// Nothing to flush.
-	if len(a.chunks) == 0 && a.currSize == 0 {
-		return nil
-	}
-
 	if err := a.appendDataChunks(); err != nil {
 		return getError(errAppenderFlush, invalidatedAppenderError(err))
 	}
@@ -120,16 +111,14 @@ func (a *Appender) Close() error {
 	a.closed = true
 
 	// Append all remaining chunks.
-	var err error
-	if len(a.chunks) != 0 || a.currSize != 0 {
-		err = a.appendDataChunks()
-	}
+	err := a.appendDataChunks()
 
-	a.destroyColumnTypes()
+	// Destroy all appender data.
+	destroyTypeSlice(a.ptr, a.types)
 	state := C.duckdb_appender_destroy(&a.duckdbAppender)
 
 	if err != nil || state == C.DuckDBError {
-		// We destroyed the appender, so we cannot retrieve the duckdb error.
+		// We destroyed the appender, so we cannot retrieve the duckdb internal error.
 		return getError(errAppenderClose, invalidatedAppenderError(err))
 	}
 	return nil
@@ -148,92 +137,64 @@ func (a *Appender) AppendRow(args ...driver.Value) error {
 	return nil
 }
 
-func (a *Appender) destroyColumnTypes() {
-	for i := range a.colTypes {
-		C.duckdb_destroy_logical_type(&a.colTypes[i])
+func (a *Appender) addDataChunk() error {
+	var chunk DataChunk
+	if err := chunk.InitFromTypes(a.ptr, a.types); err != nil {
+		return err
 	}
-	C.free(a.colTypesPtr)
-}
-
-func (*Appender) mallocTypeSlice(count int) (unsafe.Pointer, []C.duckdb_logical_type) {
-	var dummy C.duckdb_logical_type
-	size := C.size_t(unsafe.Sizeof(dummy))
-
-	ctPtr := unsafe.Pointer(C.malloc(C.size_t(count) * size))
-	slice := (*[1 << 30]C.duckdb_logical_type)(ctPtr)[:count:count]
-
-	return ctPtr, slice
-}
-
-func (a *Appender) newDataChunk(colCount int) {
-	a.currSize = 0
-
-	// duckdb_create_data_chunk takes an array of duckdb_logical_type and a column count.
-	colTypesPtr := (*C.duckdb_logical_type)(a.colTypesPtr)
-	dataChunk := C.duckdb_create_data_chunk(colTypesPtr, C.idx_t(colCount))
-	C.duckdb_data_chunk_set_size(dataChunk, C.duckdb_vector_size())
-
-	for i := 0; i < colCount; i++ {
-		duckdbVector := C.duckdb_data_chunk_get_vector(dataChunk, C.idx_t(i))
-		a.vectors[i].duckdbVector = duckdbVector
-		a.vectors[i].getChildVectors(duckdbVector)
-	}
-
-	a.chunks = append(a.chunks, dataChunk)
+	a.chunks = append(a.chunks, chunk)
+	return nil
 }
 
 func (a *Appender) appendRowSlice(args []driver.Value) error {
-	// early-out, if the number of args does not match the column count
-	if len(args) != len(a.vectors) {
-		return columnCountError(len(args), len(a.vectors))
+	// Early-out, if the number of args does not match the column count.
+	if len(args) != len(a.types) {
+		return columnCountError(len(args), len(a.types))
 	}
 
-	// Create a new data chunk if the current chunk is full, or if this is the first row.
-	if a.currSize == C.duckdb_vector_size() || len(a.chunks) == 0 {
-		a.newDataChunk(len(args))
-	}
-
-	for i, val := range args {
-		vec := a.vectors[i]
-
-		// Ensure that the types match before attempting to append anything.
-		v, err := vec.tryCast(val)
-		if err != nil {
-			// Use 1-based indexing for readability, as we're talking about columns.
-			return columnError(err, i+1)
+	// Create a new data chunk if the current chunk is full.
+	if C.idx_t(a.rowCount) == C.duckdb_vector_size() || len(a.chunks) == 0 {
+		if err := a.addDataChunk(); err != nil {
+			return err
 		}
-
-		// Append the row to the data chunk.
-		vec.fn(&vec, a.currSize, v)
 	}
 
-	a.currSize++
+	// Set all values.
+	for i, val := range args {
+		chunk := &a.chunks[len(a.chunks)-1]
+		err := chunk.SetValue(i, a.rowCount, val)
+		if err != nil {
+			return err
+		}
+	}
+
+	a.rowCount++
 	return nil
 }
 
 func (a *Appender) appendDataChunks() error {
-	// Set the size of the current chunk to the current row count.
-	C.duckdb_data_chunk_set_size(a.chunks[len(a.chunks)-1], C.idx_t(a.currSize))
-
-	// Append all chunks to the appender and destroy them.
 	var state C.duckdb_state
 	var err error
 
 	for _, chunk := range a.chunks {
-		state = C.duckdb_append_data_chunk(a.duckdbAppender, chunk)
+		if err = chunk.SetSize(); err != nil {
+			break
+		}
+		state = C.duckdb_append_data_chunk(a.duckdbAppender, chunk.data)
 		if state == C.DuckDBError {
 			err = duckdbError(C.duckdb_appender_error(a.duckdbAppender))
 			break
 		}
 	}
+
 	a.destroyDataChunks()
+	a.rowCount = 0
 	return err
 }
 
 func (a *Appender) destroyDataChunks() {
 	for _, chunk := range a.chunks {
-		C.duckdb_destroy_data_chunk(&chunk)
+		chunk.Destroy()
 	}
-	a.currSize = 0
 	a.chunks = a.chunks[:0]
 }

--- a/data_chunk.go
+++ b/data_chunk.go
@@ -1,0 +1,104 @@
+package duckdb
+
+/*
+#include <stdlib.h>
+#include <duckdb.h>
+*/
+import "C"
+
+import (
+	"unsafe"
+)
+
+// DataChunk storage of a DuckDB table.
+type DataChunk struct {
+	// data holds the underlying duckdb data chunk.
+	data C.duckdb_data_chunk
+	// columns is a helper slice providing direct access to all columns.
+	columns []vector
+	// columnNames holds the column names, if known.
+	columnNames []string
+}
+
+// InitFromTypes initializes a data chunk by providing its column types.
+func (chunk *DataChunk) InitFromTypes(ptr unsafe.Pointer, types []C.duckdb_logical_type) error {
+	columnCount := len(types)
+
+	// Initialize the callback functions to read and write values.
+	chunk.columns = make([]vector, columnCount)
+	var err error
+	for i := 0; i < columnCount; i++ {
+		if err = chunk.columns[i].init(types[i], i); err != nil {
+			break
+		}
+	}
+	if err != nil {
+		return err
+	}
+
+	logicalTypesPtr := (*C.duckdb_logical_type)(ptr)
+	chunk.data = C.duckdb_create_data_chunk(logicalTypesPtr, C.idx_t(columnCount))
+	C.duckdb_data_chunk_set_size(chunk.data, C.duckdb_vector_size())
+
+	// Initialize the vectors and their child vectors.
+	for i := 0; i < columnCount; i++ {
+		duckdbVector := C.duckdb_data_chunk_get_vector(chunk.data, C.idx_t(i))
+		chunk.columns[i].duckdbVector = duckdbVector
+		chunk.columns[i].getChildVectors(duckdbVector)
+	}
+	return nil
+}
+
+// Destroy the memory of a data chunk. This is crucial to avoid leaks.
+func (chunk *DataChunk) Destroy() {
+	C.duckdb_destroy_data_chunk(&chunk.data)
+}
+
+// SetSize sets the internal size of the data chunk. This fails if columns have different sizes.
+func (chunk *DataChunk) SetSize() error {
+	if len(chunk.columns) == 0 {
+		C.duckdb_data_chunk_set_size(chunk.data, C.idx_t(0))
+		return nil
+	}
+
+	allEqual := true
+	maxSize := C.idx_t(chunk.columns[0].size)
+	for i := 0; i < len(chunk.columns); i++ {
+		if chunk.columns[i].size != maxSize {
+			allEqual = false
+		}
+		if chunk.columns[i].size > maxSize {
+			maxSize = chunk.columns[i].size
+		}
+	}
+
+	if !allEqual {
+		return errDriver
+	}
+	C.duckdb_data_chunk_set_size(chunk.data, maxSize)
+	return nil
+}
+
+// GetSize returns the internal size of the data chunk.
+func (chunk *DataChunk) GetSize() int {
+	return int(C.duckdb_data_chunk_get_size(chunk.data))
+}
+
+// SetValue writes a single value to a column. Note that this requires casting the type for
+// each invocation. Try to use the columnar function SetColumn for performance.
+func (chunk *DataChunk) SetValue(colIdx int, rowIdx int, val any) error {
+	if colIdx >= len(chunk.columns) {
+		return errDriver
+	}
+	column := &chunk.columns[colIdx]
+
+	// Ensure that the types match before attempting to set anything.
+	v, err := column.tryCast(val)
+	if err != nil {
+		return columnError(err, colIdx)
+	}
+
+	// Set the value.
+	column.setFn(column, C.idx_t(rowIdx), v)
+	return nil
+}

--- a/data_chunk.go
+++ b/data_chunk.go
@@ -21,7 +21,7 @@ type DataChunk struct {
 // SetValue writes a single value to a column in a data chunk. Note that this requires casting the type for each invocation.
 func (chunk *DataChunk) SetValue(colIdx int, rowIdx int, val any) error {
 	if colIdx >= len(chunk.columns) {
-		return errDriver
+		return getError(errAPI, columnCountError(colIdx, len(chunk.columns)))
 	}
 	column := &chunk.columns[colIdx]
 

--- a/data_chunk.go
+++ b/data_chunk.go
@@ -16,8 +16,6 @@ type DataChunk struct {
 	data C.duckdb_data_chunk
 	// columns is a helper slice providing direct access to all columns.
 	columns []vector
-	// columnNames holds the column names, if known.
-	columnNames []string
 }
 
 // InitFromTypes initializes a data chunk by providing its column types.
@@ -79,13 +77,7 @@ func (chunk *DataChunk) SetSize() error {
 	return nil
 }
 
-// GetSize returns the internal size of the data chunk.
-func (chunk *DataChunk) GetSize() int {
-	return int(C.duckdb_data_chunk_get_size(chunk.data))
-}
-
-// SetValue writes a single value to a column. Note that this requires casting the type for
-// each invocation. Try to use the columnar function SetColumn for performance.
+// SetValue writes a single value to a column. Note that this requires casting the type for each invocation.
 func (chunk *DataChunk) SetValue(colIdx int, rowIdx int, val any) error {
 	if colIdx >= len(chunk.columns) {
 		return errDriver

--- a/errors.go
+++ b/errors.go
@@ -56,7 +56,8 @@ const (
 )
 
 var (
-	errDriver = errors.New("internal driver error, please file a bug report")
+	errDriver = errors.New("internal driver error: please file a bug report")
+	errAPI    = errors.New("API error")
 
 	errParseDSN  = errors.New("could not parse DSN for database")
 	errOpen      = errors.New("could not open database")

--- a/errors_test.go
+++ b/errors_test.go
@@ -267,3 +267,9 @@ func TestErrAppendNestedList(t *testing.T) {
 
 	cleanupAppender(t, c, con, a)
 }
+
+func TestErrAPISetValue(t *testing.T) {
+	var chunk DataChunk
+	err := chunk.SetValue(1, 42, "hello")
+	testError(t, err, errAPI.Error(), columnCountErrMsg)
+}

--- a/helper.go
+++ b/helper.go
@@ -1,0 +1,29 @@
+package duckdb
+
+/*
+#include <stdlib.h>
+#include <duckdb.h>
+*/
+import "C"
+
+import "unsafe"
+
+// secondsPerDay to calculate the days since 1970-01-01.
+const secondsPerDay = 24 * 60 * 60
+
+func mallocTypeSlice(count int) (unsafe.Pointer, []C.duckdb_logical_type) {
+	var dummy C.duckdb_logical_type
+	size := C.size_t(unsafe.Sizeof(dummy))
+
+	ptr := unsafe.Pointer(C.malloc(C.size_t(count) * size))
+	slice := (*[1 << 30]C.duckdb_logical_type)(ptr)[:count:count]
+
+	return ptr, slice
+}
+
+func destroyTypeSlice(ptr unsafe.Pointer, slice []C.duckdb_logical_type) {
+	for _, t := range slice {
+		C.duckdb_destroy_logical_type(&t)
+	}
+	C.free(ptr)
+}

--- a/statement.go
+++ b/statement.go
@@ -59,7 +59,7 @@ func (s *stmt) bind(args []driver.NamedValue) error {
 		C.duckdb_free(unsafe.Pointer(name))
 
 		// fallback on index position
-		var arg = args[i]
+		arg := args[i]
 
 		// override with ordinal if set
 		for _, v := range args {

--- a/vector_setters.go
+++ b/vector_setters.go
@@ -5,6 +5,7 @@ package duckdb
 #include <duckdb.h>
 */
 import "C"
+
 import (
 	"time"
 	"unsafe"

--- a/vector_setters.go
+++ b/vector_setters.go
@@ -1,0 +1,109 @@
+package duckdb
+
+/*
+#include <stdlib.h>
+#include <duckdb.h>
+*/
+import "C"
+import (
+	"time"
+	"unsafe"
+)
+
+// fnSetVectorValue is the setter callback function for any (nested) vector.
+type fnSetVectorValue func(vec *vector, rowIdx C.idx_t, val any)
+
+func (vec *vector) setNull(rowIdx C.idx_t) {
+	C.duckdb_vector_ensure_validity_writable(vec.duckdbVector)
+	mask := C.duckdb_vector_get_validity(vec.duckdbVector)
+	C.duckdb_validity_set_row_invalid(mask, rowIdx)
+
+	if vec.duckdbType == C.DUCKDB_TYPE_STRUCT {
+		for i := 0; i < len(vec.childVectors); i++ {
+			vec.childVectors[i].setNull(rowIdx)
+		}
+	}
+}
+
+func setPrimitive[T any](vec *vector, rowIdx C.idx_t, val any) {
+	ptr := C.duckdb_vector_get_data(vec.duckdbVector)
+	xs := (*[1 << 31]T)(ptr)
+	xs[rowIdx] = val.(T)
+}
+
+func (vec *vector) setTS(duckdbType C.duckdb_type, rowIdx C.idx_t, val any) {
+	v := val.(time.Time)
+	var ticks int64
+	switch duckdbType {
+	case C.DUCKDB_TYPE_TIMESTAMP:
+		ticks = v.UTC().UnixMicro()
+	case C.DUCKDB_TYPE_TIMESTAMP_S:
+		ticks = v.UTC().Unix()
+	case C.DUCKDB_TYPE_TIMESTAMP_MS:
+		ticks = v.UTC().UnixMilli()
+	case C.DUCKDB_TYPE_TIMESTAMP_NS:
+		ticks = v.UTC().UnixNano()
+	case C.DUCKDB_TYPE_TIMESTAMP_TZ:
+		ticks = v.UTC().UnixMicro()
+	}
+
+	var ts C.duckdb_timestamp
+	ts.micros = C.int64_t(ticks)
+	setPrimitive[C.duckdb_timestamp](vec, rowIdx, ts)
+}
+
+func (vec *vector) setDate(rowIdx C.idx_t, val any) {
+	// Days since 1970-01-01.
+	v := val.(time.Time)
+	days := int32(v.UTC().Unix() / secondsPerDay)
+
+	var date C.duckdb_date
+	date.days = C.int32_t(days)
+	setPrimitive[C.duckdb_date](vec, rowIdx, date)
+}
+
+func (vec *vector) setCString(rowIdx C.idx_t, val any) {
+	var str string
+	if vec.duckdbType == C.DUCKDB_TYPE_VARCHAR {
+		str = val.(string)
+	} else if vec.duckdbType == C.DUCKDB_TYPE_BLOB {
+		str = string(val.([]byte)[:])
+	}
+
+	// This setter also writes BLOBs.
+	cStr := C.CString(str)
+	C.duckdb_vector_assign_string_element_len(vec.duckdbVector, rowIdx, cStr, C.idx_t(len(str)))
+	C.free(unsafe.Pointer(cStr))
+}
+
+func (vec *vector) setList(rowIdx C.idx_t, val any) {
+	list := val.([]any)
+	childVectorSize := C.duckdb_list_vector_get_size(vec.duckdbVector)
+
+	// Set the offset and length of the list vector using the current size of the child vector.
+	listEntry := C.duckdb_list_entry{
+		offset: C.idx_t(childVectorSize),
+		length: C.idx_t(len(list)),
+	}
+	setPrimitive[C.duckdb_list_entry](vec, rowIdx, listEntry)
+
+	newLength := C.idx_t(len(list)) + childVectorSize
+	C.duckdb_list_vector_set_size(vec.duckdbVector, newLength)
+	C.duckdb_list_vector_reserve(vec.duckdbVector, newLength)
+
+	// Insert the values into the child vector.
+	childVector := &vec.childVectors[0]
+	for i, entry := range list {
+		offset := C.idx_t(i) + childVectorSize
+		childVector.setFn(childVector, offset, entry)
+	}
+}
+
+func (vec *vector) setStruct(rowIdx C.idx_t, val any) {
+	m := val.(map[string]any)
+	for i := 0; i < len(vec.childVectors); i++ {
+		childVector := &vec.childVectors[i]
+		childName := vec.childNames[i]
+		childVector.setFn(childVector, rowIdx, m[childName])
+	}
+}


### PR DESCRIPTION
This PR introduces a new `DataChunk` API. See the discussion [here](https://github.com/marcboeker/go-duckdb/pull/219). Ideally, all interaction between go-duckdb and duckdb's data chunks eventually goes through this API without compromising performance. As an outlook, in #219, I further used this API for go-duckdb's scanner.

As a first step, this PR moves all interaction between the `Appender` and data chunks to the `DataChunk` API and its setter functions, further decreasing the complexity of the `Appender` code.

This PR adds the following functions:
- `func (chunk *DataChunk) InitFromTypes(ptr unsafe.Pointer, types []C.duckdb_logical_type) error`
- `func (chunk *DataChunk) Destroy()`
- `func (chunk *DataChunk) SetSize() error`
- `func (chunk *DataChunk) SetValue(colIdx int, rowIdx int, val any) error`

Additionally, I reverted the column index in the data chunk when returning an unsupported type error message to 0-based indexing.

### Questions
- I introduced a new `helper.go` file. However, I recommend renaming this file or moving its functions to a different place. What do you think?
- The `DataChunk`, and by implication, the `vector` structs are becoming universal components without ties to the `Appender`. Thus, I renamed `appender_vector.go` to `vector.go`. Also, I added a new file, `vector_setters.go`, to create some functionality separation and decrease file sizes. Is this a good approach?