### PR TITLE
add String() method to Decimal

### DIFF
--- a/types.go
+++ b/types.go
@@ -9,6 +9,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math/big"
+	"strings"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -128,6 +129,36 @@ func (d *Decimal) Float64() float64 {
 	value.Quo(value, factor)
 	f, _ := value.Float64()
 	return f
+}
+
+func (d *Decimal) String() string {
+	// Get the sign, and return early if zero
+	if d.Value.Sign() == 0 {
+		return "0"
+	}
+
+	// Remove the sign from the string integer value
+	var signStr string
+	scaleless := d.Value.String()
+	if d.Value.Sign() < 0 {
+		signStr = "-"
+		scaleless = scaleless[1:]
+	}
+
+	// Remove all zeros from the right side
+	zeroTrimmed := strings.TrimRightFunc(scaleless, func(r rune) bool { return r == '0' })
+	scale := int(d.Scale) - (len(scaleless) - len(zeroTrimmed))
+
+	// If the string is still bigger than the scale factor, output it without a decimal point
+	if scale <= 0 {
+		return signStr + zeroTrimmed + strings.Repeat("0", -1*scale)
+	}
+
+	// Pad a number with 0.0's if needed
+	if len(zeroTrimmed) <= scale {
+		return fmt.Sprintf("%s0.%s%s", signStr, strings.Repeat("0", scale-len(zeroTrimmed)), zeroTrimmed)
+	}
+	return signStr + zeroTrimmed[:len(zeroTrimmed)-scale] + "." + zeroTrimmed[len(zeroTrimmed)-scale:]
 }
 
 func (d *Decimal) toString() string {

--- a/types.go
+++ b/types.go
@@ -160,7 +160,3 @@ func (d *Decimal) String() string {
 	}
 	return signStr + zeroTrimmed[:len(zeroTrimmed)-scale] + "." + zeroTrimmed[len(zeroTrimmed)-scale:]
 }
-
-func (d *Decimal) toString() string {
-	return fmt.Sprintf("DECIMAL(%d,%d)", d.Width, d.Scale)
-}


### PR DESCRIPTION
Right now, `Decimal` only has a `Float64` method and an unused `toString()`, which returns just the data type.

The Float64 method is great, but like all floats, it can introduce errors because of how floats work.

Example:
```golang
	// This outputs: 0.008216620000000001
	// It should be: 0.00821662
	fmt.Println((&duckdb.Decimal{
		Width: 18,
		Scale: 8,
		Value: big.NewInt(821662),
	}).Float64())
```

This PR adds a Stinger method allowing a lossless and correct conversion from Decimal to a string.
