### PR TITLE
Enable automated version check for go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,5 +6,13 @@ updates:
     # Check for updates to GitHub Actions every weekday
     schedule:
       interval: daily
-      time: 19:00
+      time: "19:00"
+    open-pull-requests-limit: 10
+  # Enable version updates for Go modules
+  - package-ecosystem: gomod
+    directory: /
+    # Check for updates to GitHub Actions every weekday
+    schedule:
+      interval: daily
+      time: "20:00"
     open-pull-requests-limit: 10


### PR DESCRIPTION
This PR adds automated version check for Go modules, as proposed and confirmed [here](https://github.com/marcboeker/go-duckdb/pull/260).