### PR TITLE
Add test wrappers PR 5 - tableUDF_test, type_info_test, and types_test

### DIFF
--- a/duckdb_test.go
+++ b/duckdb_test.go
@@ -113,13 +113,6 @@ func checkIsMemory(t *testing.T, db *sql.DB) {
 	require.True(t, res.Next())
 }
 
-func openDB(t *testing.T) *sql.DB {
-	db, err := sql.Open("duckdb", "")
-	require.NoError(t, err)
-	require.NoError(t, db.Ping())
-	return db
-}
-
 /* ---------- Tests ---------- */
 
 func TestOpen(t *testing.T) {

--- a/tableUDF_test.go
+++ b/tableUDF_test.go
@@ -2,7 +2,6 @@ package duckdb
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"math/big"
 	"sync"
@@ -633,8 +632,6 @@ func (udf *chunkIncTableUDF) Cardinality() *CardinalityInfo {
 }
 
 func TestTableUDF(t *testing.T) {
-	t.Parallel()
-
 	for _, udf := range rowTableUDFs {
 		t.Run(udf.name, func(t *testing.T) {
 			singleTableUDF(t, udf)
@@ -655,17 +652,18 @@ func TestTableUDF(t *testing.T) {
 }
 
 func singleTableUDF[T TableFunction](t *testing.T, fun tableUDFTest[T]) {
-	db, err := sql.Open("duckdb", "?access_mode=READ_WRITE")
-	require.NoError(t, err)
+	db := openDbWrapper(t, `?access_mode=READ_WRITE`)
+	defer closeDbWrapper(t, db)
 
-	con, err := db.Conn(context.Background())
-	require.NoError(t, err)
+	conn := openConnWrapper(t, db, context.Background())
+	defer closeConnWrapper(t, conn)
 
-	err = RegisterTableUDF(con, fun.name, fun.udf.GetFunction())
+	err := RegisterTableUDF(conn, fun.name, fun.udf.GetFunction())
 	require.NoError(t, err)
 
 	res, err := db.QueryContext(context.Background(), fmt.Sprintf(fun.query, fun.name))
 	require.NoError(t, err)
+	defer closeRowsWrapper(t, res)
 
 	values := fun.udf.GetTypes()
 	args := make([]interface{}, len(values))
@@ -676,105 +674,85 @@ func singleTableUDF[T TableFunction](t *testing.T, fun tableUDFTest[T]) {
 	count := 0
 	for r := 0; res.Next(); r++ {
 		require.NoError(t, res.Scan(args...))
-
 		for i, value := range values {
 			expected := fun.udf.GetValue(r, i)
 			require.Equal(t, expected, value, "incorrect value")
 		}
 		count++
 	}
-
 	require.Equal(t, count, fun.resultCount, "result count did not match the expected count")
-	require.NoError(t, res.Close())
-	require.NoError(t, con.Close())
-	require.NoError(t, db.Close())
 }
 
 func TestErrTableUDF(t *testing.T) {
-	t.Parallel()
+	db := openDbWrapper(t, `?access_mode=READ_WRITE`)
+	defer closeDbWrapper(t, db)
 
-	db, err := sql.Open("duckdb", "?access_mode=READ_WRITE")
-	require.NoError(t, err)
-
-	con, err := db.Conn(context.Background())
-	require.NoError(t, err)
+	conn := openConnWrapper(t, db, context.Background())
+	defer closeConnWrapper(t, conn)
 
 	// Empty name.
 	var emptyNameUDF incTableUDF
-	err = RegisterTableUDF(con, "", emptyNameUDF.GetFunction())
+	err := RegisterTableUDF(conn, "", emptyNameUDF.GetFunction())
 	testError(t, err, errAPI.Error(), errTableUDFCreate.Error(), errTableUDFNoName.Error())
 
 	// FIXME: add more error tests.
-
-	require.NoError(t, con.Close())
-	require.NoError(t, db.Close())
 }
 
 func TestErrTableUDFUnsupportedType(t *testing.T) {
-	t.Parallel()
-
 	for _, udf := range unsupportedTypeUDFs {
 		t.Run(udf.name, func(t *testing.T) {
-			db, err := sql.Open("duckdb", "?access_mode=READ_WRITE")
+			db := openDbWrapper(t, `?access_mode=READ_WRITE`)
+			conn := openConnWrapper(t, db, context.Background())
+
+			err := RegisterTableUDF(conn, udf.name, udf.udf.GetFunction())
 			require.NoError(t, err)
 
-			con, err := db.Conn(context.Background())
-			require.NoError(t, err)
-
-			err = RegisterTableUDF(con, udf.name, udf.udf.GetFunction())
-			require.NoError(t, err)
-
-			_, err = db.QueryContext(context.Background(), fmt.Sprintf(udf.query, udf.name))
+			res, err := db.QueryContext(context.Background(), fmt.Sprintf(udf.query, udf.name))
 			require.Contains(t, err.Error(), unsupportedTypeErrMsg)
 
-			require.NoError(t, con.Close())
-			require.NoError(t, db.Close())
+			closeRowsWrapper(t, res)
+			closeConnWrapper(t, conn)
+			closeDbWrapper(t, db)
 		})
 	}
 }
 
 func BenchmarkRowTableUDF(b *testing.B) {
 	b.StopTimer()
-	db, err := sql.Open("duckdb", "?access_mode=READ_WRITE")
-	require.NoError(b, err)
+	db := openDbWrapper(b, `?access_mode=READ_WRITE`)
+	defer closeDbWrapper(b, db)
 
-	con, err := db.Conn(context.Background())
-	require.NoError(b, err)
+	conn := openConnWrapper(b, db, context.Background())
+	defer closeConnWrapper(b, conn)
 
 	var fun incTableUDF
-	err = RegisterTableUDF(con, "whoo", fun.GetFunction())
+	err := RegisterTableUDF(conn, "whoo", fun.GetFunction())
 	require.NoError(b, err)
 
 	b.StartTimer()
 	for n := 0; n < b.N; n++ {
 		res, errQuery := db.QueryContext(context.Background(), "SELECT * FROM whoo(2048*64)")
 		require.NoError(b, errQuery)
-		require.NoError(b, res.Close())
+		closeRowsWrapper(b, res)
 	}
-
-	require.NoError(b, con.Close())
-	require.NoError(b, db.Close())
 }
 
 func BenchmarkChunkTableUDF(b *testing.B) {
 	b.StopTimer()
-	db, err := sql.Open("duckdb", "?access_mode=READ_WRITE")
-	require.NoError(b, err)
+	db := openDbWrapper(b, `?access_mode=READ_WRITE`)
+	defer closeDbWrapper(b, db)
 
-	con, err := db.Conn(context.Background())
-	require.NoError(b, err)
+	conn := openConnWrapper(b, db, context.Background())
+	defer closeConnWrapper(b, conn)
 
 	var fun chunkIncTableUDF
-	err = RegisterTableUDF(con, "whoo", fun.GetFunction())
+	err := RegisterTableUDF(conn, "whoo", fun.GetFunction())
 	require.NoError(b, err)
 
 	b.StartTimer()
 	for n := 0; n < b.N; n++ {
 		res, errQuery := db.QueryContext(context.Background(), "SELECT * FROM whoo(2048*64)")
 		require.NoError(b, errQuery)
-		require.NoError(b, res.Close())
+		closeRowsWrapper(b, res)
 	}
-
-	require.NoError(b, con.Close())
-	require.NoError(b, db.Close())
 }

--- a/type_info_test.go
+++ b/type_info_test.go
@@ -200,8 +200,6 @@ func TestTypeInterface(t *testing.T) {
 }
 
 func TestErrTypeInfo(t *testing.T) {
-	t.Parallel()
-
 	var incorrectTypes []Type
 	incorrectTypes = append(incorrectTypes, TYPE_DECIMAL, TYPE_ENUM, TYPE_LIST, TYPE_STRUCT, TYPE_MAP, TYPE_ARRAY)
 

--- a/types_test.go
+++ b/types_test.go
@@ -200,7 +200,7 @@ func testTypesReset[T require.TestingT](t T, c *Connector) {
 	require.NoError(t, err)
 }
 
-func testTypes[T require.TestingT](t T, c *Connector, a *Appender, expectedRows []testTypesRow) []testTypesRow {
+func testTypes[T require.TestingT](t T, db *sql.DB, a *Appender, expectedRows []testTypesRow) []testTypesRow {
 	// Append the rows. We cannot append Composite types.
 	for i := 0; i < len(expectedRows); i++ {
 		r := &expectedRows[i]
@@ -242,8 +242,9 @@ func testTypes[T require.TestingT](t T, c *Connector, a *Appender, expectedRows 
 	}
 	require.NoError(t, a.Flush())
 
-	res, err := sql.OpenDB(c).QueryContext(context.Background(), `SELECT * FROM test ORDER BY Smallint_col`)
+	res, err := db.QueryContext(context.Background(), `SELECT * FROM test ORDER BY Smallint_col`)
 	require.NoError(t, err)
+	defer closeRowsWrapper(t, res)
 
 	// Scan the rows.
 	var actualRows []testTypesRow
@@ -293,18 +294,16 @@ func testTypes[T require.TestingT](t T, c *Connector, a *Appender, expectedRows 
 }
 
 func TestTypes(t *testing.T) {
-	t.Parallel()
 	expectedRows := testTypesGenerateRows(t, 3)
-	c, db, con, a := prepareAppender(t, testTypesEnumSQL+";"+testTypesTableSQL)
-	actualRows := testTypes(t, c, a, expectedRows)
+	c, db, conn, a := prepareAppender(t, testTypesEnumSQL+";"+testTypesTableSQL)
+	defer cleanupAppender(t, c, db, conn, a)
+	actualRows := testTypes(t, db, a, expectedRows)
 
 	for i := range actualRows {
 		expectedRows[i].toUTC()
 		require.Equal(t, expectedRows[i], actualRows[i])
 	}
-
 	require.Equal(t, len(expectedRows), len(actualRows))
-	cleanupAppender(t, c, db, con, a)
 }
 
 // NOTE: go-duckdb only contains very few benchmarks. The purpose of those benchmarks is to avoid regressions
@@ -313,19 +312,19 @@ var benchmarkTypesResult []testTypesRow
 
 func BenchmarkTypes(b *testing.B) {
 	expectedRows := testTypesGenerateRows(b, GetDataChunkCapacity()*3+10)
-	c, db, con, a := prepareAppender(b, testTypesEnumSQL+";"+testTypesTableSQL)
+	c, db, conn, a := prepareAppender(b, testTypesEnumSQL+";"+testTypesTableSQL)
+	defer cleanupAppender(b, c, db, conn, a)
 
 	var r []testTypesRow
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		r = testTypes(b, c, a, expectedRows)
+		r = testTypes(b, db, a, expectedRows)
 		testTypesReset(b, c)
 	}
 	b.StopTimer()
 
 	// Ensure that the compiler does not eliminate the line by storing the result.
 	benchmarkTypesResult = r
-	cleanupAppender(b, c, db, con, a)
 }
 
 func compareDecimal(t *testing.T, want Decimal, got Decimal) {
@@ -335,8 +334,8 @@ func compareDecimal(t *testing.T, want Decimal, got Decimal) {
 }
 
 func TestDecimal(t *testing.T) {
-	t.Parallel()
-	db := openDB(t)
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
 
 	t.Run("SELECT all possible DECIMAL widths", func(t *testing.T) {
 		for i := 1; i <= 38; i++ {
@@ -361,7 +360,7 @@ func TestDecimal(t *testing.T) {
 		) v
 		ORDER BY v ASC`)
 		require.NoError(t, err)
-		require.NoError(t, res.Close())
+		defer closeRowsWrapper(t, res)
 
 		bigNumber, success := new(big.Int).SetString("1234567890123456789234", 10)
 		require.True(t, success)
@@ -443,13 +442,9 @@ func TestDecimal(t *testing.T) {
 			require.Equal(t, test.want, fs.String())
 		}
 	})
-
-	require.NoError(t, db.Close())
 }
 
 func TestDecimalString(t *testing.T) {
-	t.Parallel()
-
 	testCases := []struct {
 		input    Decimal
 		expected string
@@ -593,19 +588,18 @@ func TestDecimalString(t *testing.T) {
 }
 
 func TestBlob(t *testing.T) {
-	t.Parallel()
-	db := openDB(t)
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
 
 	// Scan a hexadecimal value.
 	var b []byte
 	require.NoError(t, db.QueryRow("SELECT '\\xAA'::BLOB").Scan(&b))
 	require.Equal(t, []byte{0xAA}, b)
-	require.NoError(t, db.Close())
 }
 
 func TestList(t *testing.T) {
-	t.Parallel()
-	db := openDB(t)
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
 
 	// Test a LIST exceeding duckdb's standard vector size.
 	const n = 4000
@@ -615,12 +609,11 @@ func TestList(t *testing.T) {
 	for i := 0; i < n; i++ {
 		require.Equal(t, i, row.Get()[i])
 	}
-	require.NoError(t, db.Close())
 }
 
 func TestUUID(t *testing.T) {
-	t.Parallel()
-	db := openDB(t)
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
 
 	_, err := db.Exec(`CREATE TABLE uuid_test(uuid UUID)`)
 	require.NoError(t, err)
@@ -654,13 +647,11 @@ func TestUUID(t *testing.T) {
 		require.NoError(t, db.QueryRow(`SELECT ?::uuid`, test).Scan(&u))
 		require.Equal(t, test.String(), u.String())
 	}
-
-	require.NoError(t, db.Close())
 }
 
 func TestUUIDScanError(t *testing.T) {
-	t.Parallel()
-	db := openDB(t)
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
 
 	var u UUID
 	// invalid value type
@@ -672,8 +663,8 @@ func TestUUIDScanError(t *testing.T) {
 }
 
 func TestDate(t *testing.T) {
-	t.Parallel()
-	db := openDB(t)
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
 
 	tests := map[string]struct {
 		want  time.Time
@@ -697,13 +688,11 @@ func TestDate(t *testing.T) {
 	err = db.QueryRow(`SELECT ?::DATE`, ts).Scan(&res)
 	require.NoError(t, err)
 	require.Equal(t, time.Date(2006, time.January, 0o2, 0, 0, 0, 0, time.UTC), res)
-
-	require.NoError(t, db.Close())
 }
 
 func TestTime(t *testing.T) {
-	t.Parallel()
-	db := openDB(t)
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
 
 	IST, err := time.LoadLocation("Asia/Kolkata")
 	require.NoError(t, err)
@@ -720,13 +709,11 @@ func TestTime(t *testing.T) {
 	err = db.QueryRow(`SELECT ?::TIMETZ`, timeTZ).Scan(&res)
 	require.NoError(t, err)
 	require.Equal(t, timeTZ.UTC(), res)
-
-	require.NoError(t, db.Close())
 }
 
 func TestENUMs(t *testing.T) {
-	t.Parallel()
-	db := openDB(t)
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
 
 	type environment string
 	const (
@@ -759,13 +746,11 @@ func TestENUMs(t *testing.T) {
 	var row Composite[[]environment]
 	require.NoError(t, db.QueryRow("SELECT environments FROM all_enums").Scan(&row))
 	require.ElementsMatch(t, []environment{Air, Sea, Land}, row.Get())
-
-	require.NoError(t, db.Close())
 }
 
 func TestHugeInt(t *testing.T) {
-	t.Parallel()
-	db := openDB(t)
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
 
 	t.Run("SELECT different HUGEINT values", func(t *testing.T) {
 		tests := []string{
@@ -805,13 +790,11 @@ func TestHugeInt(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "too big for HUGEINT")
 	})
-
-	require.NoError(t, db.Close())
 }
 
 func TestTimestampTZ(t *testing.T) {
-	t.Parallel()
-	db := openDB(t)
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
 
 	_, err := db.Exec("CREATE TABLE IF NOT EXISTS tbl (tz TIMESTAMPTZ)")
 	require.NoError(t, err)
@@ -830,12 +813,11 @@ func TestTimestampTZ(t *testing.T) {
 	err = db.QueryRow("SELECT tz FROM tbl").Scan(&tz)
 	require.NoError(t, err)
 	require.Equal(t, ts.UTC(), tz)
-	require.NoError(t, db.Close())
 }
 
 func TestBoolean(t *testing.T) {
-	t.Parallel()
-	db := openDB(t)
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
 
 	var res bool
 	require.NoError(t, db.QueryRow("SELECT ?", true).Scan(&res))
@@ -849,12 +831,11 @@ func TestBoolean(t *testing.T) {
 
 	require.NoError(t, db.QueryRow("SELECT ?", 1).Scan(&res))
 	require.True(t, res)
-	require.NoError(t, db.Close())
 }
 
 func TestTimestamp(t *testing.T) {
-	t.Parallel()
-	db := openDB(t)
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
 
 	tests := map[string]struct {
 		input string
@@ -872,12 +853,11 @@ func TestTimestamp(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, test.want, res)
 	}
-	require.NoError(t, db.Close())
 }
 
 func TestInterval(t *testing.T) {
-	t.Parallel()
-	db := openDB(t)
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
 
 	t.Run("INTERVAL binding", func(t *testing.T) {
 		interval := Interval{Days: 10, Months: 4, Micros: 4}
@@ -913,17 +893,13 @@ func TestInterval(t *testing.T) {
 			require.Equal(t, test.want, res)
 		}
 	})
-
-	require.NoError(t, db.Close())
 }
 
 func TestArray(t *testing.T) {
-	t.Parallel()
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
 
-	db, err := sql.Open("duckdb", "")
-	require.NoError(t, err)
-
-	_, err = db.Exec(`CREATE TABLE needle (vec FLOAT[3])`)
+	_, err := db.Exec(`CREATE TABLE needle (vec FLOAT[3])`)
 	require.NoError(t, err)
 
 	_, err = db.Exec(`INSERT INTO needle VALUES (array[5, 5, 5])`)
@@ -931,6 +907,7 @@ func TestArray(t *testing.T) {
 
 	res, err := db.Query(`SELECT vec FROM needle`)
 	require.NoError(t, err)
+	defer closeRowsWrapper(t, res)
 
 	for res.Next() {
 		var vec Composite[[3]float64]
@@ -939,14 +916,11 @@ func TestArray(t *testing.T) {
 		require.NoError(t, res.Err())
 		require.Equal(t, [3]float64{5, 5, 5}, vec.Get())
 	}
-
-	require.NoError(t, res.Close())
-	require.NoError(t, db.Close())
 }
 
 func TestJSONType(t *testing.T) {
-	t.Parallel()
-	db := openDB(t)
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
 
 	_, err := db.Exec(`CREATE TABLE test (c1 STRUCT(index INTEGER))`)
 	require.NoError(t, err)
@@ -968,5 +942,4 @@ func TestJSONType(t *testing.T) {
 	require.Equal(t, float64(1), res.Get()["1"])
 	require.Equal(t, float64(2), res.Get()["2"])
 	require.Equal(t, float64(3), res.Get()["3"])
-	require.NoError(t, db.Close())
 }


### PR DESCRIPTION
This is the sixth PR in a series of moving the testing changes in https://github.com/marcboeker/go-duckdb/pull/364 into separate PRs.