### PR TITLE
Test suite: code linting

### DIFF
--- a/appender_test.go
+++ b/appender_test.go
@@ -287,9 +287,9 @@ func TestAppenderNested(t *testing.T) {
 		require.Equal(t, rowsToAppend[i].intList, castList[int32](r.intList))
 
 		strRes := fmt.Sprintf("%v", r.nestedIntList)
-		require.Equal(t, strRes, "[[1 2 3] [4 5 6]]")
+		require.Equal(t, "[[1 2 3] [4 5 6]]", strRes)
 		strRes = fmt.Sprintf("%v", r.tripleNestedIntList)
-		require.Equal(t, strRes, "[[[1 2 3] [4 5 6]] [[7 8 9] [10 11 12]]]")
+		require.Equal(t, "[[[1 2 3] [4 5 6]] [[7 8 9] [10 11 12]]]", strRes)
 
 		require.Equal(t, rowsToAppend[i].simpleStruct, castMapToStruct[simpleStruct](t, r.simpleStruct))
 		require.Equal(t, rowsToAppend[i].wrappedStruct, castMapToStruct[wrappedStruct](t, r.wrappedStruct))
@@ -343,7 +343,7 @@ func TestAppenderNullList(t *testing.T) {
 			strS = fmt.Sprintf("%v", intS)
 		}
 
-		require.Equal(t, strResult[i], strS, fmt.Sprintf("row %d: expected %v, got %v", i, strResult[i], strS))
+		require.Equal(t, strResult[i], strS, "row %d: expected %v, got %v", i, strResult[i], strS)
 		i++
 	}
 
@@ -374,7 +374,7 @@ func TestAppenderNullStruct(t *testing.T) {
 		case 0:
 			require.NoError(t, err)
 		case 1:
-			require.Equal(t, nil, row)
+			require.Nil(t, row)
 		}
 		i++
 	}
@@ -425,7 +425,7 @@ func TestAppenderNestedNullStruct(t *testing.T) {
 		var row any
 		err = res.Scan(&row)
 		if i == 1 {
-			require.Equal(t, nil, row)
+			require.Nil(t, row)
 		} else {
 			require.NoError(t, err)
 		}
@@ -461,14 +461,14 @@ func TestAppenderNullIntAndString(t *testing.T) {
 		)
 		if i == 0 {
 			require.NoError(t, err)
-			require.Equal(t, id, 32)
-			require.Equal(t, str, "hello")
+			require.Equal(t, 32, id)
+			require.Equal(t, "hello", str)
 		} else if i > 0 && i < 4 {
 			require.Error(t, err)
 		} else {
 			require.NoError(t, err)
-			require.Equal(t, id, 42)
-			require.Equal(t, str, "valid again")
+			require.Equal(t, 42, id)
+			require.Equal(t, "valid again", str)
 		}
 		i++
 	}

