### PR TITLE
Add test wrappers PR 2 - arrow_test and duckdb_extensions_test

### DIFF
--- a/arrow_test.go
+++ b/arrow_test.go
@@ -15,29 +15,24 @@ import (
 )
 
 func TestArrow(t *testing.T) {
-	t.Parallel()
-	db := openDB(t)
-	defer db.Close()
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
 
-	createFooTable(db, t)
-
-	conn, err := db.Conn(context.Background())
-	require.NoError(t, err)
-	defer conn.Close()
+	createTable(t, db, `CREATE TABLE foo(bar VARCHAR, baz INTEGER)`)
+	conn := openConnWrapper(t, db, context.Background())
+	defer closeConnWrapper(t, conn)
 
 	t.Run("select series", func(t *testing.T) {
-		c, err := NewConnector("", nil)
-		require.NoError(t, err)
-		defer c.Close()
+		c := newConnectorWrapper(t, ``, nil)
+		defer closeConnectorWrapper(t, c)
 
-		conn, err := c.Connect(context.Background())
-		require.NoError(t, err)
-		defer conn.Close()
+		innerConn := openDriverConnWrapper(t, c)
+		defer closeDriverConnWrapper(t, &innerConn)
 
-		ar, err := NewArrowFromConn(conn)
+		ar, err := NewArrowFromConn(innerConn)
 		require.NoError(t, err)
 
-		rdr, err := ar.QueryContext(context.Background(), "SELECT * FROM generate_series(1, 10)")
+		rdr, err := ar.QueryContext(context.Background(), `SELECT * FROM generate_series(1, 10)`)
 		require.NoError(t, err)
 		defer rdr.Release()
 
@@ -46,23 +41,20 @@ func TestArrow(t *testing.T) {
 			require.Equal(t, int64(10), rec.NumRows())
 			require.NoError(t, err)
 		}
-
 		require.NoError(t, rdr.Err())
 	})
 
 	t.Run("select long series", func(t *testing.T) {
-		c, err := NewConnector("", nil)
-		require.NoError(t, err)
-		defer c.Close()
+		c := newConnectorWrapper(t, ``, nil)
+		defer closeConnectorWrapper(t, c)
 
-		conn, err := c.Connect(context.Background())
-		require.NoError(t, err)
-		defer conn.Close()
+		innerConn := openDriverConnWrapper(t, c)
+		defer closeDriverConnWrapper(t, &innerConn)
 
-		ar, err := NewArrowFromConn(conn)
+		ar, err := NewArrowFromConn(innerConn)
 		require.NoError(t, err)
 
-		rdr, err := ar.QueryContext(context.Background(), "SELECT * FROM generate_series(1, 10000)")
+		rdr, err := ar.QueryContext(context.Background(), `SELECT * FROM generate_series(1, 10000)`)
 		require.NoError(t, err)
 		defer rdr.Release()
 
@@ -71,24 +63,22 @@ func TestArrow(t *testing.T) {
 			rec := rdr.Record()
 			totalRows += rec.NumRows()
 		}
-
 		require.Equal(t, int64(10000), totalRows)
-
 		require.NoError(t, rdr.Err())
 	})
 
 	t.Run("query table and filter results", func(t *testing.T) {
-		err = conn.Raw(func(driverConn any) error {
-			conn, ok := driverConn.(driver.Conn)
+		err := conn.Raw(func(driverConn any) error {
+			innerConn, ok := driverConn.(driver.Conn)
 			require.True(t, ok)
 
-			ar, err := NewArrowFromConn(conn)
+			ar, err := NewArrowFromConn(innerConn)
 			require.NoError(t, err)
 
-			_, err = db.ExecContext(context.Background(), "INSERT INTO foo (bar, baz) VALUES ('lala', 2), ('dada', 3)")
+			_, err = db.ExecContext(context.Background(), `INSERT INTO foo (bar, baz) VALUES ('lala', 2), ('dada', 3)`)
 			require.NoError(t, err)
 
-			reader, err := ar.QueryContext(context.Background(), "SELECT bar, baz FROM foo WHERE baz > ?", 1)
+			reader, err := ar.QueryContext(context.Background(), `SELECT bar, baz FROM foo WHERE baz > ?`, 1)
 			require.NoError(t, err)
 			defer reader.Release()
 
@@ -106,13 +96,13 @@ func TestArrow(t *testing.T) {
 
 	t.Run("query error", func(t *testing.T) {
 		err := conn.Raw(func(driverConn any) error {
-			conn, ok := driverConn.(driver.Conn)
+			innerConn, ok := driverConn.(driver.Conn)
 			require.True(t, ok)
 
-			ar, err := NewArrowFromConn(conn)
+			ar, err := NewArrowFromConn(innerConn)
 			require.NoError(t, err)
 
-			_, err = ar.QueryContext(context.Background(), "SELECT bar")
+			_, err = ar.QueryContext(context.Background(), `SELECT bar`)
 			require.Error(t, err)
 			return nil
 		})
@@ -120,15 +110,14 @@ func TestArrow(t *testing.T) {
 	})
 
 	t.Run("register arrow stream", func(t *testing.T) {
-		err = conn.Raw(func(driverConn any) error {
-			conn, ok := driverConn.(driver.Conn)
+		err := conn.Raw(func(driverConn any) error {
+			innerConn, ok := driverConn.(driver.Conn)
 			require.True(t, ok)
 
-			ar, err := NewArrowFromConn(conn)
+			ar, err := NewArrowFromConn(innerConn)
 			require.NoError(t, err)
 
 			pool := memory.NewGoAllocator()
-
 			schema := arrow.NewSchema(
 				[]arrow.Field{
 					{Name: "f1_i32", Type: arrow.PrimitiveTypes.Int32},
@@ -163,7 +152,7 @@ func TestArrow(t *testing.T) {
 			defer tr.Release()
 
 			ctx := context.Background()
-			_, err = db.ExecContext(ctx, "CREATE TABLE conflicting (i int, f double, s varchar)")
+			_, err = db.ExecContext(ctx, `CREATE TABLE conflicting (i INT, f DOUBLE, s VARCHAR)`)
 			require.NoError(t, err)
 
 			release, err := ar.RegisterView(tr, "conflicting")
@@ -175,22 +164,21 @@ func TestArrow(t *testing.T) {
 			require.NotNil(t, release)
 			defer release()
 
-			_, err = db.ExecContext(context.Background(), "CREATE TABLE dst AS SELECT * FROM arrow_table")
+			_, err = db.ExecContext(ctx, `CREATE TABLE dst AS SELECT * FROM arrow_table`)
 			require.NoError(t, err)
 
-			// Query the table to verify the data
-			rows, err := db.QueryContext(context.Background(), "SELECT * FROM dst")
+			// Query the table to verify the data.
+			res, err := db.QueryContext(ctx, `SELECT * FROM dst`)
 			require.NoError(t, err)
-			defer rows.Close()
+			defer closeRowsWrapper(t, res)
 
 			i := 0
-			for rows.Next() {
+			for res.Next() {
 				i++
 				var f1 sql.NullInt32
 				var f2 float64
 				var f3 string
-				err = rows.Scan(&f1, &f2, &f3)
-				require.NoError(t, err)
+				require.NoError(t, res.Scan(&f1, &f2, &f3))
 
 				if i == 9 {
 					require.False(t, f1.Valid)
@@ -201,9 +189,8 @@ func TestArrow(t *testing.T) {
 				require.Equal(t, float64(i), f2)
 				require.Equal(t, string(rune('a'+i-1)), f3)
 			}
-			require.NoError(t, rows.Err())
+			require.NoError(t, res.Err())
 			require.Equal(t, 20, i)
-
 			return nil
 		})
 		require.NoError(t, err)
@@ -211,21 +198,18 @@ func TestArrow(t *testing.T) {
 }
 
 func TestArrowClosedConn(t *testing.T) {
-	db := openDB(t)
-	defer db.Close()
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
 
-	conn, err := db.Conn(context.Background())
-	require.NoError(t, err)
-
-	err = conn.Raw(func(driverConn any) error {
-		conn, ok := driverConn.(driver.Conn)
+	conn := openConnWrapper(t, db, context.Background())
+	err := conn.Raw(func(driverConn any) error {
+		innerConn, ok := driverConn.(driver.Conn)
 		require.True(t, ok)
 
-		ar, err := NewArrowFromConn(conn)
+		ar, err := NewArrowFromConn(innerConn)
 		require.NoError(t, err)
 
 		pool := memory.NewGoAllocator()
-
 		schema := arrow.NewSchema(
 			[]arrow.Field{
 				{Name: "f1", Type: arrow.PrimitiveTypes.Int64},
@@ -249,13 +233,11 @@ func TestArrowClosedConn(t *testing.T) {
 		tr := array.NewTableReader(tbl, 5)
 		defer tr.Release()
 
-		err = conn.Close()
-		require.NoError(t, err)
+		closeDriverConnWrapper(t, &innerConn)
 
 		release, err := ar.RegisterView(tr, "arrow_table")
 		require.ErrorIs(t, err, errClosedCon)
 		require.Nil(t, release)
-
 		return driver.ErrBadConn
 	})
 	require.Error(t, err)

--- a/duckdb_extensions_test.go
+++ b/duckdb_extensions_test.go
@@ -3,21 +3,17 @@
 package duckdb
 
 import (
-	"database/sql"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestOpenSQLite(t *testing.T) {
-	t.Parallel()
-
-	db, err := sql.Open("duckdb", "sqlite:testdata/pets.sqlite")
-	require.NoError(t, err)
+	db := openDbWrapper(t, `sqlite:testdata/pets.sqlite`)
+	defer closeDbWrapper(t, db)
 
 	var species string
-	res := db.QueryRow("SELECT species FROM pets WHERE id=1")
+	res := db.QueryRow(`SELECT species FROM pets WHERE id = 1`)
 	require.NoError(t, res.Scan(&species))
 	require.Equal(t, "Gopher", species)
-	require.NoError(t, db.Close())
 }

--- a/duckdb_test.go
+++ b/duckdb_test.go
@@ -60,6 +60,19 @@ func closeConnWrapper[T require.TestingT](t T, conn *sql.Conn) {
 	require.NoError(t, conn.Close())
 }
 
+func openDriverConnWrapper[T require.TestingT](t T, c *Connector) driver.Conn {
+	conn, err := c.Connect(context.Background())
+	require.NoError(t, err)
+	return conn
+}
+
+func closeDriverConnWrapper[T require.TestingT](t T, conn *driver.Conn) {
+	if conn == nil {
+		return
+	}
+	require.NoError(t, (*conn).Close())
+}
+
 func closeRowsWrapper[T require.TestingT](t T, r *sql.Rows) {
 	if r == nil {
 		return


### PR DESCRIPTION
This is the second PR in a series of moving the testing changes in https://github.com/marcboeker/go-duckdb/pull/364 into separate PRs.