### PR TITLE
Generalise exported Error

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -80,54 +80,54 @@ var (
 	errCreateConfig = errors.New("could not create config for database")
 )
 
-type DuckDBErrorType int
+type ErrorType int
 
 const (
-	ErrorTypeInvalid              DuckDBErrorType = iota // invalid type
-	ErrorTypeOutOfRange                                  // value out of range error
-	ErrorTypeConversion                                  // conversion/casting error
-	ErrorTypeUnknownType                                 // unknown type error
-	ErrorTypeDecimal                                     // decimal related
-	ErrorTypeMismatchType                                // type mismatch
-	ErrorTypeDivideByZero                                // divide by 0
-	ErrorTypeObjectSize                                  // object size exceeded
-	ErrorTypeInvalidType                                 // incompatible for operation
-	ErrorTypeSerialization                               // serialization
-	ErrorTypeTransaction                                 // transaction management
-	ErrorTypeNotImplemented                              // method not implemented
-	ErrorTypeExpression                                  // expression parsing
-	ErrorTypeCatalog                                     // catalog related
-	ErrorTypeParser                                      // parser related
-	ErrorTypePlanner                                     // planner related
-	ErrorTypeScheduler                                   // scheduler related
-	ErrorTypeExecutor                                    // executor related
-	ErrorTypeConstraint                                  // constraint related
-	ErrorTypeIndex                                       // index related
-	ErrorTypeStat                                        // stat related
-	ErrorTypeConnection                                  // connection related
-	ErrorTypeSyntax                                      // syntax related
-	ErrorTypeSettings                                    // settings related
-	ErrorTypeBinder                                      // binder related
-	ErrorTypeNetwork                                     // network related
-	ErrorTypeOptimizer                                   // optimizer related
-	ErrorTypeNullPointer                                 // nullptr exception
-	ErrorTypeIO                                          // IO exception
-	ErrorTypeInterrupt                                   // interrupt
-	ErrorTypeFatal                                       // Fatal exceptions are non-recoverable, and render the entire DB in an unusable state
-	ErrorTypeInternal                                    // Internal exceptions indicate something went wrong internally (i.e. bug in the code base)
-	ErrorTypeInvalidInput                                // Input or arguments error
-	ErrorTypeOutOfMemory                                 // out of memory
-	ErrorTypePermission                                  // insufficient permissions
-	ErrorTypeParameterNotResolved                        // parameter types could not be resolved
-	ErrorTypeParameterNotAllowed                         // parameter types not allowed
-	ErrorTypeDependency                                  // dependency
+	ErrorTypeInvalid              ErrorType = iota // invalid type
+	ErrorTypeOutOfRange                            // value out of range error
+	ErrorTypeConversion                            // conversion/casting error
+	ErrorTypeUnknownType                           // unknown type error
+	ErrorTypeDecimal                               // decimal related
+	ErrorTypeMismatchType                          // type mismatch
+	ErrorTypeDivideByZero                          // divide by 0
+	ErrorTypeObjectSize                            // object size exceeded
+	ErrorTypeInvalidType                           // incompatible for operation
+	ErrorTypeSerialization                         // serialization
+	ErrorTypeTransaction                           // transaction management
+	ErrorTypeNotImplemented                        // method not implemented
+	ErrorTypeExpression                            // expression parsing
+	ErrorTypeCatalog                               // catalog related
+	ErrorTypeParser                                // parser related
+	ErrorTypePlanner                               // planner related
+	ErrorTypeScheduler                             // scheduler related
+	ErrorTypeExecutor                              // executor related
+	ErrorTypeConstraint                            // constraint related
+	ErrorTypeIndex                                 // index related
+	ErrorTypeStat                                  // stat related
+	ErrorTypeConnection                            // connection related
+	ErrorTypeSyntax                                // syntax related
+	ErrorTypeSettings                              // settings related
+	ErrorTypeBinder                                // binder related
+	ErrorTypeNetwork                               // network related
+	ErrorTypeOptimizer                             // optimizer related
+	ErrorTypeNullPointer                           // nullptr exception
+	ErrorTypeIO                                    // IO exception
+	ErrorTypeInterrupt                             // interrupt
+	ErrorTypeFatal                                 // Fatal exceptions are non-recoverable, and render the entire DB in an unusable state
+	ErrorTypeInternal                              // Internal exceptions indicate something went wrong internally (i.e. bug in the code base)
+	ErrorTypeInvalidInput                          // Input or arguments error
+	ErrorTypeOutOfMemory                           // out of memory
+	ErrorTypePermission                            // insufficient permissions
+	ErrorTypeParameterNotResolved                  // parameter types could not be resolved
+	ErrorTypeParameterNotAllowed                   // parameter types not allowed
+	ErrorTypeDependency                            // dependency
 	ErrorTypeHTTP
 	ErrorTypeMissingExtension // Thrown when an extension is used but not loaded
 	ErrorTypeAutoLoad         // Thrown when an extension is used but not loaded
 	ErrorTypeSequence
 )
 
