### PR TITLE
GitHub workflow actions: automated version check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  # Enable version updates for GitHub action workflows
+  - package-ecosystem: github-actions
+    directory: /
+    # Check for updates to GitHub Actions every weekday
+    schedule:
+      interval: daily
+      time: 19:00
+    open-pull-requests-limit: 10


### PR DESCRIPTION
GitHub workflow actions got outdated in the past (#259) .
In order to prevent this from happening again, this PR adds automated version check for GitHub workflow actions of this repo.
I hope you like it. Automated check can be enabled for Go dependencies, too (if wanted).