### PR TITLE
Expose statement type, parameter type, and parameter name

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -38,6 +38,10 @@ func columnCountError(actual int, expected int) error {
 	return fmt.Errorf("%s: expected %d, got %d", columnCountErrMsg, expected, actual)
 }
 
+func paramIndexError(idx int, max uint64) error {
+	return fmt.Errorf("%s: %d is out of range [1, %d]", paramIndexErrMsg, idx, max)
+}
+
 func unsupportedTypeError(name string) error {
 	return fmt.Errorf("%s: %s", unsupportedTypeErrMsg, name)
 }
@@ -80,6 +84,7 @@ const (
 	unknownTypeErrMsg      = "unknown type"
 	interfaceIsNilErrMsg   = "interface is nil"
 	duplicateNameErrMsg    = "duplicate name"
+	paramIndexErrMsg       = "invalid parameter index"
 )
 
 var (
@@ -94,6 +99,9 @@ var (
 
 	errInvalidCon = errors.New("not a DuckDB driver connection")
 	errClosedCon  = errors.New("closed connection")
+
+	errClosedStmt        = errors.New("closed statement")
+	errUninitializedStmt = errors.New("uninitialized statement")
 
 	errPrepare                    = errors.New("could not prepare query")
 	errMissingPrepareContext      = errors.New("missing context for multi-statement query: try using PrepareContext")

--- a/statement.go
+++ b/statement.go
@@ -15,6 +15,39 @@ import (
 	"unsafe"
 )
 
+type StmtType C.duckdb_statement_type
+
+const (
+	DUCKDB_STATEMENT_TYPE_INVALID      StmtType = C.DUCKDB_STATEMENT_TYPE_INVALID
+	DUCKDB_STATEMENT_TYPE_SELECT       StmtType = C.DUCKDB_STATEMENT_TYPE_SELECT
+	DUCKDB_STATEMENT_TYPE_INSERT       StmtType = C.DUCKDB_STATEMENT_TYPE_INSERT
+	DUCKDB_STATEMENT_TYPE_UPDATE       StmtType = C.DUCKDB_STATEMENT_TYPE_UPDATE
+	DUCKDB_STATEMENT_TYPE_EXPLAIN      StmtType = C.DUCKDB_STATEMENT_TYPE_EXPLAIN
+	DUCKDB_STATEMENT_TYPE_DELETE       StmtType = C.DUCKDB_STATEMENT_TYPE_DELETE
+	DUCKDB_STATEMENT_TYPE_PREPARE      StmtType = C.DUCKDB_STATEMENT_TYPE_PREPARE
+	DUCKDB_STATEMENT_TYPE_CREATE       StmtType = C.DUCKDB_STATEMENT_TYPE_CREATE
+	DUCKDB_STATEMENT_TYPE_EXECUTE      StmtType = C.DUCKDB_STATEMENT_TYPE_EXECUTE
+	DUCKDB_STATEMENT_TYPE_ALTER        StmtType = C.DUCKDB_STATEMENT_TYPE_ALTER
+	DUCKDB_STATEMENT_TYPE_TRANSACTION  StmtType = C.DUCKDB_STATEMENT_TYPE_TRANSACTION
+	DUCKDB_STATEMENT_TYPE_COPY         StmtType = C.DUCKDB_STATEMENT_TYPE_COPY
+	DUCKDB_STATEMENT_TYPE_ANALYZE      StmtType = C.DUCKDB_STATEMENT_TYPE_ANALYZE
+	DUCKDB_STATEMENT_TYPE_VARIABLE_SET StmtType = C.DUCKDB_STATEMENT_TYPE_VARIABLE_SET
+	DUCKDB_STATEMENT_TYPE_CREATE_FUNC  StmtType = C.DUCKDB_STATEMENT_TYPE_CREATE_FUNC
+	DUCKDB_STATEMENT_TYPE_DROP         StmtType = C.DUCKDB_STATEMENT_TYPE_DROP
+	DUCKDB_STATEMENT_TYPE_EXPORT       StmtType = C.DUCKDB_STATEMENT_TYPE_EXPORT
+	DUCKDB_STATEMENT_TYPE_PRAGMA       StmtType = C.DUCKDB_STATEMENT_TYPE_PRAGMA
+	DUCKDB_STATEMENT_TYPE_VACUUM       StmtType = C.DUCKDB_STATEMENT_TYPE_VACUUM
+	DUCKDB_STATEMENT_TYPE_CALL         StmtType = C.DUCKDB_STATEMENT_TYPE_CALL
+	DUCKDB_STATEMENT_TYPE_SET          StmtType = C.DUCKDB_STATEMENT_TYPE_SET
+	DUCKDB_STATEMENT_TYPE_LOAD         StmtType = C.DUCKDB_STATEMENT_TYPE_LOAD
+	DUCKDB_STATEMENT_TYPE_RELATION     StmtType = C.DUCKDB_STATEMENT_TYPE_RELATION
+	DUCKDB_STATEMENT_TYPE_EXTENSION    StmtType = C.DUCKDB_STATEMENT_TYPE_EXTENSION
+	DUCKDB_STATEMENT_TYPE_LOGICAL_PLAN StmtType = C.DUCKDB_STATEMENT_TYPE_LOGICAL_PLAN
+	DUCKDB_STATEMENT_TYPE_ATTACH       StmtType = C.DUCKDB_STATEMENT_TYPE_ATTACH
+	DUCKDB_STATEMENT_TYPE_DETACH       StmtType = C.DUCKDB_STATEMENT_TYPE_DETACH
+	DUCKDB_STATEMENT_TYPE_MULTI        StmtType = C.DUCKDB_STATEMENT_TYPE_MULTI
+)
+
 // Stmt implements the driver.Stmt interface.
 type Stmt struct {
 	c                *Conn
@@ -47,6 +80,55 @@ func (s *Stmt) NumInput() int {
 	}
 	paramCount := C.duckdb_nparams(*s.stmt)
 	return int(paramCount)
+}
+
+// ParamName returns the name of the parameter at the given index (1-based).
+func (s *Stmt) ParamName(n int) (string, error) {
+	if s.closed {
+		return "", errClosedStmt
+	}
+	if s.stmt == nil {
+		return "", errUninitializedStmt
+	}
+
+	paramCount := C.duckdb_nparams(*s.stmt)
+	if C.idx_t(n) == 0 || C.idx_t(n) > paramCount {
+		return "", paramIndexError(n, uint64(paramCount))
+	}
+
+	name := C.duckdb_parameter_name(*s.stmt, C.idx_t(n))
+	paramName := C.GoString(name)
+	C.duckdb_free(unsafe.Pointer(name))
+	return paramName, nil
+}
+
+// ParamType returns the expected type of the parameter at the given index (1-based).
+func (s *Stmt) ParamType(n int) (Type, error) {
+	if s.closed {
+		return TYPE_INVALID, errClosedStmt
+	}
+	if s.stmt == nil {
+		return TYPE_INVALID, errUninitializedStmt
+	}
+
+	paramCount := C.duckdb_nparams(*s.stmt)
+	if C.idx_t(n) == 0 || C.idx_t(n) > paramCount {
+		return TYPE_INVALID, paramIndexError(n, uint64(paramCount))
+	}
+
+	return Type(C.duckdb_param_type(*s.stmt, C.idx_t(n))), nil
+}
+
+// StatementType returns the type of the statement.
+func (s *Stmt) StatementType() (StmtType, error) {
+	if s.closed {
+		return DUCKDB_STATEMENT_TYPE_INVALID, errClosedStmt
+	}
+	if s.stmt == nil {
+		return DUCKDB_STATEMENT_TYPE_INVALID, errUninitializedStmt
+	}
+
+	return StmtType(C.duckdb_prepared_statement_type(*s.stmt)), nil
 }
 
 func (s *Stmt) bind(args []driver.NamedValue) error {

--- a/statement_test.go
+++ b/statement_test.go
@@ -32,6 +32,44 @@ func TestPrepareQuery(t *testing.T) {
 
 	require.NoError(t, res.Close())
 	require.NoError(t, prepared.Close())
+
+	// Access the raw connection & statement.
+	err = c.Raw(func(driverConn interface{}) error {
+		conn := driverConn.(*Conn)
+		s, err := conn.PrepareContext(context.Background(), `SELECT * FROM foo WHERE baz = ?`)
+		require.NoError(t, err)
+		stmt := s.(*Stmt)
+
+		stmtType, err := stmt.StatementType()
+		require.NoError(t, err)
+		require.Equal(t, DUCKDB_STATEMENT_TYPE_SELECT, stmtType)
+
+		paramType, err := stmt.ParamType(0)
+		require.ErrorContains(t, err, paramIndexErrMsg)
+		require.Equal(t, TYPE_INVALID, paramType)
+
+		paramType, err = stmt.ParamType(1)
+		require.NoError(t, err)
+		require.Equal(t, TYPE_INTEGER, paramType)
+
+		paramType, err = stmt.ParamType(2)
+		require.ErrorContains(t, err, paramIndexErrMsg)
+		require.Equal(t, TYPE_INVALID, paramType)
+
+		require.NoError(t, stmt.Close())
+
+		stmtType, err = stmt.StatementType()
+		require.ErrorIs(t, err, errClosedStmt)
+		require.Equal(t, DUCKDB_STATEMENT_TYPE_INVALID, stmtType)
+
+		paramType, err = stmt.ParamType(1)
+		require.ErrorIs(t, err, errClosedStmt)
+		require.Equal(t, TYPE_INVALID, paramType)
+
+		return nil
+	})
+	require.NoError(t, err)
+
 	require.NoError(t, c.Close())
 	require.NoError(t, db.Close())
 }
@@ -53,6 +91,79 @@ func TestPrepareQueryPositional(t *testing.T) {
 	require.Equal(t, 2, bar)
 
 	require.NoError(t, prepared.Close())
+
+	// Prepare on a connection.
+	c, err := db.Conn(context.Background())
+	require.NoError(t, err)
+
+	prepared, err = c.PrepareContext(context.Background(), `SELECT * FROM foo WHERE bar = $2 AND baz = $1`)
+	require.NoError(t, err)
+	res, err := prepared.Query(0, "hello")
+	require.NoError(t, err)
+	require.NoError(t, res.Close())
+	require.NoError(t, prepared.Close())
+
+	// Access the raw connection & statement.
+	err = c.Raw(func(driverConn interface{}) error {
+		conn := driverConn.(*Conn)
+		s, err := conn.PrepareContext(context.Background(), `UPDATE foo SET bar = $2 WHERE baz = $1`)
+		require.NoError(t, err)
+		stmt := s.(*Stmt)
+
+		stmtType, err := stmt.StatementType()
+		require.NoError(t, err)
+		require.Equal(t, DUCKDB_STATEMENT_TYPE_UPDATE, stmtType)
+
+		paramName, err := stmt.ParamName(0)
+		require.ErrorContains(t, err, paramIndexErrMsg)
+		require.Equal(t, "", paramName)
+
+		paramName, err = stmt.ParamName(1)
+		require.NoError(t, err)
+		require.Equal(t, "1", paramName)
+
+		paramName, err = stmt.ParamName(2)
+		require.NoError(t, err)
+		require.Equal(t, "2", paramName)
+
+		paramName, err = stmt.ParamName(3)
+		require.ErrorContains(t, err, paramIndexErrMsg)
+		require.Equal(t, "", paramName)
+
+		paramType, err := stmt.ParamType(0)
+		require.ErrorContains(t, err, paramIndexErrMsg)
+		require.Equal(t, TYPE_INVALID, paramType)
+
+		paramType, err = stmt.ParamType(1)
+		require.NoError(t, err)
+		require.Equal(t, TYPE_INTEGER, paramType)
+
+		paramType, err = stmt.ParamType(2)
+		require.NoError(t, err)
+		require.Equal(t, TYPE_VARCHAR, paramType)
+
+		paramType, err = stmt.ParamType(3)
+		require.ErrorContains(t, err, paramIndexErrMsg)
+		require.Equal(t, TYPE_INVALID, paramType)
+
+		require.NoError(t, stmt.Close())
+
+		stmtType, err = stmt.StatementType()
+		require.ErrorIs(t, err, errClosedStmt)
+		require.Equal(t, DUCKDB_STATEMENT_TYPE_INVALID, stmtType)
+
+		paramName, err = stmt.ParamName(1)
+		require.ErrorIs(t, err, errClosedStmt)
+		require.Equal(t, "", paramName)
+
+		paramType, err = stmt.ParamType(1)
+		require.ErrorIs(t, err, errClosedStmt)
+		require.Equal(t, TYPE_INVALID, paramType)
+
+		return nil
+	})
+	require.NoError(t, err)
+
 	require.NoError(t, db.Close())
 }
 
@@ -73,7 +184,102 @@ func TestPrepareQueryNamed(t *testing.T) {
 	require.Equal(t, 1, foo2)
 
 	require.NoError(t, prepared.Close())
+
+	// Prepare on a connection.
+	c, err := db.Conn(context.Background())
+	require.NoError(t, err)
+
+	prepared, err = c.PrepareContext(context.Background(), `SELECT * FROM foo WHERE bar = $bar AND baz = $baz`)
+	require.NoError(t, err)
+	res, err := prepared.Query(sql.Named("bar", "hello"), sql.Named("baz", 0))
+	require.NoError(t, err)
+	require.NoError(t, res.Close())
+	require.NoError(t, prepared.Close())
+
+	// Access the raw connection & statement.
+	err = c.Raw(func(driverConn interface{}) error {
+		conn := driverConn.(*Conn)
+		s, err := conn.PrepareContext(context.Background(), `INSERT INTO foo VALUES ($bar, $baz)`)
+		require.NoError(t, err)
+		stmt := s.(*Stmt)
+
+		stmtType, err := stmt.StatementType()
+		require.NoError(t, err)
+		require.Equal(t, DUCKDB_STATEMENT_TYPE_INSERT, stmtType)
+
+		paramName, err := stmt.ParamName(0)
+		require.ErrorContains(t, err, paramIndexErrMsg)
+		require.Equal(t, "", paramName)
+
+		paramName, err = stmt.ParamName(1)
+		require.NoError(t, err)
+		require.Equal(t, "bar", paramName)
+
+		paramName, err = stmt.ParamName(2)
+		require.NoError(t, err)
+		require.Equal(t, "baz", paramName)
+
+		paramName, err = stmt.ParamName(3)
+		require.ErrorContains(t, err, paramIndexErrMsg)
+		require.Equal(t, "", paramName)
+
+		paramType, err := stmt.ParamType(0)
+		require.ErrorContains(t, err, paramIndexErrMsg)
+		require.Equal(t, TYPE_INVALID, paramType)
+
+		paramType, err = stmt.ParamType(1)
+		// Will be fixed in the next release.
+		// https://github.com/duckdb/duckdb/pull/14952
+		// require.Equal(t, TYPE_VARCHAR, paramType)
+		require.Equal(t, TYPE_INVALID, paramType)
+		require.NoError(t, err)
+
+		paramType, err = stmt.ParamType(2)
+		// Will be fixed in the next release.
+		// https://github.com/duckdb/duckdb/pull/14952
+		// require.Equal(t, TYPE_INTEGER, paramType)
+		require.Equal(t, TYPE_INVALID, paramType)
+		require.NoError(t, err)
+
+		paramType, err = stmt.ParamType(3)
+		require.ErrorContains(t, err, paramIndexErrMsg)
+		require.Equal(t, TYPE_INVALID, paramType)
+
+		require.NoError(t, stmt.Close())
+
+		stmtType, err = stmt.StatementType()
+		require.ErrorIs(t, err, errClosedStmt)
+		require.Equal(t, DUCKDB_STATEMENT_TYPE_INVALID, stmtType)
+
+		paramName, err = stmt.ParamName(1)
+		require.ErrorIs(t, err, errClosedStmt)
+		require.Equal(t, "", paramName)
+
+		paramType, err = stmt.ParamType(1)
+		require.ErrorIs(t, err, errClosedStmt)
+		require.Equal(t, TYPE_INVALID, paramType)
+
+		return nil
+	})
+	require.NoError(t, err)
+
 	require.NoError(t, db.Close())
+}
+
+func TestUninitializedStmt(t *testing.T) {
+	stmt := &Stmt{}
+
+	stmtType, err := stmt.StatementType()
+	require.ErrorIs(t, err, errUninitializedStmt)
+	require.Equal(t, DUCKDB_STATEMENT_TYPE_INVALID, stmtType)
+
+	paramType, err := stmt.ParamType(1)
+	require.ErrorIs(t, err, errUninitializedStmt)
+	require.Equal(t, TYPE_INVALID, paramType)
+
+	paramName, err := stmt.ParamName(1)
+	require.ErrorIs(t, err, errUninitializedStmt)
+	require.Equal(t, "", paramName)
 }
 
 func TestPrepareWithError(t *testing.T) {


### PR DESCRIPTION
This PR is part 2 of #310. Based on the code review feedback for #310, error handling has been improved by checking for uninitialized `Stmt`, detecting out-of-bounds indices, and reporting closed statements.

@taniabogatsch 
