### PR TITLE
Fix appending multiple data chunks

### DIFF
--- a/appender.go
+++ b/appender.go
@@ -184,13 +184,13 @@ func (a *Appender) appendDataChunks() error {
 			size = a.rowCount
 		}
 		if err = chunk.SetSize(size); err != nil {
-			break
+			continue
 		}
 
 		state = C.duckdb_append_data_chunk(a.duckdbAppender, chunk.data)
 		if state == C.DuckDBError {
 			err = duckdbError(C.duckdb_appender_error(a.duckdbAppender))
-			break
+			continue
 		}
 		chunk.close()
 	}

--- a/appender.go
+++ b/appender.go
@@ -184,14 +184,17 @@ func (a *Appender) appendDataChunks() error {
 			size = a.rowCount
 		}
 		if err = chunk.SetSize(size); err != nil {
-			continue
+			break
 		}
 
 		state = C.duckdb_append_data_chunk(a.duckdbAppender, chunk.data)
 		if state == C.DuckDBError {
 			err = duckdbError(C.duckdb_appender_error(a.duckdbAppender))
-			continue
+			break
 		}
+	}
+
+	for _, chunk := range a.chunks {
 		chunk.close()
 	}
 

--- a/appender.go
+++ b/appender.go
@@ -177,26 +177,23 @@ func (a *Appender) appendDataChunks() error {
 	var state C.duckdb_state
 	var err error
 
-	for i := 0; i < len(a.chunks); i++ {
+	for i, chunk := range a.chunks {
 		// All data chunks except the last are at maximum capacity.
 		size := GetDataChunkCapacity()
 		if i == len(a.chunks)-1 {
 			size = a.rowCount
 		}
-		if err = a.chunks[i].SetSize(size); err != nil {
+		if err = chunk.SetSize(size); err != nil {
 			break
 		}
 
-		state = C.duckdb_append_data_chunk(a.duckdbAppender, a.chunks[i].data)
+		state = C.duckdb_append_data_chunk(a.duckdbAppender, chunk.data)
 		if state == C.DuckDBError {
 			err = duckdbError(C.duckdb_appender_error(a.duckdbAppender))
 			break
 		}
-		a.chunks[i].close()
+		chunk.close()
 	}
-
-	//for i, chunk := range a.chunks {
-	//}
 
 	a.chunks = a.chunks[:0]
 	a.rowCount = 0

--- a/appender_test.go
+++ b/appender_test.go
@@ -278,12 +278,12 @@ func TestAppenderPrimitive(t *testing.T) {
 			&r.String,
 			&r.Bool,
 		))
-		rowsToAppend[r.ID].Timestamp = rowsToAppend[i].Timestamp.UTC()
-		rowsToAppend[r.ID].TimestampS = rowsToAppend[i].TimestampS.UTC()
-		rowsToAppend[r.ID].TimestampMS = rowsToAppend[i].TimestampMS.UTC()
-		rowsToAppend[r.ID].TimestampNS = rowsToAppend[i].TimestampNS.UTC()
-		rowsToAppend[r.ID].TimestampTZ = rowsToAppend[i].TimestampTZ.UTC()
-		require.Equal(t, rowsToAppend[r.ID], r)
+		rowsToAppend[i].Timestamp = rowsToAppend[i].Timestamp.UTC()
+		rowsToAppend[i].TimestampS = rowsToAppend[i].TimestampS.UTC()
+		rowsToAppend[i].TimestampMS = rowsToAppend[i].TimestampMS.UTC()
+		rowsToAppend[i].TimestampNS = rowsToAppend[i].TimestampNS.UTC()
+		rowsToAppend[i].TimestampTZ = rowsToAppend[i].TimestampTZ.UTC()
+		require.Equal(t, rowsToAppend[i], r)
 		i++
 	}
 

--- a/appender_test.go
+++ b/appender_test.go
@@ -15,8 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const numAppenderTestRows = 10000
-
 type simpleStruct struct {
 	A int32
 	B string
@@ -169,6 +167,8 @@ func TestAppenderPrimitive(t *testing.T) {
 			bool BOOLEAN
 	  	)`)
 
+	// Test appending a few data chunks.
+	rowCount := GetDataChunkCapacity() * 5
 	type row struct {
 		ID          int64
 		UInt8       uint8
@@ -198,8 +198,8 @@ func TestAppenderPrimitive(t *testing.T) {
 	ts, err := time.ParseInLocation(longForm, "2016-01-17 20:04:05 IST", IST)
 	require.NoError(t, err)
 
-	rowsToAppend := make([]row, numAppenderTestRows)
-	for i := 0; i < numAppenderTestRows; i++ {
+	rowsToAppend := make([]row, rowCount)
+	for i := 0; i < rowCount; i++ {
 
 		u64 := rand.Uint64()
 		// Go SQL does not support uint64 values with their high bit set (see for example https://github.com/lib/pq/issues/72).
@@ -248,10 +248,6 @@ func TestAppenderPrimitive(t *testing.T) {
 			rowsToAppend[i].String,
 			rowsToAppend[i].Bool,
 		))
-
-		if i%1000 == 0 {
-			require.NoError(t, a.Flush())
-		}
 	}
 	require.NoError(t, a.Flush())
 
@@ -282,16 +278,16 @@ func TestAppenderPrimitive(t *testing.T) {
 			&r.String,
 			&r.Bool,
 		))
-		rowsToAppend[i].Timestamp = rowsToAppend[i].Timestamp.UTC()
-		rowsToAppend[i].TimestampS = rowsToAppend[i].TimestampS.UTC()
-		rowsToAppend[i].TimestampMS = rowsToAppend[i].TimestampMS.UTC()
-		rowsToAppend[i].TimestampNS = rowsToAppend[i].TimestampNS.UTC()
-		rowsToAppend[i].TimestampTZ = rowsToAppend[i].TimestampTZ.UTC()
-		require.Equal(t, rowsToAppend[i], r)
+		rowsToAppend[r.ID].Timestamp = rowsToAppend[i].Timestamp.UTC()
+		rowsToAppend[r.ID].TimestampS = rowsToAppend[i].TimestampS.UTC()
+		rowsToAppend[r.ID].TimestampMS = rowsToAppend[i].TimestampMS.UTC()
+		rowsToAppend[r.ID].TimestampNS = rowsToAppend[i].TimestampNS.UTC()
+		rowsToAppend[r.ID].TimestampTZ = rowsToAppend[i].TimestampTZ.UTC()
+		require.Equal(t, rowsToAppend[r.ID], r)
 		i++
 	}
 
-	require.Equal(t, numAppenderTestRows, i)
+	require.Equal(t, rowCount, i)
 	require.NoError(t, res.Close())
 	cleanupAppender(t, c, con, a)
 }

--- a/data_chunk.go
+++ b/data_chunk.go
@@ -18,14 +18,14 @@ type DataChunk struct {
 	columns []vector
 }
 
-// GetCapacity returns the capacity of a data chunk.
-func (chunk *DataChunk) GetCapacity() int {
+// GetDataChunkCapacity returns the capacity of a data chunk.
+func GetDataChunkCapacity() int {
 	return int(C.duckdb_vector_size())
 }
 
 // SetSize sets the internal size of the data chunk. Cannot exceed GetCapacity().
 func (chunk *DataChunk) SetSize(size int) error {
-	if size > chunk.GetCapacity() {
+	if size > GetDataChunkCapacity() {
 		return getError(errAPI, errVectorSize)
 	}
 	C.duckdb_data_chunk_set_size(chunk.data, C.idx_t(size))


### PR DESCRIPTION
By removing the following lines from `appender_test.go`, I noticed that the `Appender` is broken when attempting to append more than one data chunk. By removing these lines, we now test multip-data-chunk appends.

```Go
if i%1000 == 0 {
	require.NoError(t, a.Flush())
}
```