### PR TITLE
Add support for renaming struct fields

### DIFF
--- a/appender_test.go
+++ b/appender_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 type simpleStruct struct {
-	A int32
+	A int32 `db:"a"`
 	B string
 }
 
@@ -321,7 +321,7 @@ func TestAppenderNullStruct(t *testing.T) {
 	t.Parallel()
 	c, con, a := prepareAppender(t, `
 	CREATE TABLE test (
-		simple_struct STRUCT(A INT, B VARCHAR)
+		simple_struct STRUCT(a INT, B VARCHAR)
 	)`)
 
 	require.NoError(t, a.AppendRow(simpleStruct{1, "hello"}))
@@ -358,7 +358,7 @@ func TestAppenderNestedNullStruct(t *testing.T) {
 				Y STRUCT(
 					N VARCHAR,
 					M STRUCT(
-						A INT,
+						a INT,
 						B VARCHAR
 					)
 				)
@@ -773,19 +773,19 @@ const createNestedDataTableSQL = `
 		int_list INT[],
 		nested_int_list INT[][],
 		triple_nested_int_list INT[][][],
-		simple_struct STRUCT(A INT, B VARCHAR),
-		wrapped_struct STRUCT(N VARCHAR, M STRUCT(A INT, B VARCHAR)),
+		simple_struct STRUCT(a INT, B VARCHAR),
+		wrapped_struct STRUCT(N VARCHAR, M STRUCT(a INT, B VARCHAR)),
 		double_wrapped_struct STRUCT(
 			X VARCHAR,
 			Y STRUCT(
 				N VARCHAR,
 				M STRUCT(
-					A INT,
+					a INT,
 					B VARCHAR
 				)
 			)
 		),
-		struct_list STRUCT(A INT, B VARCHAR)[],
+		struct_list STRUCT(a INT, B VARCHAR)[],
 		struct_with_list STRUCT(L INT[]),
 		mix STRUCT(
 			A STRUCT(L VARCHAR[]),

--- a/appender_test.go
+++ b/appender_test.go
@@ -24,6 +24,11 @@ type simpleStruct struct {
 	B string
 }
 
+type duplicateKeyStruct struct {
+	A         int64 `db:"Duplicate"`
+	Duplicate int64
+}
+
 type wrappedSimpleStruct struct {
 	A string
 	B simpleStruct

--- a/errors_test.go
+++ b/errors_test.go
@@ -241,7 +241,7 @@ func TestErrAppendSimpleStruct(t *testing.T) {
 func TestErrAppendStruct(t *testing.T) {
 	c, con, a := prepareAppender(t, `
 		CREATE TABLE test (
-			mix STRUCT(A STRUCT(L VARCHAR[]), B STRUCT(L INT[])[])
+			mix STRUCT(a STRUCT(L VARCHAR[]), B STRUCT(L INT[])[])
 		)`)
 
 	err := a.AppendRow(simpleStruct{1, "hello"})
@@ -274,7 +274,7 @@ func TestErrAppendStructWithList(t *testing.T) {
 func TestErrAppendNestedStruct(t *testing.T) {
 	c, con, a := prepareAppender(t, `
 		CREATE TABLE test (
-			wrapped_simple_struct STRUCT(A VARCHAR, B STRUCT(A INT, B VARCHAR)),
+			wrapped_simple_struct STRUCT(a VARCHAR, B STRUCT(A INT, B VARCHAR)),
 		)`)
 
 	err := a.AppendRow(simpleStruct{1, "hello"})

--- a/errors_test.go
+++ b/errors_test.go
@@ -238,6 +238,17 @@ func TestErrAppendSimpleStruct(t *testing.T) {
 	cleanupAppender(t, c, con, a)
 }
 
+func TestErrAppendDuplicateStruct(t *testing.T) {
+	c, con, a := prepareAppender(t, `
+		CREATE TABLE test (
+			duplicate_struct STRUCT(Duplicate INT)
+		)`)
+
+	err := a.AppendRow(duplicateKeyStruct{1, 2})
+	testError(t, err, errAppenderAppendRow.Error(), duplicateNameErrMsg)
+	cleanupAppender(t, c, con, a)
+}
+
 func TestErrAppendStruct(t *testing.T) {
 	c, con, a := prepareAppender(t, `
 		CREATE TABLE test (

--- a/vector_setters.go
+++ b/vector_setters.go
@@ -353,6 +353,9 @@ func setStruct[S any](vec *vector, rowIdx C.idx_t, val S) error {
 			if name, ok := structType.Field(i).Tag.Lookup("db"); ok {
 				fieldName = name
 			}
+			if _, ok := m[fieldName]; ok {
+				return duplicateNameError(fieldName)
+			}
 			m[fieldName] = rv.Field(i).Interface()
 		}
 	}

--- a/vector_setters.go
+++ b/vector_setters.go
@@ -350,6 +350,9 @@ func setStruct[S any](vec *vector, rowIdx C.idx_t, val S) error {
 				continue
 			}
 			fieldName := structType.Field(i).Name
+			if name, ok := structType.Field(i).Tag.Lookup("db"); ok {
+				fieldName = name
+			}
 			m[fieldName] = rv.Field(i).Interface()
 		}
 	}


### PR DESCRIPTION
Add support for renaming struct fields by using the `db` struct tag.