### PR TITLE
feat: add support for duckdb_arrow_scan

### DIFF
--- a/arrow.go
+++ b/arrow.go
@@ -47,6 +47,14 @@ struct ArrowArray {
   void* private_data;
 };
 
+struct ArrowArrayStream {
+	void (*get_schema)(struct ArrowArrayStream*);
+	void (*get_next)(struct ArrowArrayStream*);
+	void (*get_last_error)(struct ArrowArrayStream*);
+	void (*release)(struct ArrowArrayStream*);
+	void* private_data;
+};
+
 #endif  // ARROW_C_DATA_INTERFACE
 */
 import "C"
@@ -238,4 +246,33 @@ func (a *Arrow) anyArgsToNamedArgs(args []any) []driver.NamedValue {
 	}
 
 	return argsToNamedArgs(values)
+}
+
+// RegisterView registers an Arrow record reader as a view with the given name in DuckDB.
+// The returned release function must be called to release the memory once the view is no longer needed.
+func (a *Arrow) RegisterView(reader array.RecordReader, name string) (release func(), err error) {
+	if a.c.closed {
+		panic("database/sql/driver: misuse of duckdb driver: RegisterArrowStream after Close")
+	}
+	// duckdb_state duckdb_arrow_scan(duckdb_connection connection, const char *table_name, duckdb_arrow_stream arrow);
+
+	stream := C.calloc(1, C.sizeof_struct_ArrowArrayStream)
+	release = func() {
+		C.free(stream)
+	}
+	cdata.ExportRecordReader(reader, (*cdata.CArrowArrayStream)(stream))
+
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	if state := C.duckdb_arrow_scan(
+		a.c.duckdbCon,
+		cName,
+		(C.duckdb_arrow_stream)(stream),
+	); state == C.DuckDBError {
+		release()
+		return nil, errors.New("duckdb_arrow_scan")
+	}
+
+	return release, nil
 }

