### PR TITLE
Fix memory leak in prepared statements

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -176,11 +176,13 @@ func (c *conn) prepareStmts(ctx context.Context, query string) (*stmt, error) {
 		}
 
 		// Execute the statement without any arguments and ignore the result.
-		if _, err = prepared.ExecContext(ctx, nil); err != nil {
-			return nil, err
+		_, execErr := prepared.ExecContext(ctx, nil)
+		closeErr := prepared.Close()
+		if execErr != nil {
+			return nil, execErr
 		}
-		if err = prepared.Close(); err != nil {
-			return nil, err
+		if closeErr != nil {
+			return nil, closeErr
 		}
 	}
 	return c.prepareExtractedStmt(stmts, count-1)


### PR DESCRIPTION
This PR fixes a potential memory leak where a statement is not closed if `prepared.ExecContext` errors. 