--- a/duckdb_test.go
+++ b/duckdb_test.go
@@ -283,7 +283,7 @@ func TestJSON(t *testing.T) {
 	t.Run("SELECT an empty JSON", func(t *testing.T) {
 		var res Composite[map[string]any]
 		require.NoError(t, db.QueryRow(`SELECT '{}'::JSON`).Scan(&res))
-		require.Equal(t, 0, len(res.Get()))
+		require.Empty(t, res.Get())
 	})
 
 	t.Run("SELECT a marshalled JSON", func(t *testing.T) {
@@ -302,7 +302,7 @@ func TestJSON(t *testing.T) {
 	t.Run("SELECT a JSON array", func(t *testing.T) {
 		var res Composite[[]any]
 		require.NoError(t, db.QueryRow(`SELECT json_array('foo', 'bar')`).Scan(&res))
-		require.Equal(t, 2, len(res.Get()))
+		require.Len(t, res.Get(), 2)
 		require.Equal(t, "foo", res.Get()[0])
 		require.Equal(t, "bar", res.Get()[1])
 	})
@@ -525,7 +525,7 @@ func TestTypeNamesAndScanTypes(t *testing.T) {
 			err = r.Scan(&val)
 			require.NoError(t, err)
 			require.Equal(t, test.value, val)
-			require.Equal(t, r.Next(), false)
+			require.False(t, r.Next())
 		})
 	}
 	require.NoError(t, db.Close())

--- a/errors_test.go
+++ b/errors_test.go
@@ -481,10 +481,9 @@ func TestGetDuckDBErrorIs(t *testing.T) {
 		Msg:  "Invalid Input Error: Map keys can not be NULL",
 	}
 
-	require.ErrorIs(t, outOfRangeErr1, outOfRangeErr1)
 	require.ErrorIs(t, outOfRangeErr1Copy, outOfRangeErr1)
 	require.ErrorIs(t, &wrappedDuckDBError{outOfRangeErr1Copy}, outOfRangeErr1)
-	require.Equal(t, false, errors.Is(outOfRangeErr2, outOfRangeErr1))
-	require.Equal(t, false, errors.Is(invalidInputErr, outOfRangeErr1))
-	require.Equal(t, false, errors.Is(errors.New(errMsg), outOfRangeErr1))
+	require.NotErrorIs(t, outOfRangeErr2, outOfRangeErr1)
+	require.NotErrorIs(t, invalidInputErr, outOfRangeErr1)
+	require.NotErrorIs(t, errors.New(errMsg), outOfRangeErr1)
 }

--- a/scalarUDF_test.go
+++ b/scalarUDF_test.go
@@ -252,7 +252,7 @@ func TestAllTypesScalarUDF(t *testing.T) {
 		row := db.QueryRow(fmt.Sprintf(`SELECT my_identity(%s)::VARCHAR AS res`, info.input))
 		require.NoError(t, row.Scan(&res))
 		if info.TypeInfo.InternalType() != TYPE_UUID {
-			require.Equal(t, info.output, res, fmt.Sprintf(`output does not match expected output, input: %s`, info.input))
+			require.Equal(t, info.output, res, `output does not match expected output, input: %s`, info.input)
 		} else {
 			require.NotEqual(t, "", res, "uuid empty")
 		}

--- a/types_test.go
+++ b/types_test.go
@@ -364,9 +364,9 @@ func TestDecimal(t *testing.T) {
 		require.NoError(t, res.Close())
 
 		bigNumber, success := new(big.Int).SetString("1234567890123456789234", 10)
-		require.Equal(t, true, success)
+		require.True(t, success)
 		bigNegativeNumber, success := new(big.Int).SetString("-1234567890123456789234", 10)
-		require.Equal(t, true, success)
+		require.True(t, success)
 		tests := []struct {
 			input string
 			want  Decimal
@@ -390,7 +390,7 @@ func TestDecimal(t *testing.T) {
 
 	t.Run("SELECT a huge DECIMAL ", func(t *testing.T) {
 		bigInt, success := new(big.Int).SetString("12345678901234567890123456789", 10)
-		require.Equal(t, true, success)
+		require.True(t, success)
 		var f Decimal
 		require.NoError(t, db.QueryRow("SELECT 123456789.01234567890123456789::DECIMAL(29, 20)").Scan(&f))
 		compareDecimal(t, Decimal{Value: bigInt, Width: 29, Scale: 20}, f)
@@ -611,7 +611,7 @@ func TestList(t *testing.T) {
 	const n = 4000
 	var row Composite[[]int]
 	require.NoError(t, db.QueryRow("SELECT range(0, ?, 1)", n).Scan(&row))
-	require.Equal(t, n, len(row.Get()))
+	require.Len(t, row.Get(), n)
 	for i := 0; i < n; i++ {
 		require.Equal(t, i, row.Get()[i])
 	}
@@ -839,16 +839,16 @@ func TestBoolean(t *testing.T) {
 
 	var res bool
 	require.NoError(t, db.QueryRow("SELECT ?", true).Scan(&res))
-	require.Equal(t, true, res)
+	require.True(t, res)
 
 	require.NoError(t, db.QueryRow("SELECT ?", false).Scan(&res))
-	require.Equal(t, false, res)
+	require.False(t, res)
 
 	require.NoError(t, db.QueryRow("SELECT ?", 0).Scan(&res))
-	require.Equal(t, false, res)
+	require.False(t, res)
 
 	require.NoError(t, db.QueryRow("SELECT ?", 1).Scan(&res))
-	require.Equal(t, true, res)
+	require.True(t, res)
 	require.NoError(t, db.Close())
 }
 


### PR DESCRIPTION
This PR brings improvements to a few tests of the test suite (e.g. in `appender_test.go` expected and actual values were given in wrong order). The changes are based on the results of some code linting done by [testifylint](https://github.com/Antonboom/testifylint). In general, this PR aims at improving the readability of the tests. All tests of the test suite are still passing.