### PR TITLE
Fix UUID.Scan

### DIFF
--- a/types.go
+++ b/types.go
@@ -38,7 +38,7 @@ func (u *UUID) Scan(v any) error {
 		}
 		copy(u[:], id[:])
 	default:
-		return fmt.Errorf("invalid UUID type: %#v", val)
+		return fmt.Errorf("invalid UUID value type: %T", val)
 	}
 	return nil
 }

--- a/types.go
+++ b/types.go
@@ -7,10 +7,12 @@ import "C"
 
 import (
 	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"math/big"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -23,10 +25,38 @@ const uuid_length = 16
 type UUID [uuid_length]byte
 
 func (u *UUID) Scan(v any) error {
-	if n := copy(u[:], v.([]byte)); n != uuid_length {
-		return fmt.Errorf("invalid UUID length: %d", n)
+	switch val := v.(type) {
+	case []byte:
+		if len(val) != uuid_length {
+			return u.Scan(string(val))
+		}
+		copy(u[:], val[:])
+	case string:
+		id, err := uuid.Parse(val)
+		if err != nil {
+			return err
+		}
+		copy(u[:], id[:])
+	default:
+		return fmt.Errorf("invalid UUID type: %#v", val)
 	}
 	return nil
+}
+
+func (u *UUID) String() string {
+	buf := make([]byte, 36)
+
+	hex.Encode(buf, u[:4])
+	buf[8] = '-'
+	hex.Encode(buf[9:13], u[4:6])
+	buf[13] = '-'
+	hex.Encode(buf[14:18], u[6:8])
+	buf[18] = '-'
+	hex.Encode(buf[19:23], u[8:10])
+	buf[23] = '-'
+	hex.Encode(buf[24:], u[10:])
+
+	return string(buf)
 }
 
 // duckdb_hugeint is composed of (lower, upper) components.

--- a/types_test.go
+++ b/types_test.go
@@ -643,6 +643,16 @@ func TestUUID(t *testing.T) {
 
 		require.NoError(t, db.QueryRow(`SELECT ?::uuid`, test).Scan(&val))
 		require.Equal(t, test, val)
+
+		var u UUID
+		require.NoError(t, db.QueryRow(`SELECT uuid FROM uuid_test WHERE uuid = ?`, test).Scan(&u))
+		require.Equal(t, test.String(), u.String())
+
+		require.NoError(t, db.QueryRow(`SELECT ?`, test).Scan(&u))
+		require.Equal(t, test.String(), u.String())
+
+		require.NoError(t, db.QueryRow(`SELECT ?::uuid`, test).Scan(&u))
+		require.Equal(t, test.String(), u.String())
 	}
 
 	require.NoError(t, db.Close())

--- a/types_test.go
+++ b/types_test.go
@@ -658,6 +658,19 @@ func TestUUID(t *testing.T) {
 	require.NoError(t, db.Close())
 }
 
+func TestUUIDScanError(t *testing.T) {
+	t.Parallel()
+	db := openDB(t)
+
+	var u UUID
+	// invalid value type
+	require.Error(t, db.QueryRow(`SELECT 12345`).Scan(&u))
+	// string value not valid
+	require.Error(t, db.QueryRow(`SELECT 'I am not a UUID.'`).Scan(&u))
+	// blob value not valid
+	require.Error(t, db.QueryRow(`SELECT '123456789012345678901234567890123456'::BLOB`).Scan(&u))
+}
+
 func TestDate(t *testing.T) {
 	t.Parallel()
 	db := openDB(t)


### PR DESCRIPTION
Fix:
- db.QureyRow(`select 'urn:uuid:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'`).Scan(&uuid) panics, because the value type is string. The string value is a valid uuid text.
- db.QureyRow(`select more-than-16-bytes-and-invalid-blob`).Scan(&uuid), this should return an error, but it reports no error and creates a wrong uuid value.

Add a `String()` method to UUID, it encodes the uuid value to a string.