### PR TITLE
Add test wrappers PR 4 - profiling_test, replacement_scan_test, and scalarUDF_test

### DIFF
--- a/profiling_test.go
+++ b/profiling_test.go
@@ -2,35 +2,31 @@ package duckdb
 
 import (
 	"context"
-	"database/sql"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestProfiling(t *testing.T) {
-	t.Parallel()
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
+	conn := openConnWrapper(t, db, context.Background())
+	defer closeConnWrapper(t, conn)
 
-	db, err := sql.Open("duckdb", "")
+	_, err := conn.ExecContext(context.Background(), `PRAGMA enable_profiling = 'no_output'`)
 	require.NoError(t, err)
-	con, err := db.Conn(context.Background())
-	require.NoError(t, err)
-
-	_, err = con.ExecContext(context.Background(), `PRAGMA enable_profiling = 'no_output'`)
-	require.NoError(t, err)
-	_, err = con.ExecContext(context.Background(), `PRAGMA profiling_mode = 'detailed'`)
-	require.NoError(t, err)
-	res, err := con.QueryContext(context.Background(), `SELECT range AS i FROM range(100) ORDER BY i`)
+	_, err = conn.ExecContext(context.Background(), `PRAGMA profiling_mode = 'detailed'`)
 	require.NoError(t, err)
 
-	info, err := GetProfilingInfo(con)
+	res, err := conn.QueryContext(context.Background(), `SELECT range AS i FROM range(100) ORDER BY i`)
+	require.NoError(t, err)
+	defer closeRowsWrapper(t, res)
+
+	info, err := GetProfilingInfo(conn)
 	require.NoError(t, err)
 
-	_, err = con.ExecContext(context.Background(), `PRAGMA disable_profiling`)
+	_, err = conn.ExecContext(context.Background(), `PRAGMA disable_profiling`)
 	require.NoError(t, err)
-	require.NoError(t, res.Close())
-	require.NoError(t, con.Close())
-	require.NoError(t, db.Close())
 
 	// Verify the metrics.
 	require.NotEmpty(t, info.Metrics, "metrics must not be empty")
@@ -39,14 +35,11 @@ func TestProfiling(t *testing.T) {
 }
 
 func TestErrProfiling(t *testing.T) {
-	t.Parallel()
-	db, err := sql.Open("duckdb", "")
-	require.NoError(t, err)
-	con, err := db.Conn(context.Background())
-	require.NoError(t, err)
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
+	conn := openConnWrapper(t, db, context.Background())
+	defer closeConnWrapper(t, conn)
 
-	_, err = GetProfilingInfo(con)
+	_, err := GetProfilingInfo(conn)
 	testError(t, err, errProfilingInfoEmpty.Error())
-	require.NoError(t, con.Close())
-	require.NoError(t, db.Close())
 }

--- a/replacement_scan_test.go
+++ b/replacement_scan_test.go
@@ -8,36 +8,31 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// FIXME: More replacement scan tests, also failure paths.
 func TestReplacementScan(t *testing.T) {
-	connector, err := NewConnector("", func(execer driver.ExecerContext) error {
+	c := newConnectorWrapper(t, ``, func(execer driver.ExecerContext) error {
 		return nil
 	})
-
-	require.NoError(t, err)
-	defer connector.Close()
+	defer closeConnectorWrapper(t, c)
 
 	rangeRows := 100
-	RegisterReplacementScan(connector, func(tableName string) (string, []any, error) {
+	RegisterReplacementScan(c, func(tableName string) (string, []any, error) {
 		return "range", []any{int64(rangeRows)}, nil
 	})
 
-	db := sql.OpenDB(connector)
-	rows, err := db.Query("select * from any_table")
-	require.NoError(t, err)
-	defer rows.Close()
+	db := sql.OpenDB(c)
+	defer closeDbWrapper(t, db)
 
-	for i := 0; rows.Next(); i++ {
+	res, err := db.Query("SELECT * FROM any_table")
+	require.NoError(t, err)
+	defer closeRowsWrapper(t, res)
+
+	for i := 0; res.Next(); i++ {
 		var val int
-		require.NoError(t, rows.Scan(&val))
-		if val != i {
-			require.Fail(t, "expected %d, got %d", i, val)
-		}
+		require.NoError(t, res.Scan(&val))
+		require.Equal(t, i, val)
 		rangeRows--
 	}
-	if rows.Err() != nil {
-		require.NoError(t, rows.Err())
-	}
-	if rangeRows != 0 {
-		require.Fail(t, "expected 0, got %d", rangeRows)
-	}
+	require.NoError(t, res.Err())
+	require.Equal(t, 0, rangeRows)
 }

--- a/scalarUDF_test.go
+++ b/scalarUDF_test.go
@@ -169,17 +169,18 @@ func (*errExecSUDF) Executor() ScalarFuncExecutor {
 }
 
 func TestSimpleScalarUDF(t *testing.T) {
-	db, err := sql.Open("duckdb", "")
-	require.NoError(t, err)
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
 
-	c, err := db.Conn(context.Background())
-	require.NoError(t, err)
+	conn := openConnWrapper(t, db, context.Background())
+	defer closeConnWrapper(t, conn)
 
+	var err error
 	currentInfo, err = NewTypeInfo(TYPE_INTEGER)
 	require.NoError(t, err)
 
 	var udf *simpleSUDF
-	err = RegisterScalarUDF(c, "my_sum", udf)
+	err = RegisterScalarUDF(conn, "my_sum", udf)
 	require.NoError(t, err)
 
 	var sum *int
@@ -194,27 +195,25 @@ func TestSimpleScalarUDF(t *testing.T) {
 	row = db.QueryRow(`SELECT my_sum(42, NULL) AS sum`)
 	require.NoError(t, row.Scan(&sum))
 	require.Equal(t, (*int)(nil), sum)
-
-	require.NoError(t, c.Close())
-	require.NoError(t, db.Close())
 }
 
 func TestConstantScalarUDF(t *testing.T) {
-	db, err := sql.Open("duckdb", "")
-	require.NoError(t, err)
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
 
-	c, err := db.Conn(context.Background())
-	require.NoError(t, err)
+	conn := openConnWrapper(t, db, context.Background())
+	defer closeConnWrapper(t, conn)
 
+	var err error
 	currentInfo, err = NewTypeInfo(TYPE_INTEGER)
 	require.NoError(t, err)
 
 	var udf *constantSUDF
-	err = RegisterScalarUDF(c, "constant_one", udf)
+	err = RegisterScalarUDF(conn, "constant_one", udf)
 	require.NoError(t, err)
 
 	var otherUDF *otherConstantSUDF
-	err = RegisterScalarUDF(c, "other_constant_one", otherUDF)
+	err = RegisterScalarUDF(conn, "other_constant_one", otherUDF)
 	require.NoError(t, err)
 
 	var one int
@@ -225,56 +224,53 @@ func TestConstantScalarUDF(t *testing.T) {
 	row = db.QueryRow(`SELECT other_constant_one() AS one`)
 	require.NoError(t, row.Scan(&one))
 	require.Equal(t, 1, one)
-
-	require.NoError(t, c.Close())
-	require.NoError(t, db.Close())
 }
 
 func TestAllTypesScalarUDF(t *testing.T) {
 	typeInfos := getTypeInfos(t, false)
 	for _, info := range typeInfos {
-		currentInfo = info.TypeInfo
+		func() {
+			currentInfo = info.TypeInfo
 
-		db, err := sql.Open("duckdb", "")
-		require.NoError(t, err)
+			db := openDbWrapper(t, ``)
+			defer closeDbWrapper(t, db)
 
-		c, err := db.Conn(context.Background())
-		require.NoError(t, err)
+			conn := openConnWrapper(t, db, context.Background())
+			defer closeConnWrapper(t, conn)
 
-		_, err = c.ExecContext(context.Background(), `CREATE TYPE greeting AS ENUM ('hello', 'world')`)
-		require.NoError(t, err)
+			_, err := conn.ExecContext(context.Background(), `CREATE TYPE greeting AS ENUM ('hello', 'world')`)
+			require.NoError(t, err)
 
-		var udf *typesSUDF
-		err = RegisterScalarUDF(c, "my_identity", udf)
-		require.NoError(t, err)
+			var udf *typesSUDF
+			err = RegisterScalarUDF(conn, "my_identity", udf)
+			require.NoError(t, err)
 
-		var res string
-		row := db.QueryRow(fmt.Sprintf(`SELECT my_identity(%s)::VARCHAR AS res`, info.input))
-		require.NoError(t, row.Scan(&res))
-		if info.TypeInfo.InternalType() != TYPE_UUID {
-			require.Equal(t, info.output, res, `output does not match expected output, input: %s`, info.input)
-		} else {
-			require.NotEqual(t, "", res, "uuid empty")
-		}
-
-		require.NoError(t, c.Close())
-		require.NoError(t, db.Close())
+			var res string
+			row := db.QueryRow(fmt.Sprintf(`SELECT my_identity(%s)::VARCHAR AS res`, info.input))
+			require.NoError(t, row.Scan(&res))
+			if info.TypeInfo.InternalType() != TYPE_UUID {
+				require.Equal(t, info.output, res, `output does not match expected output, input: %s`, info.input)
+			} else {
+				require.NotEqual(t, "", res, "uuid empty")
+			}
+		}()
 	}
 }
 
 func TestScalarUDFSet(t *testing.T) {
-	db, err := sql.Open("duckdb", "")
-	require.NoError(t, err)
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
 
-	c, err := db.Conn(context.Background())
-	require.NoError(t, err)
+	conn := openConnWrapper(t, db, context.Background())
+	defer closeConnWrapper(t, conn)
 
+	var err error
 	currentInfo, err = NewTypeInfo(TYPE_INTEGER)
 	require.NoError(t, err)
 
 	var udf1 *simpleSUDF
 	var udf2 *typesSUDF
-	err = RegisterScalarUDFSet(c, "my_addition", udf1, udf2)
+	err = RegisterScalarUDFSet(conn, "my_addition", udf1, udf2)
 	require.NoError(t, err)
 
 	var sum int
@@ -285,23 +281,21 @@ func TestScalarUDFSet(t *testing.T) {
 	row = db.QueryRow(`SELECT my_addition(42) AS sum`)
 	require.NoError(t, row.Scan(&sum))
 	require.Equal(t, 42, sum)
-
-	require.NoError(t, c.Close())
-	require.NoError(t, db.Close())
 }
 
 func TestVariadicScalarUDF(t *testing.T) {
-	db, err := sql.Open("duckdb", "")
-	require.NoError(t, err)
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
 
-	c, err := db.Conn(context.Background())
-	require.NoError(t, err)
+	conn := openConnWrapper(t, db, context.Background())
+	defer closeConnWrapper(t, conn)
 
+	var err error
 	currentInfo, err = NewTypeInfo(TYPE_INTEGER)
 	require.NoError(t, err)
 
 	var udf *variadicSUDF
-	err = RegisterScalarUDF(c, "my_variadic_sum", udf)
+	err = RegisterScalarUDF(conn, "my_variadic_sum", udf)
 	require.NoError(t, err)
 
 	var sum *int
@@ -324,23 +318,21 @@ func TestVariadicScalarUDF(t *testing.T) {
 	row = db.QueryRow(`SELECT my_variadic_sum() AS msg`)
 	require.NoError(t, row.Scan(&sum))
 	require.Equal(t, 0, *sum)
-
-	require.NoError(t, c.Close())
-	require.NoError(t, db.Close())
 }
 
 func TestANYScalarUDF(t *testing.T) {
-	db, err := sql.Open("duckdb", "")
-	require.NoError(t, err)
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
 
-	c, err := db.Conn(context.Background())
-	require.NoError(t, err)
+	conn := openConnWrapper(t, db, context.Background())
+	defer closeConnWrapper(t, conn)
 
+	var err error
 	currentInfo, err = NewTypeInfo(TYPE_INTEGER)
 	require.NoError(t, err)
 
 	var udf *anyTypeSUDF
-	err = RegisterScalarUDF(c, "my_null_count", udf)
+	err = RegisterScalarUDF(conn, "my_null_count", udf)
 	require.NoError(t, err)
 
 	var count int
@@ -363,49 +355,45 @@ func TestANYScalarUDF(t *testing.T) {
 	row = db.QueryRow(`SELECT my_null_count() AS msg`)
 	require.NoError(t, row.Scan(&count))
 	require.Equal(t, 0, count)
-
-	require.NoError(t, c.Close())
-	require.NoError(t, db.Close())
 }
 
 func TestErrScalarUDF(t *testing.T) {
-	t.Parallel()
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
 
-	db, err := sql.Open("duckdb", "")
-	require.NoError(t, err)
+	conn := openConnWrapper(t, db, context.Background())
+	defer closeConnWrapper(t, conn)
 
-	c, err := db.Conn(context.Background())
-	require.NoError(t, err)
-
+	var err error
 	currentInfo, err = NewTypeInfo(TYPE_INTEGER)
 	require.NoError(t, err)
 
 	// Empty name.
 	var emptyNameUDF *simpleSUDF
-	err = RegisterScalarUDF(c, "", emptyNameUDF)
+	err = RegisterScalarUDF(conn, "", emptyNameUDF)
 	testError(t, err, errAPI.Error(), errScalarUDFCreate.Error(), errScalarUDFNoName.Error())
 
 	// Invalid executor.
 	var errExecutorUDF *errExecutorSUDF
-	err = RegisterScalarUDF(c, "err_executor_is_nil", errExecutorUDF)
+	err = RegisterScalarUDF(conn, "err_executor_is_nil", errExecutorUDF)
 	testError(t, err, errAPI.Error(), errScalarUDFCreate.Error(), errScalarUDFNoExecutor.Error())
 
 	// Invalid input parameter.
 	var errInputNilUDF *errInputNilSUDF
-	err = RegisterScalarUDF(c, "err_input_type_is_nil", errInputNilUDF)
+	err = RegisterScalarUDF(conn, "err_input_type_is_nil", errInputNilUDF)
 	testError(t, err, errAPI.Error(), errScalarUDFCreate.Error(), errScalarUDFInputTypeIsNil.Error())
 
 	// Invalid result parameters.
 	var errResultNil *errResultNilSUDF
-	err = RegisterScalarUDF(c, "err_result_type_is_nil", errResultNil)
+	err = RegisterScalarUDF(conn, "err_result_type_is_nil", errResultNil)
 	testError(t, err, errAPI.Error(), errScalarUDFCreate.Error(), errScalarUDFResultTypeIsNil.Error())
 	var errResultAny *errResultAnySUDF
-	err = RegisterScalarUDF(c, "err_result_type_is_any", errResultAny)
+	err = RegisterScalarUDF(conn, "err_result_type_is_any", errResultAny)
 	testError(t, err, errAPI.Error(), errScalarUDFCreate.Error(), errScalarUDFResultTypeIsANY.Error())
 
 	// Error during execution.
 	var errExecUDF *errExecSUDF
-	err = RegisterScalarUDF(c, "err_exec", errExecUDF)
+	err = RegisterScalarUDF(conn, "err_exec", errExecUDF)
 	require.NoError(t, err)
 	row := db.QueryRow(`SELECT err_exec(10, 10) AS res`)
 	testError(t, row.Err(), errAPI.Error())
@@ -413,24 +401,33 @@ func TestErrScalarUDF(t *testing.T) {
 	// Register the same scalar function a second time.
 	// Since RegisterScalarUDF takes ownership of udf, we are now passing nil.
 	var udf *simpleSUDF
-	err = RegisterScalarUDF(c, "my_sum", udf)
+	err = RegisterScalarUDF(conn, "my_sum", udf)
 	require.NoError(t, err)
-	err = RegisterScalarUDF(c, "my_sum", udf)
+	err = RegisterScalarUDF(conn, "my_sum", udf)
 	testError(t, err, errAPI.Error(), errScalarUDFCreate.Error())
 
 	// Register a scalar function whose name already exists.
 	var errDuplicateUDF *simpleSUDF
-	err = RegisterScalarUDF(c, "my_sum", errDuplicateUDF)
+	err = RegisterScalarUDF(conn, "my_sum", errDuplicateUDF)
 	testError(t, err, errAPI.Error(), errScalarUDFCreate.Error())
 
 	// Register a scalar function that is nil.
-	err = RegisterScalarUDF(c, "my_sum", nil)
+	err = RegisterScalarUDF(conn, "my_sum", nil)
 	testError(t, err, errAPI.Error(), errScalarUDFIsNil.Error())
-	require.NoError(t, c.Close())
+}
 
-	// Test registering the scalar function on a closed connection.
+func TestErrScalarUDFClosedConn(t *testing.T) {
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
+
+	var err error
+	currentInfo, err = NewTypeInfo(TYPE_INTEGER)
+	require.NoError(t, err)
+
+	conn := openConnWrapper(t, db, context.Background())
+	closeConnWrapper(t, conn)
+
 	var errClosedConUDF *simpleSUDF
-	err = RegisterScalarUDF(c, "closed_con", errClosedConUDF)
+	err = RegisterScalarUDF(conn, "closed_con", errClosedConUDF)
 	require.ErrorContains(t, err, sql.ErrConnDone.Error())
-	require.NoError(t, db.Close())
 }


### PR DESCRIPTION
This is the fourth PR in a series of moving the testing changes in https://github.com/marcboeker/go-duckdb/pull/364 into separate PRs.