### PR TITLE
Appender support for TIME, INTERVAL, HUGEINT, DECIMAL, ENUM, and MAP

### DIFF
--- a/appender.go
+++ b/appender.go
@@ -74,7 +74,7 @@ func NewAppenderFromConn(driverConn driver.Conn, schema, table string) (*Appende
 
 		// Ensure that we only create an appender for supported column types.
 		duckdbType := C.duckdb_get_type_id(a.types[i])
-		name, found := unsupportedAppenderTypeMap[duckdbType]
+		name, found := unsupportedTypeMap[duckdbType]
 		if found {
 			err := columnError(unsupportedTypeError(name), i+1)
 			destroyTypeSlice(a.ptr, a.types)

--- a/appender_test.go
+++ b/appender_test.go
@@ -46,6 +46,9 @@ type mixedStruct struct {
 	B []struct {
 		L []int32
 	}
+	C struct {
+		L Map
+	}
 }
 
 type nestedDataRow struct {
@@ -106,7 +109,7 @@ func randInt(lo int64, hi int64) int64 {
 	return rand.Int63n(hi-lo+1) + lo
 }
 
-func cleanupAppender(t *testing.T, c *Connector, con driver.Conn, a *Appender) {
+func cleanupAppender[T require.TestingT](t T, c *Connector, con driver.Conn, a *Appender) {
 	require.NoError(t, a.Close())
 	require.NoError(t, con.Close())
 	require.NoError(t, c.Close())
@@ -232,11 +235,13 @@ func TestAppenderNested(t *testing.T) {
 			struct_with_list STRUCT(L INT[]),
 			mix STRUCT(
 				A STRUCT(L VARCHAR[]),
-				B STRUCT(L INT[])[]
+				B STRUCT(L INT[])[],
+			    C STRUCT(L MAP(VARCHAR, INT))
 			),
 			mix_list STRUCT(
 				A STRUCT(L VARCHAR[]),
-				B STRUCT(L INT[])[]
+				B STRUCT(L INT[])[],
+			    C STRUCT(L MAP(VARCHAR, INT))
 			)[]
 		)
 	`)
@@ -252,6 +257,9 @@ func TestAppenderNested(t *testing.T) {
 		}{
 			{[]int32{1, 2, 3}},
 		},
+		C: struct {
+			L Map
+		}{L: Map{"foo": int32(1), "bar": int32(2)}},
 	}
 	rowsToAppend := make([]nestedDataRow, 10)
 	for i := 0; i < 10; i++ {

--- a/appender_test.go
+++ b/appender_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// INTERVAL, HUGEINT, DECIMAL, ENUM, MAP
+
 const numAppenderTestRows = 10000
 
 type simpleStruct struct {
@@ -648,7 +650,7 @@ func TestAppenderUUID(t *testing.T) {
 	cleanupAppender(t, c, con, a)
 }
 
-func TestAppenderTime(t *testing.T) {
+func TestAppenderTS(t *testing.T) {
 	c, con, a := prepareAppender(t, `CREATE TABLE test (timestamp TIMESTAMP)`)
 
 	ts := time.Date(2022, time.January, 1, 12, 0, 0, 0, time.UTC)
@@ -667,7 +669,7 @@ func TestAppenderTime(t *testing.T) {
 func TestAppenderDate(t *testing.T) {
 	c, con, a := prepareAppender(t, `CREATE TABLE test (date DATE)`)
 
-	ts := time.Date(1996, time.July, 23, 11, 42, 23, 0, time.UTC)
+	ts := time.Date(1996, time.July, 23, 11, 42, 23, 123, time.UTC)
 	require.NoError(t, a.AppendRow(ts))
 	require.NoError(t, a.Flush())
 
@@ -679,6 +681,22 @@ func TestAppenderDate(t *testing.T) {
 	require.Equal(t, ts.Year(), res.Year())
 	require.Equal(t, ts.Month(), res.Month())
 	require.Equal(t, ts.Day(), res.Day())
+	cleanupAppender(t, c, con, a)
+}
+
+func TestAppenderTime(t *testing.T) {
+	c, con, a := prepareAppender(t, `CREATE TABLE test (time TIME)`)
+
+	ts := time.Date(1996, time.July, 23, 11, 42, 23, 123, time.UTC)
+	require.NoError(t, a.AppendRow(ts))
+	require.NoError(t, a.Flush())
+
+	// Verify results.
+	row := sql.OpenDB(c).QueryRowContext(context.Background(), `SELECT time FROM test`)
+
+	var res time.Time
+	require.NoError(t, row.Scan(&res))
+	require.Equal(t, ts.UnixMicro(), res.UnixMicro())
 	cleanupAppender(t, c, con, a)
 }
 

--- a/data_chunk.go
+++ b/data_chunk.go
@@ -33,6 +33,7 @@ func (chunk *DataChunk) SetSize(size int) error {
 }
 
 // SetValue writes a single value to a column in a data chunk. Note that this requires casting the type for each invocation.
+// NOTE: Custom ENUM types must be passed as string.
 func (chunk *DataChunk) SetValue(colIdx int, rowIdx int, val any) error {
 	if colIdx >= len(chunk.columns) {
 		return getError(errAPI, columnCountError(colIdx, len(chunk.columns)))

--- a/data_chunk.go
+++ b/data_chunk.go
@@ -43,7 +43,7 @@ func (chunk *DataChunk) SetValue(colIdx int, rowIdx int, val any) error {
 	// Ensure that the types match before attempting to set anything.
 	// This is done to prevent failures 'halfway through' writing column values,
 	// potentially corrupting data in that column.
-	// FIXME: Can we improve efficiency here? We are casting back-and-forth to any A LOT currently.
+	// FIXME: Can we improve efficiency here? We are casting back-and-forth to any A LOT.
 	// FIXME: Maybe we can make columnar insertions unsafe, i.e., we always assume a correct type.
 	v, err := column.tryCast(val)
 	if err != nil {

--- a/data_chunk.go
+++ b/data_chunk.go
@@ -42,6 +42,8 @@ func (chunk *DataChunk) SetValue(colIdx int, rowIdx int, val any) error {
 	// Ensure that the types match before attempting to set anything.
 	// This is done to prevent failures 'halfway through' writing column values,
 	// potentially corrupting data in that column.
+	// FIXME: Can we improve efficiency here? We are casting back-and-forth to any A LOT currently.
+	// FIXME: Maybe we can make columnar insertions unsafe, i.e., we always assume a correct type.
 	v, err := column.tryCast(val)
 	if err != nil {
 		return columnError(err, colIdx)

--- a/errors.go
+++ b/errors.go
@@ -56,8 +56,6 @@ const (
 )
 
 var (
-	errDriver = errors.New("internal driver error: please file a bug report")
-
 	errAPI        = errors.New("API error")
 	errVectorSize = errors.New("data chunks cannot exceed duckdb's internal vector size")
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -56,6 +56,8 @@ func TestErrNestedMap(t *testing.T) {
 }
 
 func TestErrAppender(t *testing.T) {
+	t.Parallel()
+
 	t.Run(errAppenderInvalidCon.Error(), func(t *testing.T) {
 		var con driver.Conn
 		_, err := NewAppenderFromConn(con, "", "test")
@@ -160,6 +162,13 @@ func TestErrAppender(t *testing.T) {
 		require.NoError(t, con.Close())
 		require.NoError(t, c.Close())
 	})
+
+	t.Run(errUnsupportedMapKeyType.Error(), func(t *testing.T) {
+		c, con, a := prepareAppender(t, `CREATE TABLE test (m MAP(INT[], STRUCT(v INT)))`)
+		err := a.AppendRow(nil)
+		testError(t, err, errAppenderAppendRow.Error(), errUnsupportedMapKeyType.Error())
+		cleanupAppender(t, c, con, a)
+	})
 }
 
 func TestErrAppend(t *testing.T) {
@@ -186,10 +195,8 @@ func TestErrAppendDecimal(t *testing.T) {
 
 func TestErrAppendEnum(t *testing.T) {
 	c, con, a := prepareAppender(t, testTypesEnumSQL+";"+`CREATE TABLE test (e my_enum)`)
-
 	err := a.AppendRow("3")
 	testError(t, err, errAppenderAppendRow.Error(), castErrMsg)
-
 	cleanupAppender(t, c, con, a)
 }
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -110,7 +110,7 @@ func TestErrAppender(t *testing.T) {
 		c, err := NewConnector("", nil)
 		require.NoError(t, err)
 
-		_, err = sql.OpenDB(c).Exec(`CREATE TABLE test AS SELECT MAP() AS m`)
+		_, err = sql.OpenDB(c).Exec(`CREATE TABLE test (int_array INTEGER[2])`)
 		require.NoError(t, err)
 
 		con, err := c.Connect(context.Background())

--- a/errors_test.go
+++ b/errors_test.go
@@ -173,6 +173,26 @@ func TestErrAppend(t *testing.T) {
 	cleanupAppender(t, c, con, a)
 }
 
+func TestErrAppendDecimal(t *testing.T) {
+	c, con, a := prepareAppender(t, `CREATE TABLE test (d DECIMAL(8, 2))`)
+
+	err := a.AppendRow(Decimal{Width: 9, Scale: 2})
+	testError(t, err, errAppenderAppendRow.Error(), castErrMsg)
+	err = a.AppendRow(Decimal{Width: 8, Scale: 3})
+	testError(t, err, errAppenderAppendRow.Error(), castErrMsg)
+
+	cleanupAppender(t, c, con, a)
+}
+
+func TestErrAppendEnum(t *testing.T) {
+	c, con, a := prepareAppender(t, testTypesEnumSQL+";"+`CREATE TABLE test (e my_enum)`)
+
+	err := a.AppendRow("3")
+	testError(t, err, errAppenderAppendRow.Error(), castErrMsg)
+
+	cleanupAppender(t, c, con, a)
+}
+
 func TestErrAppendSimpleStruct(t *testing.T) {
 	c, con, a := prepareAppender(t, `
 		CREATE TABLE test (

--- a/rows.go
+++ b/rows.go
@@ -95,12 +95,6 @@ func scanValue(vector C.duckdb_vector, rowIdx C.idx_t) (any, error) {
 }
 
 func scan(vector C.duckdb_vector, rowIdx C.idx_t) (any, error) {
-	// FIXME: implement support for these types:
-	// DUCKDB_TYPE_UHUGEINT
-	// DUCKDB_TYPE_UNION
-	// DUCKDB_TYPE_BIT
-	// DUCKDB_TYPE_TIME_TZ
-
 	validity := C.duckdb_vector_get_validity(vector)
 	if !C.duckdb_validity_row_is_valid(validity, rowIdx) {
 		return nil, nil
@@ -389,7 +383,7 @@ func scanDecimal(ty C.duckdb_logical_type, vector C.duckdb_vector, rowIdx C.idx_
 	case C.DUCKDB_TYPE_INTEGER:
 		nativeValue = big.NewInt(int64(get[int32](vector, rowIdx)))
 	case C.DUCKDB_TYPE_BIGINT:
-		nativeValue = big.NewInt(int64(get[int64](vector, rowIdx)))
+		nativeValue = big.NewInt(get[int64](vector, rowIdx))
 	case C.DUCKDB_TYPE_HUGEINT:
 		i := get[C.duckdb_hugeint](vector, rowIdx)
 		nativeValue = hugeIntToNative(C.duckdb_hugeint{

--- a/types.go
+++ b/types.go
@@ -13,15 +13,11 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-var unsupportedAppenderTypeMap = map[C.duckdb_type]string{
+// FIXME: Implement support for these types.
+var unsupportedTypeMap = map[C.duckdb_type]string{
 	C.DUCKDB_TYPE_INVALID:  "INVALID",
-	C.DUCKDB_TYPE_TIME:     "TIME",
-	C.DUCKDB_TYPE_INTERVAL: "INTERVAL",
-	C.DUCKDB_TYPE_HUGEINT:  "HUGEINT",
 	C.DUCKDB_TYPE_UHUGEINT: "UHUGEINT",
-	C.DUCKDB_TYPE_DECIMAL:  "DECIMAL",
-	C.DUCKDB_TYPE_ENUM:     "ENUM",
-	C.DUCKDB_TYPE_MAP:      "MAP",
+	C.DUCKDB_TYPE_ARRAY:    "ARRAY",
 	C.DUCKDB_TYPE_UNION:    "UNION",
 	C.DUCKDB_TYPE_BIT:      "BIT",
 	C.DUCKDB_TYPE_TIME_TZ:  "TIME_TZ",
@@ -137,6 +133,14 @@ func (m *Map) Scan(v any) error {
 
 	*m = data
 	return nil
+}
+
+func mapKeysField() string {
+	return "key"
+}
+
+func mapValuesField() string {
+	return "value"
 }
 
 type Interval struct {

--- a/types.go
+++ b/types.go
@@ -176,3 +176,7 @@ func (d *Decimal) Float64() float64 {
 	f, _ := value.Float64()
 	return f
 }
+
+func (d *Decimal) toString() string {
+	return fmt.Sprintf("DECIMAL(%d,%d)", d.Width, d.Scale)
+}

--- a/types_test.go
+++ b/types_test.go
@@ -42,7 +42,7 @@ type testTypesRow struct {
 	Date_col         time.Time
 	Time_col         time.Time
 	Interval_col     Interval
-	Hugeint_col      Composite[big.Int]
+	Hugeint_col      *big.Int
 	Varchar_col      string
 	Blob_col         []byte
 	Timestamp_s_col  time.Time
@@ -88,9 +88,6 @@ func testTypesGenerateRow(i int) testTypesRow {
 	ts := time.Date(1992, 9, 20, 11, 30, 0, 0, time.UTC)
 	date := time.Date(1992, 9, 20, 0, 0, 0, 0, time.UTC)
 	t := time.Date(1970, 1, 1, 11, 42, 7, 0, time.UTC)
-	hugeintCol := Composite[big.Int]{
-		*big.NewInt(int64(i)),
-	}
 	varcharCol := ""
 	for j := 0; j < i; j++ {
 		varcharCol += "hello!"
@@ -121,7 +118,7 @@ func testTypesGenerateRow(i int) testTypesRow {
 		date,
 		t,
 		Interval{Days: 0, Months: int32(i), Micros: 0},
-		hugeintCol,
+		big.NewInt(int64(i)),
 		varcharCol,
 		[]byte{'A', 'B'},
 		ts,
@@ -187,7 +184,7 @@ func testTypes[T require.TestingT](t T, c *Connector, con driver.Conn, a *Append
 			r.Timestamp_s_col,
 			r.Timestamp_ms_col,
 			r.Timestamp_ns_col,
-			r.Enum_col,
+			string(r.Enum_col),
 			r.List_col,
 			r.Struct_col,
 			r.Map_col,

--- a/types_test.go
+++ b/types_test.go
@@ -257,15 +257,21 @@ func TestTypes(t *testing.T) {
 
 // NOTE: go-duckdb only contains very few benchmarks. The purpose of those benchmarks is to avoid regressions
 // of its main functionalities. I.e., functions related to implementing the database/sql interface.
+var benchmarkTypesResult []testTypesRow
 
 func BenchmarkTypes(b *testing.B) {
 	expectedRows := testTypesGenerateRows(b, GetDataChunkCapacity()*3+10)
 	c, con, a := prepareAppender(b, testTypesEnumSQL+";"+testTypesTableSQL)
 
+	var r []testTypesRow
+	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		_ = testTypes(b, c, a, expectedRows)
+		r = testTypes(b, c, a, expectedRows)
 		testTypesReset(b, c)
 	}
+
+	// Ensure that the compiler does not eliminate the line by storing the result.
+	benchmarkTypesResult = r
 	cleanupAppender(b, c, con, a)
 }
 

--- a/vector.go
+++ b/vector.go
@@ -66,15 +66,8 @@ func (vec *vector) tryCast(val any) (any, error) {
 	case C.DUCKDB_TYPE_INTERVAL:
 		return tryPrimitiveCast[Interval](val, reflect.TypeOf(Interval{}).String())
 	case C.DUCKDB_TYPE_HUGEINT:
-		v, ok := val.(big.Int)
-		if ok {
-			return v, nil
-		}
-
-		goType := reflect.TypeOf(val)
-		return v, castError(goType.String(), reflect.TypeOf(big.Int{}).String())
-		//// Note that this expects *big.Int.
-		//return tryPrimitiveCast[big.Int](val, reflect.TypeOf(big.Int{}).String())
+		// Note that this expects *big.Int.
+		return tryPrimitiveCast[*big.Int](val, reflect.TypeOf(big.Int{}).String())
 	case C.DUCKDB_TYPE_UHUGEINT:
 		return nil, unsupportedTypeError(duckdbTypeMap[vec.duckdbType])
 	case C.DUCKDB_TYPE_VARCHAR, C.DUCKDB_TYPE_ENUM:

--- a/vector.go
+++ b/vector.go
@@ -297,7 +297,7 @@ func initPrimitive[T any](vec *vector, duckdbType C.duckdb_type) {
 			vec.setNull(rowIdx)
 			return
 		}
-		setPrimitive[T](vec, rowIdx, val.(T))
+		setPrimitive(vec, rowIdx, val.(T))
 	}
 	vec.duckdbType = duckdbType
 }
@@ -515,7 +515,7 @@ func (vec *vector) initUUID() {
 			vec.setNull(rowIdx)
 			return
 		}
-		setPrimitive[C.duckdb_hugeint](vec, rowIdx, uuidToHugeInt(val.(UUID)))
+		setPrimitive(vec, rowIdx, uuidToHugeInt(val.(UUID)))
 	}
 	vec.duckdbType = C.DUCKDB_TYPE_UUID
 }

--- a/vector.go
+++ b/vector.go
@@ -404,7 +404,6 @@ func (vec *vector) initCString(duckdbType C.duckdb_type) {
 }
 
 func (vec *vector) initDecimal(logicalType C.duckdb_logical_type, colIdx int) error {
-	// Get the width and scale.
 	vec.width = uint8(C.duckdb_decimal_width(logicalType))
 	vec.scale = uint8(C.duckdb_decimal_scale(logicalType))
 

--- a/vector.go
+++ b/vector.go
@@ -81,7 +81,6 @@ func (vec *vector) tryCast(val any) (any, error) {
 	case C.DUCKDB_TYPE_STRUCT:
 		return vec.tryCastStruct(val)
 	case C.DUCKDB_TYPE_MAP:
-		// TODO: pretty sure that this will break.
 		return tryPrimitiveCast[Map](val, reflect.TypeOf(Map{}).String())
 	case C.DUCKDB_TYPE_ARRAY:
 		return nil, unsupportedTypeError(duckdbTypeMap[vec.duckdbType])
@@ -204,11 +203,6 @@ func (vec *vector) tryCastStruct(val any) (map[string]any, error) {
 		}
 	}
 	return m, nil
-}
-
-func (vec *vector) tryCastMap(val any) ([]any, error) {
-	// TODO
-	return nil, nil
 }
 
 func (vec *vector) init(logicalType C.duckdb_logical_type, colIdx int) error {

--- a/vector.go
+++ b/vector.go
@@ -7,6 +7,7 @@ package duckdb
 import "C"
 
 import (
+	"math/big"
 	"reflect"
 	"strconv"
 	"time"
@@ -25,6 +26,8 @@ type vector struct {
 	childNames []string
 	// The child vectors of nested data types.
 	childVectors []vector
+	// The dictionary for ENUM types.
+	dict map[string]uint32
 }
 
 func (vec *vector) tryCast(val any) (any, error) {
@@ -33,44 +36,66 @@ func (vec *vector) tryCast(val any) (any, error) {
 	}
 
 	switch vec.duckdbType {
-	case C.DUCKDB_TYPE_UTINYINT:
-		return tryNumericCast[uint8](val, reflect.Uint8.String())
+	case C.DUCKDB_TYPE_INVALID:
+		return nil, unsupportedTypeError(duckdbTypeMap[vec.duckdbType])
+	case C.DUCKDB_TYPE_BOOLEAN:
+		return tryPrimitiveCast[bool](val, reflect.Bool.String())
 	case C.DUCKDB_TYPE_TINYINT:
 		return tryNumericCast[int8](val, reflect.Int8.String())
-	case C.DUCKDB_TYPE_USMALLINT:
-		return tryNumericCast[uint16](val, reflect.Uint16.String())
 	case C.DUCKDB_TYPE_SMALLINT:
 		return tryNumericCast[int16](val, reflect.Int16.String())
-	case C.DUCKDB_TYPE_UINTEGER:
-		return tryNumericCast[uint32](val, reflect.Uint32.String())
 	case C.DUCKDB_TYPE_INTEGER:
 		return tryNumericCast[int32](val, reflect.Int32.String())
-	case C.DUCKDB_TYPE_UBIGINT:
-		return tryNumericCast[uint64](val, reflect.Uint64.String())
 	case C.DUCKDB_TYPE_BIGINT:
 		return tryNumericCast[int64](val, reflect.Int64.String())
+	case C.DUCKDB_TYPE_UTINYINT:
+		return tryNumericCast[uint8](val, reflect.Uint8.String())
+	case C.DUCKDB_TYPE_USMALLINT:
+		return tryNumericCast[uint16](val, reflect.Uint16.String())
+	case C.DUCKDB_TYPE_UINTEGER:
+		return tryNumericCast[uint32](val, reflect.Uint32.String())
+	case C.DUCKDB_TYPE_UBIGINT:
+		return tryNumericCast[uint64](val, reflect.Uint64.String())
 	case C.DUCKDB_TYPE_FLOAT:
 		return tryNumericCast[float32](val, reflect.Float32.String())
 	case C.DUCKDB_TYPE_DOUBLE:
 		return tryNumericCast[float64](val, reflect.Float64.String())
-	case C.DUCKDB_TYPE_BOOLEAN:
-		return tryPrimitiveCast[bool](val, reflect.Bool.String())
-	case C.DUCKDB_TYPE_VARCHAR:
+	case C.DUCKDB_TYPE_TIMESTAMP, C.DUCKDB_TYPE_TIMESTAMP_S, C.DUCKDB_TYPE_TIMESTAMP_MS,
+		C.DUCKDB_TYPE_TIMESTAMP_NS, C.DUCKDB_TYPE_TIMESTAMP_TZ, C.DUCKDB_TYPE_DATE, C.DUCKDB_TYPE_TIME:
+		return tryPrimitiveCast[time.Time](val, reflect.TypeOf(time.Time{}).String())
+	case C.DUCKDB_TYPE_INTERVAL:
+		return tryPrimitiveCast[Interval](val, reflect.TypeOf(Interval{}).String())
+	case C.DUCKDB_TYPE_HUGEINT:
+		// Note that this expects *big.Int.
+		return tryPrimitiveCast[*big.Int](val, reflect.TypeOf(big.Int{}).String())
+	case C.DUCKDB_TYPE_UHUGEINT:
+		return nil, unsupportedTypeError(duckdbTypeMap[vec.duckdbType])
+	case C.DUCKDB_TYPE_VARCHAR, C.DUCKDB_TYPE_ENUM:
 		return tryPrimitiveCast[string](val, reflect.String.String())
 	case C.DUCKDB_TYPE_BLOB:
 		return tryPrimitiveCast[[]byte](val, reflect.TypeOf([]byte{}).String())
-	case C.DUCKDB_TYPE_TIMESTAMP, C.DUCKDB_TYPE_TIMESTAMP_S, C.DUCKDB_TYPE_TIMESTAMP_MS,
-		C.DUCKDB_TYPE_TIMESTAMP_NS, C.DUCKDB_TYPE_TIMESTAMP_TZ, C.DUCKDB_TYPE_DATE:
-		return tryPrimitiveCast[time.Time](val, reflect.TypeOf(time.Time{}).String())
-	case C.DUCKDB_TYPE_UUID:
-		return tryPrimitiveCast[UUID](val, reflect.TypeOf(UUID{}).String())
+	case C.DUCKDB_TYPE_DECIMAL:
+		return tryPrimitiveCast[Decimal](val, reflect.TypeOf(Decimal{}).String())
 	case C.DUCKDB_TYPE_LIST:
 		return vec.tryCastList(val)
 	case C.DUCKDB_TYPE_STRUCT:
 		return vec.tryCastStruct(val)
+	case C.DUCKDB_TYPE_MAP:
+		// TODO: pretty sure that this will break.
+		return tryPrimitiveCast[Map](val, reflect.TypeOf(Map{}).String())
+	case C.DUCKDB_TYPE_ARRAY:
+		return nil, unsupportedTypeError(duckdbTypeMap[vec.duckdbType])
+	case C.DUCKDB_TYPE_UUID:
+		return tryPrimitiveCast[UUID](val, reflect.TypeOf(UUID{}).String())
+	case C.DUCKDB_TYPE_UNION:
+		return nil, unsupportedTypeError(duckdbTypeMap[vec.duckdbType])
+	case C.DUCKDB_TYPE_BIT:
+		return nil, unsupportedTypeError(duckdbTypeMap[vec.duckdbType])
+	case C.DUCKDB_TYPE_TIME_TZ:
+		return nil, unsupportedTypeError(duckdbTypeMap[vec.duckdbType])
+	default:
+		return nil, unsupportedTypeError("unknown type")
 	}
-
-	return nil, getError(errDriver, nil)
 }
 
 func (*vector) canNil(val reflect.Value) bool {
@@ -181,6 +206,11 @@ func (vec *vector) tryCastStruct(val any) (map[string]any, error) {
 	return m, nil
 }
 
+func (vec *vector) tryCastMap(val any) ([]any, error) {
+	// TODO
+	return nil, nil
+}
+
 func (vec *vector) init(logicalType C.duckdb_logical_type, colIdx int) error {
 	duckdbType := C.duckdb_get_type_id(logicalType)
 
@@ -215,25 +245,25 @@ func (vec *vector) init(logicalType C.duckdb_logical_type, colIdx int) error {
 	case C.DUCKDB_TYPE_DATE:
 		vec.initDate()
 	case C.DUCKDB_TYPE_TIME:
-		return columnError(unsupportedTypeError(duckdbTypeMap[duckdbType]), colIdx)
+		vec.initTime()
 	case C.DUCKDB_TYPE_INTERVAL:
-		return columnError(unsupportedTypeError(duckdbTypeMap[duckdbType]), colIdx)
+		vec.initInterval()
 	case C.DUCKDB_TYPE_HUGEINT:
-		return columnError(unsupportedTypeError(duckdbTypeMap[duckdbType]), colIdx)
+		vec.initHugeint()
 	case C.DUCKDB_TYPE_UHUGEINT:
 		return columnError(unsupportedTypeError(duckdbTypeMap[duckdbType]), colIdx)
 	case C.DUCKDB_TYPE_VARCHAR, C.DUCKDB_TYPE_BLOB:
 		vec.initCString(duckdbType)
 	case C.DUCKDB_TYPE_DECIMAL:
-		return columnError(unsupportedTypeError(duckdbTypeMap[duckdbType]), colIdx)
+		return vec.initDecimal(logicalType, colIdx)
 	case C.DUCKDB_TYPE_ENUM:
-		return columnError(unsupportedTypeError(duckdbTypeMap[duckdbType]), colIdx)
+		return vec.initEnum(logicalType, colIdx)
 	case C.DUCKDB_TYPE_LIST:
 		return vec.initList(logicalType, colIdx)
 	case C.DUCKDB_TYPE_STRUCT:
 		return vec.initStruct(logicalType, colIdx)
 	case C.DUCKDB_TYPE_MAP:
-		return columnError(unsupportedTypeError(duckdbTypeMap[duckdbType]), colIdx)
+		return vec.initMap(logicalType, colIdx)
 	case C.DUCKDB_TYPE_ARRAY:
 		return columnError(unsupportedTypeError(duckdbTypeMap[duckdbType]), colIdx)
 	case C.DUCKDB_TYPE_UUID:
@@ -253,7 +283,7 @@ func (vec *vector) init(logicalType C.duckdb_logical_type, colIdx int) error {
 func (vec *vector) getChildVectors(vector C.duckdb_vector) {
 	switch vec.duckdbType {
 
-	case C.DUCKDB_TYPE_LIST:
+	case C.DUCKDB_TYPE_LIST, C.DUCKDB_TYPE_MAP:
 		child := C.duckdb_list_vector_get_child(vector)
 		vec.childVectors[0].duckdbVector = child
 		vec.childVectors[0].getChildVectors(child)
@@ -300,6 +330,39 @@ func (vec *vector) initDate() {
 	vec.duckdbType = C.DUCKDB_TYPE_DATE
 }
 
+func (vec *vector) initTime() {
+	vec.setFn = func(vec *vector, rowIdx C.idx_t, val any) {
+		if val == nil {
+			vec.setNull(rowIdx)
+			return
+		}
+		vec.setTime(rowIdx, val)
+	}
+	vec.duckdbType = C.DUCKDB_TYPE_TIME
+}
+
+func (vec *vector) initInterval() {
+	vec.setFn = func(vec *vector, rowIdx C.idx_t, val any) {
+		if val == nil {
+			vec.setNull(rowIdx)
+			return
+		}
+		vec.setInterval(rowIdx, val)
+	}
+	vec.duckdbType = C.DUCKDB_TYPE_INTERVAL
+}
+
+func (vec *vector) initHugeint() {
+	vec.setFn = func(vec *vector, rowIdx C.idx_t, val any) {
+		if val == nil {
+			vec.setNull(rowIdx)
+			return
+		}
+		vec.setHugeint(rowIdx, val)
+	}
+	vec.duckdbType = C.DUCKDB_TYPE_HUGEINT
+}
+
 func (vec *vector) initCString(duckdbType C.duckdb_type) {
 	vec.setFn = func(vec *vector, rowIdx C.idx_t, val any) {
 		if val == nil {
@@ -309,6 +372,52 @@ func (vec *vector) initCString(duckdbType C.duckdb_type) {
 		vec.setCString(rowIdx, val)
 	}
 	vec.duckdbType = duckdbType
+}
+
+func (vec *vector) initDecimal(logicalType C.duckdb_logical_type, colIdx int) error {
+	internalType := C.duckdb_decimal_internal_type(logicalType)
+	switch internalType {
+	case C.DUCKDB_TYPE_SMALLINT, C.DUCKDB_TYPE_INTEGER, C.DUCKDB_TYPE_BIGINT, C.DUCKDB_TYPE_HUGEINT:
+		vec.setFn = func(vec *vector, rowIdx C.idx_t, val any) {
+			if val == nil {
+				vec.setNull(rowIdx)
+				return
+			}
+			vec.setDecimal(internalType, rowIdx, val)
+		}
+	default:
+		return columnError(unsupportedTypeError(duckdbTypeMap[internalType]), colIdx)
+	}
+
+	vec.duckdbType = C.DUCKDB_TYPE_DECIMAL
+	return nil
+}
+
+func (vec *vector) initEnum(logicalType C.duckdb_logical_type, colIdx int) error {
+	// Initialize the dictionary.
+	dictSize := uint32(C.duckdb_enum_dictionary_size(logicalType))
+	for i := uint32(0); i < dictSize; i++ {
+		cStr := C.duckdb_enum_dictionary_value(logicalType, C.idx_t(i))
+		vec.dict[C.GoString(cStr)] = i
+		C.duckdb_free(unsafe.Pointer(cStr))
+	}
+
+	internalType := C.duckdb_enum_internal_type(logicalType)
+	switch internalType {
+	case C.DUCKDB_TYPE_UTINYINT, C.DUCKDB_TYPE_USMALLINT, C.DUCKDB_TYPE_UINTEGER, C.DUCKDB_TYPE_UBIGINT:
+		vec.setFn = func(vec *vector, rowIdx C.idx_t, val any) {
+			if val == nil {
+				vec.setNull(rowIdx)
+				return
+			}
+			vec.setEnum(internalType, rowIdx, val)
+		}
+	default:
+		return columnError(unsupportedTypeError(duckdbTypeMap[internalType]), colIdx)
+	}
+
+	vec.duckdbType = C.DUCKDB_TYPE_ENUM
+	return nil
 }
 
 func (vec *vector) initList(logicalType C.duckdb_logical_type, colIdx int) error {
@@ -365,6 +474,42 @@ func (vec *vector) initStruct(logicalType C.duckdb_logical_type, colIdx int) err
 		vec.setStruct(rowIdx, val)
 	}
 	vec.duckdbType = C.DUCKDB_TYPE_STRUCT
+	return nil
+}
+
+func (vec *vector) initMap(logicalType C.duckdb_logical_type, colIdx int) error {
+	// A MAP is a LIST of STRUCT values. Each STRUCT holds two children: a key and a value.
+
+	// Get the child vector type.
+	childType := C.duckdb_list_type_child_type(logicalType)
+	defer C.duckdb_destroy_logical_type(&childType)
+
+	// Recurse into the child.
+	vec.childVectors = make([]vector, 1)
+	err := vec.childVectors[0].init(childType, colIdx)
+	if err != nil {
+		return err
+	}
+
+	// DuckDB supports more MAP key types than Go, which only supports comparable types.
+	// We ensure that the key type itself is comparable.
+	keyType := C.duckdb_map_type_key_type(logicalType)
+	defer C.duckdb_destroy_logical_type(&keyType)
+
+	duckdbKeyType := C.duckdb_get_type_id(keyType)
+	switch duckdbKeyType {
+	case C.DUCKDB_TYPE_LIST, C.DUCKDB_TYPE_STRUCT, C.DUCKDB_TYPE_MAP, C.DUCKDB_TYPE_ARRAY:
+		return columnError(errUnsupportedMapKeyType, colIdx)
+	}
+
+	vec.setFn = func(vec *vector, rowIdx C.idx_t, val any) {
+		if val == nil {
+			vec.setNull(rowIdx)
+			return
+		}
+		vec.setMap(rowIdx, val)
+	}
+	vec.duckdbType = C.DUCKDB_TYPE_MAP
 	return nil
 }
 

--- a/vector_setters.go
+++ b/vector_setters.go
@@ -106,17 +106,17 @@ func (vec *vector) setCString(rowIdx C.idx_t, val any) {
 }
 
 func (vec *vector) setDecimal(internalType C.duckdb_type, rowIdx C.idx_t, val any) {
-	v := val.(*big.Int)
+	v := val.(Decimal)
 
 	switch internalType {
 	case C.DUCKDB_TYPE_SMALLINT:
-		setPrimitive(vec, rowIdx, int16(v.Int64()))
+		setPrimitive(vec, rowIdx, int16(v.Value.Int64()))
 	case C.DUCKDB_TYPE_INTEGER:
-		setPrimitive(vec, rowIdx, int32(v.Int64()))
+		setPrimitive(vec, rowIdx, int32(v.Value.Int64()))
 	case C.DUCKDB_TYPE_BIGINT:
-		setPrimitive(vec, rowIdx, v.Int64())
+		setPrimitive(vec, rowIdx, v.Value.Int64())
 	case C.DUCKDB_TYPE_HUGEINT:
-		value, _ := hugeIntFromNative(v)
+		value, _ := hugeIntFromNative(v.Value)
 		setPrimitive(vec, rowIdx, value)
 	}
 }

--- a/vector_setters.go
+++ b/vector_setters.go
@@ -54,7 +54,7 @@ func (vec *vector) setTS(duckdbType C.duckdb_type, rowIdx C.idx_t, val any) {
 
 	var ts C.duckdb_timestamp
 	ts.micros = C.int64_t(ticks)
-	setPrimitive[C.duckdb_timestamp](vec, rowIdx, ts)
+	setPrimitive(vec, rowIdx, ts)
 }
 
 func (vec *vector) setDate(rowIdx C.idx_t, val any) {
@@ -64,7 +64,7 @@ func (vec *vector) setDate(rowIdx C.idx_t, val any) {
 
 	var date C.duckdb_date
 	date.days = C.int32_t(days)
-	setPrimitive[C.duckdb_date](vec, rowIdx, date)
+	setPrimitive(vec, rowIdx, date)
 }
 
 func (vec *vector) setTime(rowIdx C.idx_t, val any) {
@@ -73,7 +73,7 @@ func (vec *vector) setTime(rowIdx C.idx_t, val any) {
 
 	var t C.duckdb_time
 	t.micros = C.int64_t(ticks)
-	setPrimitive[C.duckdb_time](vec, rowIdx, t)
+	setPrimitive(vec, rowIdx, t)
 }
 
 func (vec *vector) setInterval(rowIdx C.idx_t, val any) {
@@ -82,13 +82,13 @@ func (vec *vector) setInterval(rowIdx C.idx_t, val any) {
 	interval.days = C.int32_t(v.Days)
 	interval.months = C.int32_t(v.Months)
 	interval.micros = C.int64_t(v.Micros)
-	setPrimitive[C.duckdb_interval](vec, rowIdx, interval)
+	setPrimitive(vec, rowIdx, interval)
 }
 
 func (vec *vector) setHugeint(rowIdx C.idx_t, val any) {
 	v := val.(*big.Int)
 	hugeInt, _ := hugeIntFromNative(v)
-	setPrimitive[C.duckdb_hugeint](vec, rowIdx, hugeInt)
+	setPrimitive(vec, rowIdx, hugeInt)
 }
 
 func (vec *vector) setCString(rowIdx C.idx_t, val any) {
@@ -110,14 +110,14 @@ func (vec *vector) setDecimal(internalType C.duckdb_type, rowIdx C.idx_t, val an
 
 	switch internalType {
 	case C.DUCKDB_TYPE_SMALLINT:
-		setPrimitive[int16](vec, rowIdx, int16(v.Int64()))
+		setPrimitive(vec, rowIdx, int16(v.Int64()))
 	case C.DUCKDB_TYPE_INTEGER:
-		setPrimitive[int32](vec, rowIdx, int32(v.Int64()))
+		setPrimitive(vec, rowIdx, int32(v.Int64()))
 	case C.DUCKDB_TYPE_BIGINT:
-		setPrimitive[int64](vec, rowIdx, v.Int64())
+		setPrimitive(vec, rowIdx, v.Int64())
 	case C.DUCKDB_TYPE_HUGEINT:
 		value, _ := hugeIntFromNative(v)
-		setPrimitive[C.duckdb_hugeint](vec, rowIdx, value)
+		setPrimitive(vec, rowIdx, value)
 	}
 }
 
@@ -126,13 +126,13 @@ func (vec *vector) setEnum(internalType C.duckdb_type, rowIdx C.idx_t, val any) 
 
 	switch internalType {
 	case C.DUCKDB_TYPE_UTINYINT:
-		setPrimitive[uint8](vec, rowIdx, uint8(v))
+		setPrimitive(vec, rowIdx, uint8(v))
 	case C.DUCKDB_TYPE_USMALLINT:
-		setPrimitive[uint16](vec, rowIdx, uint16(v))
+		setPrimitive(vec, rowIdx, uint16(v))
 	case C.DUCKDB_TYPE_UINTEGER:
-		setPrimitive[uint32](vec, rowIdx, v)
+		setPrimitive(vec, rowIdx, v)
 	case C.DUCKDB_TYPE_UBIGINT:
-		setPrimitive[uint64](vec, rowIdx, uint64(v))
+		setPrimitive(vec, rowIdx, uint64(v))
 	}
 }
 
@@ -145,7 +145,7 @@ func (vec *vector) setList(rowIdx C.idx_t, val any) {
 		offset: C.idx_t(childVectorSize),
 		length: C.idx_t(len(list)),
 	}
-	setPrimitive[C.duckdb_list_entry](vec, rowIdx, listEntry)
+	setPrimitive(vec, rowIdx, listEntry)
 
 	newLength := C.idx_t(len(list)) + childVectorSize
 	C.duckdb_list_vector_set_size(vec.duckdbVector, newLength)

--- a/vector_setters.go
+++ b/vector_setters.go
@@ -172,11 +172,12 @@ func (vec *vector) setMap(rowIdx C.idx_t, val any) {
 	m := val.(Map)
 
 	// Create a LIST of STRUCT values.
-	entries := make([]map[string]any, len(m))
+	i := 0
+	list := make([]any, len(m))
 	for key, value := range m {
-		entry := map[string]any{mapKeysField(): key, mapValuesField(): value}
-		entries = append(entries, entry)
+		list[i] = map[string]any{mapKeysField(): key, mapValuesField(): value}
+		i++
 	}
 
-	vec.setList(rowIdx, entries)
+	vec.setList(rowIdx, list)
 }


### PR DESCRIPTION
This PR introduces support for `TIME`, `INTERVAL`, `HUGEINT`, `DECIMAL`, `ENUM`, and `MAP` in the `Appender`. go-duckdb now supports all scannable types in the `Appender`.

### Other relevant changes

- I moved most primitive appender tests into `testTypes` to populate the table. That way, we're testing both appending to the table and scanning from it.
- For faster `SetValue` calls, we store additional information for `STRUCT`, `ENUM`, and `DECIMAL` in `vector`, if applicable.

### EDIT
I've extended this PR with some code paths to skip typecasting. This does not include more than one-level nested `LIST`s and `STRUCT`s, for which we still transform the input.

### EDIT EDIT
I'll move these changes into a different (follow-up) PR.

### Benchmark results

`BenchmarkTypes-10    	       4	 329119177 ns/op`