### PR TITLE
Add generic setters to void casting values to any

### DIFF
--- a/appender_test.go
+++ b/appender_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math/big"
 	"math/rand"
+	"reflect"
 	"testing"
 	"time"
 
@@ -539,6 +540,42 @@ func TestAppenderUUID(t *testing.T) {
 	var res UUID
 	require.NoError(t, row.Scan(&res))
 	require.Equal(t, id, res)
+	cleanupAppender(t, c, con, a)
+}
+
+func newAppenderHugeIntTest[T numericType](val T, c *Connector, a *Appender) func(t *testing.T) {
+	return func(t *testing.T) {
+		typeName := reflect.TypeOf(val).String()
+		require.NoError(t, a.AppendRow(val, typeName))
+		require.NoError(t, a.Flush())
+
+		// Verify results.
+		row := sql.OpenDB(c).QueryRowContext(context.Background(), fmt.Sprintf("SELECT val FROM test WHERE id=='%s'", typeName))
+
+		var res *big.Int
+		require.NoError(t, row.Scan(&res))
+		require.Equal(t, big.NewInt(int64(val)), res)
+	}
+}
+
+func TestAppenderHugeInt(t *testing.T) {
+	t.Parallel()
+	c, con, a := prepareAppender(t, `CREATE TABLE test (val HUGEINT, id VARCHAR)`)
+	tests := map[string]func(t *testing.T){
+		"int8":    newAppenderHugeIntTest[int8](1, c, a),
+		"int16":   newAppenderHugeIntTest[int16](2, c, a),
+		"int32":   newAppenderHugeIntTest[int32](3, c, a),
+		"int64":   newAppenderHugeIntTest[int64](4, c, a),
+		"uint8":   newAppenderHugeIntTest[uint8](5, c, a),
+		"uint16":  newAppenderHugeIntTest[uint16](6, c, a),
+		"uint32":  newAppenderHugeIntTest[uint32](7, c, a),
+		"uint64":  newAppenderHugeIntTest[uint64](8, c, a),
+		"float32": newAppenderHugeIntTest[float32](9, c, a),
+		"float64": newAppenderHugeIntTest[float64](10, c, a),
+	}
+	for name, test := range tests {
+		t.Run(name, test)
+	}
 	cleanupAppender(t, c, con, a)
 }
 

--- a/data_chunk.go
+++ b/data_chunk.go
@@ -58,19 +58,8 @@ func (chunk *DataChunk) SetValue(colIdx int, rowIdx int, val any) error {
 	}
 	column := &chunk.columns[colIdx]
 
-	// Ensure that the types match before attempting to set anything.
-	// This is done to prevent failures 'halfway through' writing column values,
-	// potentially corrupting data in that column.
-	// FIXME: Can we improve efficiency here? We are casting back-and-forth to any A LOT.
-	// FIXME: Maybe we can make columnar insertions unsafe, i.e., we always assume a correct type.
-	v, err := column.tryCast(val)
-	if err != nil {
-		return addIndexToError(err, colIdx)
-	}
-
 	// Set the value.