-var errorPrefixMap = map[string]DuckDBErrorType{
+var errorPrefixMap = map[string]ErrorType{
 	"Invalid Error":                ErrorTypeInvalid,
 	"Out of Range Error":           ErrorTypeOutOfRange,
 	"Conversion Error":             ErrorTypeConversion,
@@ -172,18 +172,18 @@ var errorPrefixMap = map[string]DuckDBErrorType{
 	"Sequence Error":               ErrorTypeSequence,
 }
 
-type DuckDBError struct {
-	Type DuckDBErrorType
+type Error struct {
+	Type ErrorType
 	Msg  string
 }
 
-func (de *DuckDBError) Error() string {
-	return de.Msg
+func (e *Error) Error() string {
+	return e.Msg
 }
 
-func (de *DuckDBError) Is(err error) bool {
-	if derr, ok := err.(*DuckDBError); ok {
-		return derr.Msg == de.Msg
+func (e *Error) Is(err error) bool {
+	if other, ok := err.(*Error); ok {
+		return other.Msg == e.Msg
 	}
 	return false
 }
@@ -196,7 +196,7 @@ func getDuckDBError(errMsg string) error {
 			errType = typ
 		}
 	}
-	return &DuckDBError{
+	return &Error{
 		Type: errType,
 		Msg:  errMsg,
 	}

--- a/errors_test.go
+++ b/errors_test.go
@@ -310,7 +310,7 @@ func TestDuckDBErrors(t *testing.T) {
 
 	testCases := []struct {
 		tpl    string
-		errTyp DuckDBErrorType
+		errTyp ErrorType
 	}{
 		{
 			tpl:    "SELECT * FROM not_exist WHERE baz=0",
@@ -347,7 +347,7 @@ func TestDuckDBErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		_, err := db.Exec(tc.tpl)
-		de, ok := err.(*DuckDBError)
+		de, ok := err.(*Error)
 		if !ok {
 			require.Fail(t, "error type is not DuckDBError", "tql: %s\ngot: %#v", tc.tpl, err)
 		}
@@ -357,7 +357,7 @@ func TestDuckDBErrors(t *testing.T) {
 
 func TestGetDuckDBError(t *testing.T) {
 	// only for the corner cases
-	testCases := []*DuckDBError{
+	testCases := []*Error{
 		{
 			Msg:  "",
 			Type: ErrorTypeInvalid,
@@ -382,7 +382,7 @@ func TestGetDuckDBError(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		err := getDuckDBError(tc.Msg).(*DuckDBError)
+		err := getDuckDBError(tc.Msg).(*Error)
 		require.Equal(t, tc, err)
 	}
 }

--- a/statement_test.go
+++ b/statement_test.go
@@ -83,7 +83,7 @@ func TestPrepareWithError(t *testing.T) {
 	for _, tc := range testCases {
 		stmt, err := db.Prepare(tc.tpl)
 		if err != nil {
-			if _, ok := err.(*DuckDBError); !ok {
+			if _, ok := err.(*Error); !ok {
 				require.Fail(t, "error type is not DuckDBError")
 			}
 			require.ErrorContains(t, err, tc.err)


### PR DESCRIPTION
Follow-up to https://github.com/marcboeker/go-duckdb/pull/239. This is a small, breaking change to the exported name.

@apocelipes, these changes make the new error type less verbose outside the package and generalize possible error types. For example, instead of `duckdb.DuckDBError`, it'll read `duckdb.Error`.