### PR TITLE
add DUCKDB_INVALID_CONFIGURATION to duckdb.Error

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -125,6 +125,7 @@ const (
 	ErrorTypeMissingExtension // Thrown when an extension is used but not loaded
 	ErrorTypeAutoLoad         // Thrown when an extension is used but not loaded
 	ErrorTypeSequence
+	ErrorTypeInvalidConfiguration // An invalid configuration was detected (e.g. a Secret param was missing, or a required setting not found)
 )
 
 var errorPrefixMap = map[string]ErrorType{
@@ -170,6 +171,7 @@ var errorPrefixMap = map[string]ErrorType{
 	"Missing Extension Error":      ErrorTypeMissingExtension,
 	"Extension Autoloading Error":  ErrorTypeAutoLoad,
 	"Sequence Error":               ErrorTypeSequence,
+	"Invalid Configuration Error":  ErrorTypeInvalidConfiguration,
 }
 
 type Error struct {

--- a/errors_test.go
+++ b/errors_test.go
@@ -383,7 +383,7 @@ func TestGetDuckDBError(t *testing.T) {
 			Msg:  "Error: xxx",
 			Type: ErrorTypeUnknownType,
 		},
-		// next two for the prefix testing
+		// next 3 cases for the prefix testing
 		{
 			Msg:  "Invalid Error: xxx",
 			Type: ErrorTypeInvalid,
@@ -391,6 +391,10 @@ func TestGetDuckDBError(t *testing.T) {
 		{
 			Msg:  "Invalid Input Error: xxx",
 			Type: ErrorTypeInvalidInput,
+		},
+		{
+			Msg:  "Invalid Configuration Error: xxx",
+			Type: ErrorTypeInvalidConfiguration,
 		},
 	}
 


### PR DESCRIPTION
DuckDB 1.1.0 added a new error "DUCKDB_INVALID_CONFIGURATION". This PR add it to the `duckdb.Error`.