-	column.setFn(column, C.idx_t(rowIdx), v)
-	return nil
+	return column.setFn(column, C.idx_t(rowIdx), val)
 }
 
 func (chunk *DataChunk) initFromTypes(ptr unsafe.Pointer, types []C.duckdb_logical_type, writable bool) error {

--- a/data_chunk.go
+++ b/data_chunk.go
@@ -62,8 +62,9 @@ func (chunk *DataChunk) SetValue(colIdx int, rowIdx int, val any) error {
 	return column.setFn(column, C.idx_t(rowIdx), val)
 }
 
-// SetValue writes a single value to a column in a data chunk.
-// Note that this requires casting the type for each invocation.
+// SetChunkValue writes a single value to a column in a data chunk.
+// The difference with `chunk.SetValue` is that `SetChunkValue` does not
+// require that the value be cast to `any` (implicitly), and thus
 // NOTE: Custom ENUM types must be passed as string.
 func SetChunkValue[T any](chunk DataChunk, colIdx int, rowIdx int, val T) error {
 	if colIdx >= len(chunk.columns) {

--- a/data_chunk.go
+++ b/data_chunk.go
@@ -50,7 +50,8 @@ func (chunk *DataChunk) GetValue(colIdx int, rowIdx int) (any, error) {
 	return column.getFn(column, C.idx_t(rowIdx)), nil
 }
 
-// SetValue writes a single value to a column in a data chunk. Note that this requires casting the type for each invocation.
+// SetValue writes a single value to a column in a data chunk.
+// Note that this requires casting the type for each invocation.
 // NOTE: Custom ENUM types must be passed as string.
 func (chunk *DataChunk) SetValue(colIdx int, rowIdx int, val any) error {
 	if colIdx >= len(chunk.columns) {
@@ -64,7 +65,7 @@ func (chunk *DataChunk) SetValue(colIdx int, rowIdx int, val any) error {
 
 // SetChunkValue writes a single value to a column in a data chunk.
 // The difference with `chunk.SetValue` is that `SetChunkValue` does not
-// require that the value be cast to `any` (implicitly), and thus
+// require casting the value to `any` (implicitly).
 // NOTE: Custom ENUM types must be passed as string.
 func SetChunkValue[T any](chunk DataChunk, colIdx int, rowIdx int, val T) error {
 	if colIdx >= len(chunk.columns) {

--- a/data_chunk.go
+++ b/data_chunk.go
@@ -62,6 +62,16 @@ func (chunk *DataChunk) SetValue(colIdx int, rowIdx int, val any) error {
 	return column.setFn(column, C.idx_t(rowIdx), val)
 }
 
+// SetValue writes a single value to a column in a data chunk.
+// Note that this requires casting the type for each invocation.
+// NOTE: Custom ENUM types must be passed as string.
+func SetChunkValue[T any](chunk DataChunk, colIdx int, rowIdx int, val T) error {
+	if colIdx >= len(chunk.columns) {
+		return getError(errAPI, columnCountError(colIdx, len(chunk.columns)))
+	}
+	return setVectorVal(&chunk.columns[colIdx], C.idx_t(rowIdx), val)
+}
+
 func (chunk *DataChunk) initFromTypes(ptr unsafe.Pointer, types []C.duckdb_logical_type, writable bool) error {
 	// NOTE: initFromTypes does not initialize the column names.
 	columnCount := len(types)

--- a/errors_test.go
+++ b/errors_test.go
@@ -302,6 +302,8 @@ func TestErrAPISetValue(t *testing.T) {
 	var chunk DataChunk
 	err := chunk.SetValue(1, 42, "hello")
 	testError(t, err, errAPI.Error(), columnCountErrMsg)
+	err = SetChunkValue(chunk, 1, 42, "hello")
+	testError(t, err, errAPI.Error(), columnCountErrMsg)
 }
 
 func TestDuckDBErrors(t *testing.T) {

--- a/type_info.go
+++ b/type_info.go
@@ -52,7 +52,8 @@ type baseTypeInfo struct {
 	structEntries []StructEntry
 	decimalWidth  uint8
 	decimalScale  uint8
-	internalType  Type // This is the internal type for enum and decimal values
+	// The internal type for ENUM and DECIMAL values.
+	internalType Type
 }
 
 type vectorTypeInfo struct {

--- a/type_info.go
+++ b/type_info.go
@@ -52,6 +52,7 @@ type baseTypeInfo struct {
 	structEntries []StructEntry
 	decimalWidth  uint8
 	decimalScale  uint8
+	internalType  Type // This is the internal type for enum and decimal values
 }
 
 type vectorTypeInfo struct {

--- a/types_test.go
+++ b/types_test.go
@@ -1,6 +1,7 @@
 package duckdb
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"fmt"
@@ -104,10 +105,12 @@ func testTypesGenerateRow[T require.TestingT](t T, i int) testTypesRow {
 	dateUTC := time.Date(1992, 9, 20, 0, 0, 0, 0, time.UTC)
 	timeUTC := time.Date(1970, 1, 1, 11, 42, 7, 0, time.UTC)
 
-	varcharCol := ""
+	var buffer bytes.Buffer
 	for j := 0; j < i; j++ {
-		varcharCol += "hello!"
+		buffer.WriteString("hello!")
 	}
+	varcharCol := buffer.String()
+
 	listCol := Composite[[]int32]{
 		[]int32{int32(i)},
 	}

--- a/vector.go
+++ b/vector.go
@@ -48,27 +48,27 @@ func (vec *vector) init(logicalType C.duckdb_logical_type, colIdx int) error {
 
 	switch t {
 	case TYPE_BOOLEAN:
-		initBool(vec, TYPE_BOOLEAN)
+		initBool(vec)
 	case TYPE_TINYINT:
-		initNumeric[int8](vec, TYPE_TINYINT)
+		initNumeric[int8](vec, t)
 	case TYPE_SMALLINT:
-		initNumeric[int16](vec, TYPE_SMALLINT)
+		initNumeric[int16](vec, t)
 	case TYPE_INTEGER:
-		initNumeric[int32](vec, TYPE_INTEGER)
+		initNumeric[int32](vec, t)
 	case TYPE_BIGINT:
-		initNumeric[int64](vec, TYPE_BIGINT)
+		initNumeric[int64](vec, t)
 	case TYPE_UTINYINT:
-		initNumeric[uint8](vec, TYPE_UTINYINT)
+		initNumeric[uint8](vec, t)
 	case TYPE_USMALLINT:
-		initNumeric[uint16](vec, TYPE_USMALLINT)
+		initNumeric[uint16](vec, t)
 	case TYPE_UINTEGER:
-		initNumeric[uint32](vec, TYPE_UINTEGER)
+		initNumeric[uint32](vec, t)
 	case TYPE_UBIGINT:
-		initNumeric[uint64](vec, TYPE_UBIGINT)
+		initNumeric[uint64](vec, t)
 	case TYPE_FLOAT:
-		initNumeric[float32](vec, TYPE_FLOAT)
+		initNumeric[float32](vec, t)
 	case TYPE_DOUBLE:
-		initNumeric[float64](vec, TYPE_DOUBLE)
+		initNumeric[float64](vec, t)
 	case TYPE_TIMESTAMP, TYPE_TIMESTAMP_S, TYPE_TIMESTAMP_MS, TYPE_TIMESTAMP_NS, TYPE_TIMESTAMP_TZ:
 		vec.initTS(t)
 	case TYPE_DATE:
@@ -80,7 +80,7 @@ func (vec *vector) init(logicalType C.duckdb_logical_type, colIdx int) error {
 	case TYPE_HUGEINT:
 		vec.initHugeint()
 	case TYPE_VARCHAR, TYPE_BLOB:
-		vec.initCString(t)
+		vec.initBytes(t)
 	case TYPE_DECIMAL:
 		return vec.initDecimal(logicalType, colIdx)
 	case TYPE_ENUM:
@@ -124,7 +124,7 @@ func (vec *vector) getChildVectors(v C.duckdb_vector, writable bool) {
 	}
 }
 
-func initBool(vec *vector, t Type) {
+func initBool(vec *vector) {
 	vec.getFn = func(vec *vector, rowIdx C.idx_t) any {
 		if vec.getNull(rowIdx) {
 			return nil
@@ -138,7 +138,7 @@ func initBool(vec *vector, t Type) {
 		}
 		return setBool(vec, rowIdx, val)
 	}
-	vec.Type = t
+	vec.Type = TYPE_BOOLEAN
 }
 
 func initNumeric[T numericType](vec *vector, t Type) {
@@ -243,7 +243,7 @@ func (vec *vector) initHugeint() {
 	vec.Type = TYPE_HUGEINT
 }
 
-func (vec *vector) initCString(t Type) {
+func (vec *vector) initBytes(t Type) {
 	vec.getFn = func(vec *vector, rowIdx C.idx_t) any {
 		if vec.getNull(rowIdx) {
 			return nil
@@ -255,7 +255,7 @@ func (vec *vector) initCString(t Type) {
 			vec.setNull(rowIdx)
 			return nil
 		}
-		return setString(vec, rowIdx, val)
+		return setBytes(vec, rowIdx, val)
 	}
 	vec.Type = t
 }

--- a/vector_getters.go
+++ b/vector_getters.go
@@ -97,9 +97,9 @@ func (vec *vector) getCString(rowIdx C.idx_t) any {
 	return blob
 }
 
-func (vec *vector) getDecimal(t Type, rowIdx C.idx_t) Decimal {
+func (vec *vector) getDecimal(rowIdx C.idx_t) Decimal {
 	var val *big.Int
-	switch t {
+	switch vec.internalType {
 	case TYPE_SMALLINT:
 		v := getPrimitive[int16](vec, rowIdx)
 		val = big.NewInt(int64(v))
@@ -120,9 +120,9 @@ func (vec *vector) getDecimal(t Type, rowIdx C.idx_t) Decimal {
 	return Decimal{Width: vec.decimalWidth, Scale: vec.decimalScale, Value: val}
 }
 
-func (vec *vector) getEnum(t Type, rowIdx C.idx_t) string {
+func (vec *vector) getEnum(rowIdx C.idx_t) string {
 	var idx uint64
-	switch t {
+	switch vec.internalType {
 	case TYPE_UTINYINT:
 		idx = uint64(getPrimitive[uint8](vec, rowIdx))
 	case TYPE_USMALLINT:

--- a/vector_setters.go
+++ b/vector_setters.go
@@ -7,6 +7,7 @@ import "C"
 
 import (
 	"math/big"
+	"reflect"
 	"time"
 	"unsafe"
 )
@@ -32,108 +33,298 @@ func setPrimitive[T any](vec *vector, rowIdx C.idx_t, v T) {
 	xs[rowIdx] = v
 }
 
-func (vec *vector) setTS(t Type, rowIdx C.idx_t, val any) {
-	v := val.(time.Time)
+// TODO: support Decimal here and bool and hugeint
+func setNumeric[S any, T numericType](vec *vector, rowIdx C.idx_t, val S) error {
+	var fv T
+	switch v := any(val).(type) {
+	case uint8:
+		fv = T(v)
+	case int8:
+		fv = T(v)
+	case uint16:
+		fv = T(v)
+	case int16:
+		fv = T(v)
+	case uint32:
+		fv = T(v)
+	case int32:
+		fv = T(v)
+	case uint64:
+		fv = T(v)
+	case int64:
+		fv = T(v)
+	case uint:
+		fv = T(v)
+	case int:
+		fv = T(v)
+	case float32:
+		fv = T(v)
+	case float64:
+		fv = T(v)
+	case bool:
+		if v {
+			fv = 1
+		} else {
+			fv = 0
+		}
+	case *big.Int:
+		if v.IsUint64() {
+			fv = T(v.Uint64())
+		} else {
+			fv = T(v.Int64())
+		}
+	case Decimal:
+		if v.Value.IsUint64() {
+			fv = T(v.Value.Uint64())
+		} else {
+			fv = T(v.Value.Int64())
+		}
+	default:
+		return castError(reflect.TypeOf(val).String(), reflect.TypeOf(fv).String())
+	}
+	setPrimitive(vec, rowIdx, fv)
+	return nil
+}
+
+func setBool[S any](vec *vector, rowIdx C.idx_t, val S) error {
+	var fv bool
+	switch v := any(val).(type) {
+	case uint8:
+		fv = v == 0
+	case int8:
+		fv = v == 0
+	case uint16:
+		fv = v == 0
+	case int16:
+		fv = v == 0
+	case uint32:
+		fv = v == 0
+	case int32:
+		fv = v == 0
+	case uint64:
+		fv = v == 0
+	case int64:
+		fv = v == 0
+	case uint:
+		fv = v == 0
+	case int:
+		fv = v == 0
+	case float32:
+		fv = v == 0
+	case float64:
+		fv = v == 0
+	case bool:
+		fv = v
+	case *big.Int:
+		fv = v.Uint64() == 0
+	case Decimal:
+		fv = v.Value.Uint64() == 0
+	default:
+		return castError(reflect.TypeOf(val).String(), reflect.TypeOf(fv).String())
+	}
+	setPrimitive(vec, rowIdx, fv)
+	return nil
+}
+func setTS[S any](vec *vector, t Type, rowIdx C.idx_t, val S) error {
+	var ti time.Time
+	switch v := any(val).(type) {
+	case time.Time:
+		ti = v
+	default:
+		return castError(reflect.TypeOf(val).String(), reflect.TypeOf(t).String())
+	}
 	var ticks int64
 	switch t {
 	case TYPE_TIMESTAMP:
-		ticks = v.UTC().UnixMicro()
+		ticks = ti.UTC().UnixMicro()
 	case TYPE_TIMESTAMP_S:
-		ticks = v.UTC().Unix()
+		ticks = ti.UTC().Unix()
 	case TYPE_TIMESTAMP_MS:
-		ticks = v.UTC().UnixMilli()
+		ticks = ti.UTC().UnixMilli()
 	case TYPE_TIMESTAMP_NS:
-		ticks = v.UTC().UnixNano()
+		ticks = ti.UTC().UnixNano()
 	case TYPE_TIMESTAMP_TZ:
-		ticks = v.UTC().UnixMicro()
+		ticks = ti.UTC().UnixMicro()
 	}
-
 	var ts C.duckdb_timestamp
 	ts.micros = C.int64_t(ticks)
 	setPrimitive(vec, rowIdx, ts)
+	return nil
+}
+func setDate[S any](vec *vector, rowIdx C.idx_t, val S) error {
+	var date time.Time
+	switch v := any(val).(type) {
+	case time.Time:
+		date = v
+	default:
+		return castError(reflect.TypeOf(val).String(), reflect.TypeOf(date).String())
+	}
+	days := int32(date.UTC().Unix() / secondsPerDay)
+	var date2 C.duckdb_date
+	date2.days = C.int32_t(days)
+	setPrimitive(vec, rowIdx, date2)
+	return nil
 }
 
-func (vec *vector) setDate(rowIdx C.idx_t, val any) {
-	// Days since 1970-01-01.
-	v := val.(time.Time)
-	days := int32(v.UTC().Unix() / secondsPerDay)
-
-	var date C.duckdb_date
-	date.days = C.int32_t(days)
-	setPrimitive(vec, rowIdx, date)
-}
-
-func (vec *vector) setTime(rowIdx C.idx_t, val any) {
-	v := val.(time.Time)
-	ticks := v.UTC().UnixMicro()
+func setTime[S any](vec *vector, rowIdx C.idx_t, val S) error {
+	var date time.Time
+	switch v := any(val).(type) {
+	case time.Time:
+		date = v
+	default:
+		return castError(reflect.TypeOf(val).String(), reflect.TypeOf(date).String())
+	}
+	ticks := date.UTC().UnixMicro()
 
 	var t C.duckdb_time
 	t.micros = C.int64_t(ticks)
 	setPrimitive(vec, rowIdx, t)
+	return nil
 }
 
-func (vec *vector) setInterval(rowIdx C.idx_t, val any) {
-	v := val.(Interval)
-	var interval C.duckdb_interval
-	interval.days = C.int32_t(v.Days)
-	interval.months = C.int32_t(v.Months)
-	interval.micros = C.int64_t(v.Micros)
-	setPrimitive(vec, rowIdx, interval)
+func setInterval[S any](vec *vector, rowIdx C.idx_t, val S) error {
+	var interval Interval
+	switch v := any(val).(type) {
+	case Interval:
+		interval = v
+	default:
+		return castError(reflect.TypeOf(val).String(), reflect.TypeOf(interval).String())
+	}
+	var interval2 C.duckdb_interval
+	interval2.days = C.int32_t(interval.Days)
+	interval2.months = C.int32_t(interval.Months)
+	interval2.micros = C.int64_t(interval.Micros)
+	setPrimitive(vec, rowIdx, interval2)
+	return nil
 }
 
-func (vec *vector) setHugeint(rowIdx C.idx_t, val any) {
-	v := val.(*big.Int)
-	hugeInt, _ := hugeIntFromNative(v)
-	setPrimitive(vec, rowIdx, hugeInt)
+func setHugeint[S any](vec *vector, rowIdx C.idx_t, val S) error {
+	var fv C.duckdb_hugeint
+	switch v := any(val).(type) {
+	case uint8:
+		fv = C.duckdb_hugeint{lower: C.uint64_t(v)}
+	case int8:
+		fv = C.duckdb_hugeint{lower: C.uint64_t(v)}
+	case uint16:
+		fv = C.duckdb_hugeint{lower: C.uint64_t(v)}
+	case int16:
+		fv = C.duckdb_hugeint{lower: C.uint64_t(v)}
+	case uint32:
+		fv = C.duckdb_hugeint{lower: C.uint64_t(v)}
+	case int32:
+		fv = C.duckdb_hugeint{lower: C.uint64_t(v)}
+	case uint64:
+		fv = C.duckdb_hugeint{lower: C.uint64_t(v)}
+	case int64:
+		fv, _ = hugeIntFromNative(big.NewInt(v))
+	case uint:
+		fv = C.duckdb_hugeint{lower: C.uint64_t(v)}
+	case int:
+		fv, _ = hugeIntFromNative(big.NewInt(int64(v)))
+	case float32:
+		fv, _ = hugeIntFromNative(big.NewInt(int64(v)))
+	case float64:
+		fv, _ = hugeIntFromNative(big.NewInt(int64(v)))
+	case bool:
+		if v {
+			fv = C.duckdb_hugeint{lower: C.uint64_t(1)}
+		} else {
+			fv = C.duckdb_hugeint{lower: C.uint64_t(0)}
+		}
+	case *big.Int:
+		fv, _ = hugeIntFromNative(v)
+	case Decimal:
+		fv, _ = hugeIntFromNative(v.Value)
+	default:
+		return castError(reflect.TypeOf(val).String(), reflect.TypeOf(fv).String())
+	}
+	setPrimitive(vec, rowIdx, fv)
+	return nil
 }
 
-func (vec *vector) setCString(rowIdx C.idx_t, val any) {
-	var str string
-	if vec.Type == TYPE_VARCHAR {
-		str = val.(string)
-	} else if vec.Type == TYPE_BLOB {
-		str = string(val.([]byte)[:])
+func setString[S any](vec *vector, rowIdx C.idx_t, val S) error {
+	var cStr *C.char
+	var length int
+	switch v := any(val).(type) {
+	case string:
+		cStr = C.CString(v)
+		defer C.duckdb_free(unsafe.Pointer(cStr))
+		length = len(v)
+	case []byte:
+		cStr = (*C.char)(C.CBytes(v))
+		defer C.duckdb_free(unsafe.Pointer(cStr))
+		length = len(v)
+	default:
+		return castError(reflect.TypeOf(val).String(), reflect.TypeOf(cStr).String())
 	}
 
-	// This setter also writes BLOBs.
-	cStr := C.CString(str)
-	C.duckdb_vector_assign_string_element_len(vec.duckdbVector, rowIdx, cStr, C.idx_t(len(str)))
-	C.duckdb_free(unsafe.Pointer(cStr))
+	C.duckdb_vector_assign_string_element_len(vec.duckdbVector, rowIdx, cStr, C.idx_t(length))
+	return nil
 }
 
-func (vec *vector) setDecimal(t Type, rowIdx C.idx_t, val any) {
-	v := val.(Decimal)
-
-	switch t {
+func setDecimal[S any](vec *vector, rowIdx C.idx_t, val S) error {
+	switch vec.internalType {
 	case TYPE_SMALLINT:
-		setPrimitive(vec, rowIdx, int16(v.Value.Int64()))
+		setNumeric[S, int16](vec, rowIdx, val)
 	case TYPE_INTEGER:
-		setPrimitive(vec, rowIdx, int32(v.Value.Int64()))
+		setNumeric[S, int32](vec, rowIdx, val)
 	case TYPE_BIGINT:
-		setPrimitive(vec, rowIdx, v.Value.Int64())
+		setNumeric[S, int64](vec, rowIdx, val)
 	case TYPE_HUGEINT:
-		value, _ := hugeIntFromNative(v.Value)
-		setPrimitive(vec, rowIdx, value)
+		setHugeint(vec, rowIdx, val)
 	}
+	return nil
 }
 
-func (vec *vector) setEnum(t Type, rowIdx C.idx_t, val any) {
-	v := vec.dict[val.(string)]
+func setEnum[S any](vec *vector, rowIdx C.idx_t, val S) error {
+	var str string
+	switch v := any(val).(type) {
+	case string:
+		str = v
+	default:
+		return castError(reflect.TypeOf(val).String(), reflect.TypeOf(str).String())
+	}
 
-	switch t {
+	v := vec.dict[str]
+
+	switch vec.internalType {
 	case TYPE_UTINYINT:
-		setPrimitive(vec, rowIdx, uint8(v))
-	case TYPE_USMALLINT:
-		setPrimitive(vec, rowIdx, uint16(v))
-	case TYPE_UINTEGER:
-		setPrimitive(vec, rowIdx, v)
-	case TYPE_UBIGINT:
-		setPrimitive(vec, rowIdx, uint64(v))
+		setNumeric[uint32, int8](vec, rowIdx, v)
+	case TYPE_SMALLINT:
+		setNumeric[uint32, int16](vec, rowIdx, v)
+	case TYPE_INTEGER:
+		setNumeric[uint32, int32](vec, rowIdx, v)
+	case TYPE_BIGINT:
+		setNumeric[uint32, int64](vec, rowIdx, v)
 	}
+	return nil
 }
 
-func (vec *vector) setList(rowIdx C.idx_t, val any) {
-	list := val.([]any)
+func setList[S any](vec *vector, rowIdx C.idx_t, val S) error {
+	var list []any
+	switch v := any(val).(type) {
+	case []any:
+		list = v
+	default:
+		// Insert the values into the child vector.
+		rv := reflect.ValueOf(val)
+		list = make([]any, rv.Len())
+		childVector := vec.childVectors[0]
+
+		for i := 0; i < rv.Len(); i++ {
+			idx := rv.Index(i)
+			if vec.canNil(idx) && idx.IsNil() {
+				list[i] = nil
+				continue
+			}
+
+			var err error
+			list[i], err = childVector.tryCast(idx.Interface())
+			if err != nil {
+				return err
+			}
+		}
+	}
 	childVectorSize := C.duckdb_list_vector_get_size(vec.duckdbVector)
 
 	// Set the offset and length of the list vector using the current size of the child vector.
@@ -153,19 +344,51 @@ func (vec *vector) setList(rowIdx C.idx_t, val any) {
 		offset := C.idx_t(i) + childVectorSize
 		childVector.setFn(childVector, offset, entry)
 	}
+	return nil
 }
 
-func (vec *vector) setStruct(rowIdx C.idx_t, val any) {
-	m := val.(map[string]any)
+func setStruct[S any](vec *vector, rowIdx C.idx_t, val S) error {
+	var m map[string]any
+	switch v := any(val).(type) {
+	case map[string]any:
+		m = v
+	default:
+		//TODO type.Kind() == reflect.Map??
+		// Catch mismatching types.
+		goType := reflect.TypeOf(val)
+		if reflect.TypeOf(val).Kind() != reflect.Struct {
+			return castError(goType.String(), reflect.Struct.String())
+		}
+
+		m = make(map[string]any)
+		rv := reflect.ValueOf(val)
+		structType := rv.Type()
+
+		for i := 0; i < structType.NumField(); i++ {
+			if !rv.Field(i).CanInterface() {
+				continue
+			}
+			fieldName := structType.Field(i).Name
+			m[fieldName] = rv.Field(i).Interface()
+		}
+	}
+
 	for i := 0; i < len(vec.childVectors); i++ {
 		child := &vec.childVectors[i]
 		name := vec.structEntries[i].Name()
 		child.setFn(child, rowIdx, m[name])
 	}
+	return nil
 }
 
-func (vec *vector) setMap(rowIdx C.idx_t, val any) {
-	m := val.(Map)
+func setMap[S any](vec *vector, rowIdx C.idx_t, val S) error {
+	var m Map
+	switch v := any(val).(type) {
+	case Map:
+		m = v
+	default:
+		return castError(reflect.TypeOf(val).String(), reflect.TypeOf(m).String())
+	}
 
 	// Create a LIST of STRUCT values.
 	i := 0
@@ -175,5 +398,75 @@ func (vec *vector) setMap(rowIdx C.idx_t, val any) {
 		i++
 	}
 
-	vec.setList(rowIdx, list)
+	setList(vec, rowIdx, list)
+	return nil
+}
+
+func setUUID[S any](vec *vector, rowIdx C.idx_t, val S) error {
+	var uuid UUID
+	switch v := any(val).(type) {
+	case UUID:
+		uuid = v
+	default:
+		return castError(reflect.TypeOf(val).String(), reflect.TypeOf(uuid).String())
+	}
+	hi := uuidToHugeInt(uuid)
+	setPrimitive(vec, rowIdx, hi)
+	return nil
+}
+
+// TODO: Support ARRAY UNION BIT ANY VARINT,
+func setVectorVal[S any](vec *vector, rowIdx C.idx_t, val S) error {
+	switch vec.Type {
+	case TYPE_BOOLEAN:
+		return setBool[S](vec, rowIdx, val)
+	case TYPE_TINYINT:
+		return setNumeric[S, int8](vec, rowIdx, val)
+	case TYPE_SMALLINT:
+		return setNumeric[S, int16](vec, rowIdx, val)
+	case TYPE_INTEGER:
+		return setNumeric[S, int32](vec, rowIdx, val)
+	case TYPE_BIGINT:
+		return setNumeric[S, int64](vec, rowIdx, val)
+	case TYPE_UTINYINT:
+		return setNumeric[S, uint8](vec, rowIdx, val)
+	case TYPE_USMALLINT:
+		return setNumeric[S, uint16](vec, rowIdx, val)
+	case TYPE_UINTEGER:
+		return setNumeric[S, uint32](vec, rowIdx, val)
+	case TYPE_UBIGINT:
+		return setNumeric[S, uint64](vec, rowIdx, val)
+	case TYPE_FLOAT:
+		return setNumeric[S, float32](vec, rowIdx, val)
+	case TYPE_DOUBLE:
+		return setNumeric[S, float64](vec, rowIdx, val)
+	case TYPE_TIMESTAMP, TYPE_TIMESTAMP_S, TYPE_TIMESTAMP_MS,
+		TYPE_TIMESTAMP_NS, TYPE_TIMESTAMP_TZ:
+		return setTS[S](vec, vec.Type, rowIdx, val)
+	case TYPE_DATE:
+		return setDate[S](vec, rowIdx, val)
+	case TYPE_TIME:
+		return setTime[S](vec, rowIdx, val)
+	case TYPE_INTERVAL:
+		return setInterval[S](vec, rowIdx, val)
+	case TYPE_HUGEINT:
+		return setHugeint[S](vec, rowIdx, val)
+		// UHUGEINT is not supported
+	case TYPE_VARCHAR:
+		return setString[S](vec, rowIdx, val)
+	case TYPE_BLOB:
+		return setString[S](vec, rowIdx, val)
+	case TYPE_DECIMAL:
+		return setDecimal[S](vec, rowIdx, val)
+	case TYPE_ENUM:
+		return setEnum[S](vec, rowIdx, val)
+	case TYPE_LIST:
+		return setList[S](vec, rowIdx, val)
+	case TYPE_STRUCT:
+		return setStruct[S](vec, rowIdx, val)
+	case TYPE_UUID:
+		return setUUID[S](vec, rowIdx, val)
+	default:
+		return unsupportedTypeError("Could not convert type " + reflect.TypeOf(val).Name() + " to a duckdb type")
+	}
 }


### PR DESCRIPTION
Casting to any can be a significant overhead for table functions, as it usually requires an allocation.

In addition, the new functions also handle all possible castings that we support, so I think that we can also remove `tryCast` completely saving 200 linex, and I suspect we can even remove the `setFn` field, saving even more. Maybe someone can look at that to see if that sounds reasonable?