### PR TITLE
Expose conn and stmt [Part 1]

### DIFF
--- a/appender.go
+++ b/appender.go
@@ -13,7 +13,7 @@ import (
 
 // Appender holds the DuckDB appender. It allows efficient bulk loading into a DuckDB database.
 type Appender struct {
-	con            *conn
+	con            *Conn
 	schema         string
 	table          string
 	duckdbAppender C.duckdb_appender
@@ -31,7 +31,7 @@ type Appender struct {
 
 // NewAppenderFromConn returns a new Appender from a DuckDB driver connection.
 func NewAppenderFromConn(driverConn driver.Conn, schema, table string) (*Appender, error) {
-	con, ok := driverConn.(*conn)
+	con, ok := driverConn.(*Conn)
 	if !ok {
 		return nil, getError(errInvalidCon, nil)
 	}

--- a/arrow.go
+++ b/arrow.go
@@ -74,12 +74,12 @@ import (
 // Arrow exposes DuckDB Apache Arrow interface.
 // https://duckdb.org/docs/api/c/api#arrow-interface
 type Arrow struct {
-	c *conn
+	c *Conn
 }
 
 // NewArrowFromConn returns a new Arrow from a DuckDB driver connection.
 func NewArrowFromConn(driverConn driver.Conn) (*Arrow, error) {
-	dbConn, ok := driverConn.(*conn)
+	dbConn, ok := driverConn.(*Conn)
 	if !ok {
 		return nil, fmt.Errorf("not a duckdb driver connection")
 	}
@@ -216,7 +216,7 @@ func (a *Arrow) queryArrowArray(res *C.duckdb_arrow, sc *arrow.Schema) (arrow.Re
 	return rec, nil
 }
 
-func (a *Arrow) execute(s *stmt, args []driver.NamedValue) (*C.duckdb_arrow, error) {
+func (a *Arrow) execute(s *Stmt, args []driver.NamedValue) (*C.duckdb_arrow, error) {
 	if s.closed {
 		return nil, errClosedCon
 	}

--- a/duckdb.go
+++ b/duckdb.go
@@ -87,7 +87,7 @@ func (c *Connector) Connect(context.Context) (driver.Conn, error) {
 		return nil, getError(errConnect, nil)
 	}
 
-	con := &conn{duckdbCon: duckdbCon}
+	con := &Conn{duckdbCon: duckdbCon}
 
 	if c.connInitFn != nil {
 		if err := c.connInitFn(con); err != nil {

--- a/profiling.go
+++ b/profiling.go
@@ -26,7 +26,7 @@ type ProfilingInfo struct {
 func GetProfilingInfo(c *sql.Conn) (ProfilingInfo, error) {
 	info := ProfilingInfo{}
 	err := c.Raw(func(driverConn any) error {
-		con := driverConn.(*conn)
+		con := driverConn.(*Conn)
 		duckdbInfo := C.duckdb_get_profiling_info(con.duckdbCon)
 		if duckdbInfo == nil {
 			return getError(errProfilingInfoEmpty, nil)

--- a/rows.go
+++ b/rows.go
@@ -19,7 +19,7 @@ import (
 // rows is a helper struct for scanning a duckdb result.
 type rows struct {
 	// stmt is a pointer to the stmt of which we are scanning the result.
-	stmt *stmt
+	stmt *Stmt
 	// res is the result of stmt.
 	res C.duckdb_result
 	// chunk holds the currently active data chunk.
@@ -32,7 +32,7 @@ type rows struct {
 	rowCount int
 }
 
-func newRowsWithStmt(res C.duckdb_result, stmt *stmt) *rows {
+func newRowsWithStmt(res C.duckdb_result, stmt *Stmt) *rows {
 	columnCount := C.duckdb_column_count(&res)
 	r := rows{
 		res:        res,

--- a/scalarUDF.go
+++ b/scalarUDF.go
@@ -70,7 +70,7 @@ func RegisterScalarUDF(c *sql.Conn, name string, f ScalarFunc) error {
 
 	// Register the function on the underlying driver connection exposed by c.Raw.
 	err = c.Raw(func(driverConn any) error {
-		con := driverConn.(*conn)
+		con := driverConn.(*Conn)
 		state := C.duckdb_register_scalar_function(con.duckdbCon, function)
 		C.duckdb_destroy_scalar_function(&function)
 		if state == C.DuckDBError {
@@ -111,7 +111,7 @@ func RegisterScalarUDFSet(c *sql.Conn, name string, functions ...ScalarFunc) err
 
 	// Register the function set on the underlying driver connection exposed by c.Raw.
 	err := c.Raw(func(driverConn any) error {
-		con := driverConn.(*conn)
+		con := driverConn.(*Conn)
 		state := C.duckdb_register_scalar_function_set(con.duckdbCon, set)
 		C.duckdb_destroy_scalar_function_set(&set)
 		if state == C.DuckDBError {

--- a/statement.go
+++ b/statement.go
@@ -15,15 +15,18 @@ import (
 	"unsafe"
 )
 
-type stmt struct {
-	c                *conn
+// Stmt implements the driver.Stmt interface.
+type Stmt struct {
+	c                *Conn
 	stmt             *C.duckdb_prepared_statement
 	closeOnRowsClose bool
 	closed           bool
 	rows             bool
 }
 
-func (s *stmt) Close() error {
+// Close closes the statement.
+// It implements the driver.Stmt interface.
+func (s *Stmt) Close() error {
 	if s.rows {
 		panic("database/sql/driver: misuse of duckdb driver: Close with active Rows")
 	}
@@ -36,7 +39,9 @@ func (s *stmt) Close() error {
 	return nil
 }
 
-func (s *stmt) NumInput() int {
+// NumInput returns the number of placeholder parameters.
+// It implements the driver.Stmt interface.
+func (s *Stmt) NumInput() int {
 	if s.closed {
 		panic("database/sql/driver: misuse of duckdb driver: NumInput after Close")
 	}
@@ -44,7 +49,7 @@ func (s *stmt) NumInput() int {
 	return int(paramCount)
 }
 
-func (s *stmt) bind(args []driver.NamedValue) error {
+func (s *Stmt) bind(args []driver.NamedValue) error {
 	if s.NumInput() > len(args) {
 		return fmt.Errorf("incorrect argument count for command: have %d want %d", len(args), s.NumInput())
 	}
@@ -175,11 +180,13 @@ func (s *stmt) bind(args []driver.NamedValue) error {
 }
 
 // Deprecated: Use ExecContext instead.
-func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
+func (s *Stmt) Exec(args []driver.Value) (driver.Result, error) {
 	return s.ExecContext(context.Background(), argsToNamedArgs(args))
 }
 
-func (s *stmt) ExecContext(ctx context.Context, nargs []driver.NamedValue) (driver.Result, error) {
+// ExecContext executes a query that doesn't return rows, such as an INSERT or UPDATE.
+// It implements the driver.StmtExecContext interface.
+func (s *Stmt) ExecContext(ctx context.Context, nargs []driver.NamedValue) (driver.Result, error) {
 	res, err := s.execute(ctx, nargs)
 	if err != nil {
 		return nil, err
@@ -191,11 +198,13 @@ func (s *stmt) ExecContext(ctx context.Context, nargs []driver.NamedValue) (driv
 }
 
 // Deprecated: Use QueryContext instead.
-func (s *stmt) Query(args []driver.Value) (driver.Rows, error) {
+func (s *Stmt) Query(args []driver.Value) (driver.Rows, error) {
 	return s.QueryContext(context.Background(), argsToNamedArgs(args))
 }
 
-func (s *stmt) QueryContext(ctx context.Context, nargs []driver.NamedValue) (driver.Rows, error) {
+// QueryContext executes a query that may return rows, such as a SELECT.
+// It implements the driver.StmtQueryContext interface.
+func (s *Stmt) QueryContext(ctx context.Context, nargs []driver.NamedValue) (driver.Rows, error) {
 	res, err := s.execute(ctx, nargs)
 	if err != nil {
 		return nil, err
@@ -206,7 +215,7 @@ func (s *stmt) QueryContext(ctx context.Context, nargs []driver.NamedValue) (dri
 
 // This method executes the query in steps and checks if context is cancelled before executing each step.
 // It uses Pending Result Interface C APIs to achieve this. Reference - https://duckdb.org/docs/api/c/api#pending-result-interface
-func (s *stmt) execute(ctx context.Context, args []driver.NamedValue) (*C.duckdb_result, error) {
+func (s *Stmt) execute(ctx context.Context, args []driver.NamedValue) (*C.duckdb_result, error) {
 	if s.closed {
 		panic("database/sql/driver: misuse of duckdb driver: ExecContext or QueryContext after Close")
 	}

--- a/tableUDF.go
+++ b/tableUDF.go
@@ -472,7 +472,7 @@ func RegisterTableUDF[TFT TableFunction](c *sql.Conn, name string, f TFT) error 
 
 	// Register the function on the underlying driver connection exposed by c.Raw.
 	err := c.Raw(func(driverConn any) error {
-		con := driverConn.(*conn)
+		con := driverConn.(*Conn)
 		state := C.duckdb_register_table_function(con.duckdbCon, function)
 		C.duckdb_destroy_table_function(&function)
 		if state == C.DuckDBError {

--- a/transaction.go
+++ b/transaction.go
@@ -3,7 +3,7 @@ package duckdb
 import "context"
 
 type tx struct {
-	c *conn
+	c *Conn
 }
 
 func (t *tx) Commit() error {


### PR DESCRIPTION
This PR is Part 1 of #310. It renames `conn` to `Conn` and `stmt` to `Stmt`. Additionally, comments have been added for all public methods. No other changes are included.