### PR TITLE
feature: allow :memory: in DSN

### DIFF
--- a/duckdb.go
+++ b/duckdb.go
@@ -45,6 +45,11 @@ func (Driver) OpenConnector(dsn string) (driver.Connector, error) {
 func NewConnector(dsn string, connInitFn func(execer driver.ExecerContext) error) (*Connector, error) {
 	var db C.duckdb_database
 
+	const inMemoryName = ":memory:"
+	if dsn == inMemoryName || strings.HasPrefix(dsn, inMemoryName+"?") {
+		dsn = dsn[len(inMemoryName):]
+	}
+
 	parsedDSN, err := url.Parse(dsn)
 	if err != nil {
 		return nil, getError(errParseDSN, err)


### PR DESCRIPTION
It is useful to accept both :memory: and empty string to connect to in-memory DB, because it is a (small) pitfall that one of the options described at https://duckdb.org/docs/connect/overview.html#in-memory-database is not currently supported.

Closes #360