### PR TITLE
Cache the validity mask, data pointers, and the chunk size

### DIFF
--- a/appender.go
+++ b/appender.go
@@ -139,7 +139,7 @@ func (a *Appender) AppendRow(args ...driver.Value) error {
 
 func (a *Appender) addDataChunk() error {
 	var chunk DataChunk
-	if err := chunk.initFromTypes(a.ptr, a.types); err != nil {
+	if err := chunk.initFromTypes(a.ptr, a.types, true); err != nil {
 		return err
 	}
 	a.chunks = append(a.chunks, chunk)

--- a/errors_test.go
+++ b/errors_test.go
@@ -407,6 +407,7 @@ type wrappedDuckDBError struct {
 func (w *wrappedDuckDBError) Error() string {
 	return w.e.Error()
 }
+
 func (w *wrappedDuckDBError) Unwrap() error {
 	return w.e
 }

--- a/rows.go
+++ b/rows.go
@@ -55,13 +55,13 @@ func (r *rows) Columns() []string {
 }
 
 func (r *rows) Next(dst []driver.Value) error {
-	for r.rowCount == r.chunk.GetSize() {
+	for r.rowCount == r.chunk.size {
 		r.chunk.close()
 		if r.chunkIdx == r.chunkCount {
 			return io.EOF
 		}
 		data := C.duckdb_result_get_chunk(r.res, r.chunkIdx)
-		if err := r.chunk.initFromDuckDataChunk(data); err != nil {
+		if err := r.chunk.initFromDuckDataChunk(data, false); err != nil {
 			return getError(err, nil)
 		}
 

--- a/vector_setters.go
+++ b/vector_setters.go
@@ -19,9 +19,7 @@ const secondsPerDay = 24 * 60 * 60
 type fnSetVectorValue func(vec *vector, rowIdx C.idx_t, val any)
 
 func (vec *vector) setNull(rowIdx C.idx_t) {
-	C.duckdb_vector_ensure_validity_writable(vec.duckdbVector)
-	mask := C.duckdb_vector_get_validity(vec.duckdbVector)
-	C.duckdb_validity_set_row_invalid(mask, rowIdx)
+	C.duckdb_validity_set_row_invalid(vec.mask, rowIdx)
 
 	if vec.duckdbType == C.DUCKDB_TYPE_STRUCT {
 		for i := 0; i < len(vec.childVectors); i++ {
@@ -31,8 +29,7 @@ func (vec *vector) setNull(rowIdx C.idx_t) {
 }
 
 func setPrimitive[T any](vec *vector, rowIdx C.idx_t, v T) {
-	ptr := C.duckdb_vector_get_data(vec.duckdbVector)
-	xs := (*[1 << 31]T)(ptr)
+	xs := (*[1 << 31]T)(vec.ptr)
 	xs[rowIdx] = v
 }
 


### PR DESCRIPTION
Fixes #253.

Significant performance improvement for scans.

Scan benchmark.
- `CREATE TABLE tbl (col1 STRUCT(value INTEGER));`
- Fill the table with 1M mock values.
- We see huge improvements both for scanning nested data, and for scanning the integer directly.

PR timings.
```
SELECT col1.value FROM stress2.main.table2, took 32.725833ms
SELECT col1 FROM stress2.main.table2, took 192.932708ms
SELECT * FROM stress2.main.table2, took 198.002875ms

Additionally, the included benchmark for all types improved slightly.
BenchmarkTypes-10    	       5	 248644567 ns/op
```

Before.
```
SELECT col1.value FROM stress2.main.table2, took 236.263375ms
SELECT col1 FROM stress2.main.table2, took 466.651625ms
SELECT * FROM stress2.main.table2, took 460.474834ms

BenchmarkTypes-10    	       4	 286125906 ns/op
```