--- a/arrow.go
+++ b/arrow.go
@@ -252,8 +252,9 @@ func (a *Arrow) anyArgsToNamedArgs(args []any) []driver.NamedValue {
 // The returned release function must be called to release the memory once the view is no longer needed.
 func (a *Arrow) RegisterView(reader array.RecordReader, name string) (release func(), err error) {
 	if a.c.closed {
-		panic("database/sql/driver: misuse of duckdb driver: RegisterArrowStream after Close")
+		panic("database/sql/driver: misuse of duckdb driver: RegisterView after Close")
 	}
+
 	// duckdb_state duckdb_arrow_scan(duckdb_connection connection, const char *table_name, duckdb_arrow_stream arrow);
 
 	stream := C.calloc(1, C.sizeof_struct_ArrowArrayStream)

--- a/arrow.go
+++ b/arrow.go
@@ -85,7 +85,7 @@ func NewArrowFromConn(driverConn driver.Conn) (*Arrow, error) {
 	}
 
 	if dbConn.closed {
-		panic("database/sql/driver: misuse of duckdb driver: Arrow after Close")
+		return nil, errClosedCon
 	}
 
 	return &Arrow{c: dbConn}, nil
@@ -95,7 +95,7 @@ func NewArrowFromConn(driverConn driver.Conn) (*Arrow, error) {
 // executed statement. Arguments are bound to the last statement.
 func (a *Arrow) QueryContext(ctx context.Context, query string, args ...any) (array.RecordReader, error) {
 	if a.c.closed {
-		panic("database/sql/driver: misuse of duckdb driver: Arrow.Query after Close")
+		return nil, errClosedCon
 	}
 
 	stmts, size, err := a.c.extractStmts(query)
@@ -218,7 +218,7 @@ func (a *Arrow) queryArrowArray(res *C.duckdb_arrow, sc *arrow.Schema) (arrow.Re
 
 func (a *Arrow) execute(s *stmt, args []driver.NamedValue) (*C.duckdb_arrow, error) {
 	if s.closed {
-		panic("database/sql/driver: misuse of duckdb driver: executeArrow after Close")
+		return nil, errClosedCon
 	}
 
 	if err := s.bind(args); err != nil {
@@ -252,7 +252,7 @@ func (a *Arrow) anyArgsToNamedArgs(args []any) []driver.NamedValue {
 // The returned release function must be called to release the memory once the view is no longer needed.
 func (a *Arrow) RegisterView(reader array.RecordReader, name string) (release func(), err error) {
 	if a.c.closed {
-		panic("database/sql/driver: misuse of duckdb driver: RegisterView after Close")
+		return nil, errClosedCon
 	}
 
 	// duckdb_state duckdb_arrow_scan(duckdb_connection connection, const char *table_name, duckdb_arrow_stream arrow);

--- a/arrow_test.go
+++ b/arrow_test.go
@@ -4,9 +4,13 @@ package duckdb
 
 import (
 	"context"
+	"database/sql"
 	"database/sql/driver"
 	"testing"
 
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
 	"github.com/stretchr/testify/require"
 )
 
@@ -110,6 +114,86 @@ func TestArrow(t *testing.T) {
 
 			_, err = ar.QueryContext(context.Background(), "SELECT bar")
 			require.Error(t, err)
+			return nil
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("register arrow stream", func(t *testing.T) {
+		err = conn.Raw(func(driverConn any) error {
+			conn, ok := driverConn.(driver.Conn)
+			require.True(t, ok)
+
+			ar, err := NewArrowFromConn(conn)
+			require.NoError(t, err)
+
+			pool := memory.NewGoAllocator()
+
+			schema := arrow.NewSchema(
+				[]arrow.Field{
+					{Name: "f1_i32", Type: arrow.PrimitiveTypes.Int32},
+					{Name: "f2_f64", Type: arrow.PrimitiveTypes.Float64},
+					{Name: "f3_str", Type: arrow.BinaryTypes.String},
+				},
+				nil,
+			)
+
+			b := array.NewRecordBuilder(pool, schema)
+			defer b.Release()
+
+			b.Field(0).(*array.Int32Builder).AppendValues([]int32{1, 2, 3, 4, 5, 6}, nil)
+			b.Field(0).(*array.Int32Builder).AppendValues([]int32{7, 8, 9, 10}, []bool{true, true, false, true})
+			b.Field(1).(*array.Float64Builder).AppendValues([]float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, nil)
+			b.Field(2).(*array.StringBuilder).AppendValues([]string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}, nil)
+
+			rec1 := b.NewRecord()
+			defer rec1.Release()
+
+			b.Field(0).(*array.Int32Builder).AppendValues([]int32{11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, nil)
+			b.Field(1).(*array.Float64Builder).AppendValues([]float64{11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, nil)
+			b.Field(2).(*array.StringBuilder).AppendValues([]string{"k", "l", "m", "n", "o", "p", "q", "r", "s", "t"}, nil)
+
+			rec2 := b.NewRecord()
+			defer rec2.Release()
+
+			tbl := array.NewTableFromRecords(schema, []arrow.Record{rec1, rec2})
+			defer tbl.Release()
+
+			tr := array.NewTableReader(tbl, 5)
+			defer tr.Release()
+
+			release, err := ar.RegisterView(tr, "arrow_table")
+			require.NoError(t, err)
+			defer release()
+
+			_, err = db.ExecContext(context.Background(), "CREATE TABLE dst AS SELECT * FROM arrow_table")
+			require.NoError(t, err)
+
+			// Query the table to verify the data
+			rows, err := db.QueryContext(context.Background(), "SELECT * FROM dst")
+			require.NoError(t, err)
+			defer rows.Close()
+
+			i := 0
+			for rows.Next() {
+				i++
+				var f1 sql.NullInt32
+				var f2 float64
+				var f3 string
+				err = rows.Scan(&f1, &f2, &f3)
+				require.NoError(t, err)
+
+				if i == 9 {
+					require.False(t, f1.Valid)
+				} else {
+					require.True(t, f1.Valid)
+					require.Equal(t, int32(i), f1.Int32)
+				}
+				require.Equal(t, float64(i), f2)
+				require.Equal(t, string(rune('a'+i-1)), f3)
+			}
+			require.NoError(t, rows.Err())
+
 			return nil
 		})
 		require.NoError(t, err)

--- a/arrow_test.go
+++ b/arrow_test.go
@@ -193,6 +193,7 @@ func TestArrow(t *testing.T) {
 				require.Equal(t, string(rune('a'+i-1)), f3)
 			}
 			require.NoError(t, rows.Err())
+			require.Equal(t, 20, i)
 
 			return nil
 		})

--- a/connection.go
+++ b/connection.go
@@ -141,7 +141,7 @@ func (c *conn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, e
 
 func (c *conn) Close() error {
 	if c.closed {
-		panic("database/sql/driver: misuse of duckdb driver: Close of already closed connection")
+		return errClosedCon
 	}
 	c.closed = true
 


### PR DESCRIPTION
This PR exposes the `duckdb_arrow_scan` C API to `go-duckdb` users, partially resolving issue #161.

My use case involves efficiently ingesting Arrow data into DuckDB. Without the feature implemented in this PR, the next best option is to use the `scan_arrow_ipc` function provided by the [DuckDB `arrow` extension](https://github.com/duckdb/arrow), which requires serializing an Arrow table into Arrow IPC buffers.