### PR TITLE
Improve appender speed

### DIFF
--- a/data_chunk.go
+++ b/data_chunk.go
@@ -6,6 +6,7 @@ package duckdb
 import "C"
 
 import (
+	"sync"
 	"unsafe"
 )
 
@@ -21,10 +22,7 @@ type DataChunk struct {
 	size int
 }
 
-// GetDataChunkCapacity returns the capacity of a data chunk.
-func GetDataChunkCapacity() int {
-	return int(C.duckdb_vector_size())
-}
+var GetDataChunkCapacity = sync.OnceValue[int](func() int {return int(C.duckdb_vector_size())})
 
 // GetSize returns the internal size of the data chunk.
 func (chunk *DataChunk) GetSize() int {


### PR DESCRIPTION
Rough performance before:
```
BenchmarkAppenderSingle/int8-16         	    8288	    142109 ns/op
```

Rough performance after caching chunk size:
```
BenchmarkAppenderSingle/int8-16         	   35270	     32326 ns/op
```


Full (existing API without reusing the appender for fairness) vs the new TS (`TableSource`) implementation
```
BenchmarkAppenderSingleFull/int8-16         	   11076	    109986 ns/op
BenchmarkAppenderSingleFull/int8-16         	   10000	    103503 ns/op
BenchmarkAppenderSingleFull/int8-16         	   10000	    103835 ns/op
BenchmarkAppenderSingleFull/int8-16         	   11526	    107647 ns/op
BenchmarkAppenderSingleFull/int8-16         	   10000	    107233 ns/op
BenchmarkAppenderSingleTS/int8-16           	   12663	     99329 ns/op
BenchmarkAppenderSingleTS/int8-16           	   12016	     97747 ns/op
BenchmarkAppenderSingleTS/int8-16           	   12054	     98896 ns/op
BenchmarkAppenderSingleTS/int8-16           	   12721	     96048 ns/op
BenchmarkAppenderSingleTS/int8-16           	   12434	    102425 ns/op
```

This benchmark only tests the single threaded row based tablesource, if this gets looked at and there are no major problems I can implement the multi-threaded and chunk APIs as well. These will be even faster!