### PR TITLE
Add test wrappers PR 3 - appender_test and errors_test

### DIFF
--- a/duckdb_test.go
+++ b/duckdb_test.go
@@ -16,9 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-/* ------------------------------------------ */
-/* -------- Open and Close Wrappers --------- */
-/* ------------------------------------------ */
+/* ---------- Open and Close Wrappers ---------- */
 
 func openDbWrapper[T require.TestingT](t T, dsn string) *sql.DB {
 	db, err := sql.Open(`duckdb`, dsn)
@@ -80,9 +78,20 @@ func closeRowsWrapper[T require.TestingT](t T, r *sql.Rows) {
 	require.NoError(t, r.Close())
 }
 
-/* ------------------------------------------ */
-/* -------------- Test Helpers -------------- */
-/* ------------------------------------------ */
+func newAppenderWrapper[T require.TestingT](t T, conn *driver.Conn, schema string, table string) *Appender {
+	a, err := NewAppenderFromConn(*conn, schema, table)
+	require.NoError(t, err)
+	return a
+}
+
+func closeAppenderWrapper[T require.TestingT](t T, a *Appender) {
+	if a == nil {
+		return
+	}
+	require.NoError(t, a.Close())
+}
+
+/* ---------- Test Helpers ---------- */
 
 func createTable(t *testing.T, db *sql.DB, query string) {
 	res, err := db.Exec(query)
@@ -108,9 +117,7 @@ func openDB(t *testing.T) *sql.DB {
 	return db
 }
 
-/* ------------------------------------------ */
-/* ------------------ Tests ----------------- */
-/* ------------------------------------------ */
+/* ---------- Tests ---------- */
 
 func TestOpen(t *testing.T) {
 	t.Run("without config", func(t *testing.T) {

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,7 +1,6 @@
 package duckdb
 
 import (
-	"context"
 	"database/sql"
 	"database/sql/driver"
 	"errors"
@@ -27,193 +26,203 @@ func testError(t *testing.T, actual error, contains ...string) {
 
 func TestErrConnect(t *testing.T) {
 	t.Run(errParseDSN.Error(), func(t *testing.T) {
-		_, err := sql.Open("duckdb", ":mem ory:")
+		db, err := sql.Open(`duckdb`, `:mem ory:`)
+		defer closeDbWrapper(t, db)
 		testError(t, err, errParseDSN.Error())
 	})
 
 	t.Run(errConnect.Error(), func(t *testing.T) {
-		_, err := sql.Open("duckdb", "?readonly")
-		testError(t, err, errConnect.Error(), duckdbErrMsg)
+		db, err := sql.Open(`duckdb`, `?readonly`)
+		defer closeDbWrapper(t, db)
+		testError(t, err, errConnect.Error())
 	})
 
 	t.Run(errSetConfig.Error(), func(t *testing.T) {
-		_, err := sql.Open("duckdb", "?threads=NaN")
+		db, err := sql.Open(`duckdb`, `?threads=NaN`)
+		defer closeDbWrapper(t, db)
 		testError(t, err, errSetConfig.Error())
 	})
 
 	t.Run("local config option", func(t *testing.T) {
-		_, err := sql.Open("duckdb", "?schema=main")
+		db, err := sql.Open(`duckdb`, `?schema=main`)
+		defer closeDbWrapper(t, db)
 		testError(t, err, errSetConfig.Error())
 	})
 }
 
 func TestErrNestedMap(t *testing.T) {
-	t.Parallel()
-	db := openDB(t)
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
 
 	var m Map
 	err := db.QueryRow(`SELECT MAP([MAP([1], [1]), MAP([2], [2])], ['a', 'e'])`).Scan(&m)
 	testError(t, err, errUnsupportedMapKeyType.Error())
-	require.NoError(t, db.Close())
 }
 
 func TestErrAppender(t *testing.T) {
-	t.Parallel()
-
 	t.Run(errInvalidCon.Error(), func(t *testing.T) {
-		var con driver.Conn
-		_, err := NewAppenderFromConn(con, "", "test")
+		var conn driver.Conn
+		a, err := NewAppenderFromConn(conn, "", "test")
+		defer closeAppenderWrapper(t, a)
 		testError(t, err, errInvalidCon.Error())
 	})
 
 	t.Run(errClosedCon.Error(), func(t *testing.T) {
-		c, err := NewConnector("", nil)
-		require.NoError(t, err)
+		c := newConnectorWrapper(t, ``, nil)
+		defer closeConnectorWrapper(t, c)
 
-		con, err := c.Connect(context.Background())
-		require.NoError(t, err)
-		require.NoError(t, con.Close())
+		conn := openDriverConnWrapper(t, c)
+		closeDriverConnWrapper(t, &conn)
 
-		_, err = NewAppenderFromConn(con, "", "test")
+		a, err := NewAppenderFromConn(conn, "", "test")
+		defer closeAppenderWrapper(t, a)
 		testError(t, err, errClosedCon.Error())
-		require.NoError(t, c.Close())
 	})
 
 	t.Run(errAppenderCreation.Error(), func(t *testing.T) {
-		c, err := NewConnector("", nil)
-		require.NoError(t, err)
+		c := newConnectorWrapper(t, ``, nil)
+		defer closeConnectorWrapper(t, c)
 
-		con, err := c.Connect(context.Background())
-		require.NoError(t, err)
+		conn := openDriverConnWrapper(t, c)
+		defer closeDriverConnWrapper(t, &conn)
 
-		_, err = NewAppenderFromConn(con, "", "does_not_exist")
-		testError(t, err, errAppenderCreation.Error(), duckdbErrMsg)
-		require.NoError(t, con.Close())
-		require.NoError(t, c.Close())
+		a, err := NewAppenderFromConn(conn, "", "does_not_exist")
+		defer closeAppenderWrapper(t, a)
+		testError(t, err, errAppenderCreation.Error())
 	})
 
 	t.Run(errAppenderDoubleClose.Error(), func(t *testing.T) {
-		c, err := NewConnector("", nil)
+		c := newConnectorWrapper(t, ``, nil)
+		defer closeConnectorWrapper(t, c)
+
+		db := sql.OpenDB(c)
+		defer closeDbWrapper(t, db)
+		_, err := db.Exec(`CREATE TABLE tbl (i INTEGER)`)
 		require.NoError(t, err)
 
-		_, err = sql.OpenDB(c).Exec(`CREATE TABLE tbl (i INTEGER)`)
-		require.NoError(t, err)
+		conn := openDriverConnWrapper(t, c)
+		defer closeDriverConnWrapper(t, &conn)
 
-		con, err := c.Connect(context.Background())
+		a, err := NewAppenderFromConn(conn, "", "tbl")
+		closeAppenderWrapper(t, a)
 		require.NoError(t, err)
-
-		a, err := NewAppenderFromConn(con, "", "tbl")
-		require.NoError(t, err)
-		cleanupAppender(t, c, con, a)
 
 		err = a.Close()
 		testError(t, err, errAppenderDoubleClose.Error())
 	})
 
 	t.Run(unsupportedTypeErrMsg, func(t *testing.T) {
-		c, err := NewConnector("", nil)
-		require.NoError(t, err)
+		c := newConnectorWrapper(t, ``, nil)
+		defer closeConnectorWrapper(t, c)
 
-		_, err = sql.OpenDB(c).Exec(`CREATE TABLE test (bit_col BIT)`)
+		db := sql.OpenDB(c)
+		_, err := db.Exec(`CREATE TABLE test (bit_col BIT)`)
 		require.NoError(t, err)
+		defer closeDbWrapper(t, db)
 
-		con, err := c.Connect(context.Background())
-		require.NoError(t, err)
+		conn := openDriverConnWrapper(t, c)
+		defer closeDriverConnWrapper(t, &conn)
 
-		_, err = NewAppenderFromConn(con, "", "test")
+		a, err := NewAppenderFromConn(conn, "", "test")
+		defer closeAppenderWrapper(t, a)
 		testError(t, err, errAppenderCreation.Error(), unsupportedTypeErrMsg)
-
-		require.NoError(t, con.Close())
-		require.NoError(t, c.Close())
 	})
 
 	t.Run(columnCountErrMsg, func(t *testing.T) {
-		c, con, a := prepareAppender(t, `CREATE TABLE test (a VARCHAR, b VARCHAR)`)
+		c, db, conn, a := prepareAppender(t, `CREATE TABLE test (a VARCHAR, b VARCHAR)`)
+		defer cleanupAppender(t, c, db, conn, a)
 		err := a.AppendRow("hello")
 		testError(t, err, errAppenderAppendRow.Error(), columnCountErrMsg)
-		cleanupAppender(t, c, con, a)
 	})
 
 	t.Run(errAppenderAppendAfterClose.Error(), func(t *testing.T) {
-		c, con, a := prepareAppender(t, `CREATE TABLE test (str VARCHAR)`)
-		require.NoError(t, a.Close())
+		c, db, conn, a := prepareAppender(t, `CREATE TABLE test (str VARCHAR)`)
+		closeAppenderWrapper(t, a)
+		defer closeDriverConnWrapper(t, &conn)
+		defer closeDbWrapper(t, db)
+		defer closeConnectorWrapper(t, c)
+
 		err := a.AppendRow("hello")
 		testError(t, err, errAppenderAppendAfterClose.Error())
-		require.NoError(t, con.Close())
-		require.NoError(t, c.Close())
 	})
 
 	t.Run(errAppenderFlush.Error(), func(t *testing.T) {
-		c, con, a := prepareAppender(t, `CREATE TABLE test (c1 INTEGER PRIMARY KEY)`)
+		c, db, conn, a := prepareAppender(t, `CREATE TABLE test (c1 INTEGER PRIMARY KEY)`)
+		defer closeDriverConnWrapper(t, &conn)
+		defer closeDbWrapper(t, db)
+		defer closeConnectorWrapper(t, c)
+
 		require.NoError(t, a.AppendRow(int32(1)))
 		require.NoError(t, a.AppendRow(int32(1)))
 		err := a.Flush()
 		testError(t, err, errAppenderFlush.Error())
+
 		err = a.Close()
 		testError(t, err, errAppenderClose.Error())
-		require.NoError(t, con.Close())
-		require.NoError(t, c.Close())
 	})
 
 	t.Run(errAppenderClose.Error(), func(t *testing.T) {
-		c, con, a := prepareAppender(t, `CREATE TABLE test (c1 INTEGER PRIMARY KEY)`)
+		c, db, conn, a := prepareAppender(t, `CREATE TABLE test (c1 INTEGER PRIMARY KEY)`)
+		defer closeDriverConnWrapper(t, &conn)
+		defer closeDbWrapper(t, db)
+		defer closeConnectorWrapper(t, c)
+
 		require.NoError(t, a.AppendRow(int32(1)))
 		require.NoError(t, a.AppendRow(int32(1)))
+
 		err := a.Close()
 		testError(t, err, errAppenderClose.Error())
-		require.NoError(t, con.Close())
-		require.NoError(t, c.Close())
 	})
 
 	t.Run(errUnsupportedMapKeyType.Error(), func(t *testing.T) {
-		c, con, a := prepareAppender(t, `CREATE TABLE test (m MAP(INT[], STRUCT(v INT)))`)
+		c, db, conn, a := prepareAppender(t, `CREATE TABLE test (m MAP(INT[], STRUCT(v INT)))`)
+		defer cleanupAppender(t, c, db, conn, a)
 		err := a.AppendRow(nil)
 		testError(t, err, errAppenderAppendRow.Error(), errUnsupportedMapKeyType.Error())
-		cleanupAppender(t, c, con, a)
 	})
 
 	t.Run(invalidInputErrMsg, func(t *testing.T) {
-		c, con, a := prepareAppender(t, `CREATE TABLE test (col INT[3])`)
+		c, db, conn, a := prepareAppender(t, `CREATE TABLE test (col INT[3])`)
+		defer cleanupAppender(t, c, db, conn, a)
 		err := a.AppendRow([]int32{1, 2})
 		testError(t, err, errAppenderAppendRow.Error(), invalidInputErrMsg)
-		cleanupAppender(t, c, con, a)
 	})
 }
 
 func TestErrAppend(t *testing.T) {
-	c, con, a := prepareAppender(t, `CREATE TABLE test (id BIGINT, str VARCHAR)`)
+	c, db, conn, a := prepareAppender(t, `CREATE TABLE test (id BIGINT, str VARCHAR)`)
+	defer cleanupAppender(t, c, db, conn, a)
 
 	err := a.AppendRow("hello", "world")
 	testError(t, err, errAppenderAppendRow.Error(), castErrMsg)
 	err = a.AppendRow(false, 42)
 	testError(t, err, errAppenderAppendRow.Error(), castErrMsg)
-
-	cleanupAppender(t, c, con, a)
 }
 
 func TestErrAppendDecimal(t *testing.T) {
-	c, con, a := prepareAppender(t, `CREATE TABLE test (d DECIMAL(8, 2))`)
+	c, db, conn, a := prepareAppender(t, `CREATE TABLE test (d DECIMAL(8, 2))`)
+	defer cleanupAppender(t, c, db, conn, a)
 
 	err := a.AppendRow(Decimal{Width: 9, Scale: 2})
 	testError(t, err, errAppenderAppendRow.Error(), castErrMsg)
 	err = a.AppendRow(Decimal{Width: 8, Scale: 3})
 	testError(t, err, errAppenderAppendRow.Error(), castErrMsg)
-
-	cleanupAppender(t, c, con, a)
 }
 
 func TestErrAppendEnum(t *testing.T) {
-	c, con, a := prepareAppender(t, testTypesEnumSQL+";"+`CREATE TABLE test (e my_enum)`)
+	c, db, conn, a := prepareAppender(t, testTypesEnumSQL+";"+`CREATE TABLE test (e my_enum)`)
+	defer cleanupAppender(t, c, db, conn, a)
+
 	err := a.AppendRow("3")
 	testError(t, err, errAppenderAppendRow.Error(), castErrMsg)
-	cleanupAppender(t, c, con, a)
 }
 
 func TestErrAppendSimpleStruct(t *testing.T) {
-	c, con, a := prepareAppender(t, `
+	c, db, conn, a := prepareAppender(t, `
 		CREATE TABLE test (
 			simple_struct STRUCT(A INT, B VARCHAR)
 		)`)
+	defer cleanupAppender(t, c, db, conn, a)
 
 	err := a.AppendRow(1)
 	testError(t, err, errAppenderAppendRow.Error(), castErrMsg)
@@ -242,68 +251,64 @@ func TestErrAppendSimpleStruct(t *testing.T) {
 		},
 	)
 	testError(t, err, errAppenderAppendRow.Error(), structFieldErrMsg)
-
-	cleanupAppender(t, c, con, a)
 }
 
 func TestErrAppendDuplicateStruct(t *testing.T) {
-	c, con, a := prepareAppender(t, `
+	c, db, conn, a := prepareAppender(t, `
 		CREATE TABLE test (
 			duplicate_struct STRUCT(Duplicate INT)
 		)`)
+	defer cleanupAppender(t, c, db, conn, a)
 
 	err := a.AppendRow(duplicateKeyStruct{1, 2})
 	testError(t, err, errAppenderAppendRow.Error(), duplicateNameErrMsg)
-	cleanupAppender(t, c, con, a)
 }
 
 func TestErrAppendStruct(t *testing.T) {
-	c, con, a := prepareAppender(t, `
+	c, db, conn, a := prepareAppender(t, `
 		CREATE TABLE test (
 			mix STRUCT(a STRUCT(L VARCHAR[]), B STRUCT(L INT[])[])
 		)`)
+	defer cleanupAppender(t, c, db, conn, a)
 
 	err := a.AppendRow(simpleStruct{1, "hello"})
 	testError(t, err, errAppenderAppendRow.Error(), castErrMsg)
-	cleanupAppender(t, c, con, a)
 }
 
 func TestErrAppendList(t *testing.T) {
-	c, con, a := prepareAppender(t, `CREATE TABLE test(intSlice INT[])`)
+	c, db, conn, a := prepareAppender(t, `CREATE TABLE test(intSlice INT[])`)
+	defer cleanupAppender(t, c, db, conn, a)
 
 	err := a.AppendRow([]string{"foo", "bar", "baz"})
 	testError(t, err, errAppenderAppendRow.Error(), castErrMsg)
 	err = a.AppendRow([][]int32{{1, 2, 3}, {4, 5, 6}})
 	testError(t, err, errAppenderAppendRow.Error(), castErrMsg)
-
-	cleanupAppender(t, c, con, a)
 }
 
 func TestErrAppendStructWithList(t *testing.T) {
-	c, con, a := prepareAppender(t, `CREATE TABLE test (struct_with_list STRUCT(L INT[]))`)
+	c, db, conn, a := prepareAppender(t, `CREATE TABLE test (struct_with_list STRUCT(L INT[]))`)
+	defer cleanupAppender(t, c, db, conn, a)
 
 	err := a.AppendRow([]int32{1, 2, 3})
 	testError(t, err, errAppenderAppendRow.Error(), castErrMsg)
 	l := struct{ L []string }{L: []string{"a", "b", "c"}}
 	testError(t, a.AppendRow(l), errAppenderAppendRow.Error(), castErrMsg)
-
-	cleanupAppender(t, c, con, a)
 }
 
 func TestErrAppendNestedStruct(t *testing.T) {
-	c, con, a := prepareAppender(t, `
+	c, db, conn, a := prepareAppender(t, `
 		CREATE TABLE test (
 			wrapped_simple_struct STRUCT(a VARCHAR, B STRUCT(A INT, B VARCHAR)),
 		)`)
+	defer cleanupAppender(t, c, db, conn, a)
 
 	err := a.AppendRow(simpleStruct{1, "hello"})
 	testError(t, err, errAppenderAppendRow.Error(), castErrMsg)
-
-	cleanupAppender(t, c, con, a)
 }
 
 func TestErrAppendNestedList(t *testing.T) {
-	c, con, a := prepareAppender(t, `CREATE TABLE test(int_slice INT[][][])`)
+	c, db, conn, a := prepareAppender(t, `CREATE TABLE test(int_slice INT[][][])`)
+	defer cleanupAppender(t, c, db, conn, a)
 
 	err := a.AppendRow([]int32{1, 2, 3})
 	testError(t, err, errAppenderAppendRow.Error(), castErrMsg)
@@ -311,17 +316,14 @@ func TestErrAppendNestedList(t *testing.T) {
 	testError(t, err, errAppenderAppendRow.Error(), castErrMsg)
 	err = a.AppendRow([][]int32{{1, 2, 3}, {4, 5, 6}})
 	testError(t, err, errAppenderAppendRow.Error(), castErrMsg)
-
-	cleanupAppender(t, c, con, a)
 }
 
 func TestErrAppenderTSConversion(t *testing.T) {
-	t.Parallel()
-
 	testCases := []string{"TIMESTAMP_NS", "TIMESTAMP", "TIMESTAMPTZ"}
 	for _, tc := range testCases {
 		t.Run(tc+" conversion error", func(t *testing.T) {
-			c, con, a := prepareAppender(t, `CREATE TABLE test (t `+tc+`)`)
+			c, db, conn, a := prepareAppender(t, `CREATE TABLE test (t `+tc+`)`)
+			defer cleanupAppender(t, c, db, conn, a)
 
 			tsLess := time.Date(-290407, time.January, 1, 15, 0o4, 5, 123456, time.UTC)
 			err := a.AppendRow(tsLess)
@@ -330,15 +332,11 @@ func TestErrAppenderTSConversion(t *testing.T) {
 			tsGreater := time.Date(294346, time.January, 1, 15, 0o4, 5, 123456, time.UTC)
 			err = a.AppendRow(tsGreater)
 			testError(t, err, errAppenderAppendRow.Error(), convertErrMsg)
-
-			cleanupAppender(t, c, con, a)
 		})
 	}
 }
 
 func TestErrAPISetValue(t *testing.T) {
-	t.Parallel()
-
 	var chunk DataChunk
 	err := chunk.SetValue(1, 42, "hello")
 	testError(t, err, errAPI.Error(), columnCountErrMsg)
@@ -347,7 +345,9 @@ func TestErrAPISetValue(t *testing.T) {
 }
 
 func TestDuckDBErrors(t *testing.T) {
-	db := openDB(t)
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
+
 	createTable(t, db, `CREATE TABLE duckdb_error_test(bar VARCHAR UNIQUE, baz INT32, u_1 UNION("string" VARCHAR))`)
 	_, err := db.Exec(`INSERT INTO duckdb_error_test(bar, baz) VALUES ('bar', 0)`)
 	require.NoError(t, err)
@@ -410,8 +410,6 @@ func TestDuckDBErrors(t *testing.T) {
 		}
 		require.Equal(t, de.Type, tc.errTyp, "tpl: %s\nactual error msg: %s", tc.tpl, de.Msg)
 	}
-
-	require.NoError(t, db.Close())
 }
 
 func TestDuckDBErrorsCornerCases(t *testing.T) {

--- a/types_test.go
+++ b/types_test.go
@@ -295,7 +295,7 @@ func testTypes[T require.TestingT](t T, c *Connector, a *Appender, expectedRows 
 func TestTypes(t *testing.T) {
 	t.Parallel()
 	expectedRows := testTypesGenerateRows(t, 3)
-	c, con, a := prepareAppender(t, testTypesEnumSQL+";"+testTypesTableSQL)
+	c, db, con, a := prepareAppender(t, testTypesEnumSQL+";"+testTypesTableSQL)
 	actualRows := testTypes(t, c, a, expectedRows)
 
 	for i := range actualRows {
@@ -304,7 +304,7 @@ func TestTypes(t *testing.T) {
 	}
 
 	require.Equal(t, len(expectedRows), len(actualRows))
-	cleanupAppender(t, c, con, a)
+	cleanupAppender(t, c, db, con, a)
 }
 
 // NOTE: go-duckdb only contains very few benchmarks. The purpose of those benchmarks is to avoid regressions
@@ -313,7 +313,7 @@ var benchmarkTypesResult []testTypesRow
 
 func BenchmarkTypes(b *testing.B) {
 	expectedRows := testTypesGenerateRows(b, GetDataChunkCapacity()*3+10)
-	c, con, a := prepareAppender(b, testTypesEnumSQL+";"+testTypesTableSQL)
+	c, db, con, a := prepareAppender(b, testTypesEnumSQL+";"+testTypesTableSQL)
 
 	var r []testTypesRow
 	b.ResetTimer()
@@ -325,7 +325,7 @@ func BenchmarkTypes(b *testing.B) {
 
 	// Ensure that the compiler does not eliminate the line by storing the result.
 	benchmarkTypesResult = r
-	cleanupAppender(b, c, con, a)
+	cleanupAppender(b, c, db, con, a)
 }
 
 func compareDecimal(t *testing.T, want Decimal, got Decimal) {


### PR DESCRIPTION
This is the third PR in a series of moving the testing changes in https://github.com/marcboeker/go-duckdb/pull/364 into separate PRs.