### PR TITLE
Improve appender speed (1.1)

### DIFF
--- a/row.go
+++ b/row.go
@@ -24,8 +24,8 @@ func SetRowValue[T any](row Row, colIdx int, val T) error {
 	if projectedIdx < 0 || projectedIdx >= len(row.chunk.columns) {
 		return nil
 	}
-	vec := row.chunk.columns[projectedIdx]
-	return setVectorVal(&vec, row.r, val)
+	vec := &row.chunk.columns[projectedIdx]
+	return setVectorVal(vec, row.r, val)
 }
 
 // SetRowValue sets the value at colIdx to val. Returns an error on failure.

--- a/tableUDF.go
+++ b/tableUDF.go
@@ -314,7 +314,7 @@ func table_udf_row_callback(info C.duckdb_function_info, output C.duckdb_data_ch
 		chunk:      &chunk,
 		projection: instance.projection,
 	}
-	maxSize := C.duckdb_vector_size()
+	maxSize :=  C.idx_t(GetDataChunkCapacity())
 
 	switch fun := instance.fun.(type) {
 	case RowTableSource:

--- a/tableUDF.go
+++ b/tableUDF.go
@@ -118,7 +118,7 @@ type (
 	ChunkTableSource interface {
 		sequentialTableSource
 		// FillChunk takes a Chunk and fills it with values.
-		// It returns true, if there are more chunks to fill.
+		// Set the chunk size to 0 for end the function
 		FillChunk(DataChunk) error
 	}
 
@@ -131,7 +131,7 @@ type (
 	ParallelChunkTableSource interface {
 		parallelTableSource
 		// FillChunk takes a Chunk and fills it with values.
-		// It returns true, if there are more chunks to fill.
+		// Set the chunk size to 0 for end the function
 		FillChunk(any, DataChunk) error
 	}
 
@@ -258,7 +258,7 @@ func udfBindTyped[T tableSource](info C.duckdb_bind_info) {
 
 	cardinality := instance.Cardinality()
 	if cardinality != nil {
-		C.duckdb_bind_set_cardinality(info, C.idx_t(cardinality.Cardinality), C.bool(cardinality.Exact))
+	C.duckdb_bind_set_cardinality(info, C.idx_t(cardinality.Cardinality), C.bool(cardinality.Exact))
 	}
 
 	pinnedInstanceData := pinnedValue[tableFunctionData]{

--- a/tableUDF_test.go
+++ b/tableUDF_test.go
@@ -610,7 +610,7 @@ func (udf *chunkIncTableUDF) FillChunk(chunk DataChunk) error {
 			return err
 		}
 		udf.count++
-		err := chunk.SetValue(0, i, udf.count)
+		err := SetChunkValue(chunk, 0, i, udf.count)
 		if err != nil {
 			return err
 		}

--- a/vector_setters.go
+++ b/vector_setters.go
@@ -427,11 +427,6 @@ func setUUID[S any](vec *vector, rowIdx C.idx_t, val S) error {
 }
 
 func setVectorVal[S any](vec *vector, rowIdx C.idx_t, val S) error {
-	name, inMap := unsupportedTypeToStringMap[vec.Type]
-	if inMap {
-		return unsupportedTypeError(name)
-	}
-
 	switch vec.Type {
 	case TYPE_BOOLEAN:
 		return setBool[S](vec, rowIdx, val)
@@ -483,6 +478,10 @@ func setVectorVal[S any](vec *vector, rowIdx C.idx_t, val S) error {
 	case TYPE_UUID:
 		return setUUID[S](vec, rowIdx, val)
 	default:
+		name, inMap := unsupportedTypeToStringMap[vec.Type]
+		if inMap {
+			return unsupportedTypeError(name)
+		}
 		return unsupportedTypeError(unknownTypeErrMsg)
 	}
 }


### PR DESCRIPTION
I wasn't fully done with the PR, here are the implementations for parallel row and chunk sources (I will add parallel chunk tmrw).

The chunk version is, as expected, marginally better (~10%). I think this can be further improved by having faster chunk access in one way or another, as the bottleneck is still just setting the values and everything in involved with that