### PR TITLE
Do not use the instance cache for in-memory databases

### DIFF
--- a/duckdb.go
+++ b/duckdb.go
@@ -74,7 +74,7 @@ func NewConnector(dsn string, connInitFn func(execer driver.ExecerContext) error
 
 	if inMemory {
 		// Open an in-memory database.
-		state = mapping.OpenExt(getDBPath(dsn), &db, config, &errMsg)
+		state = mapping.OpenExt("", &db, config, &errMsg)
 	} else {
 		// Open a file-backed database.
 		state = mapping.GetOrCreateFromCache(GetInstanceCache(), getDBPath(dsn), &db, config, &errMsg)

--- a/duckdb_test.go
+++ b/duckdb_test.go
@@ -782,6 +782,21 @@ func TestInstanceCache(t *testing.T) {
 	}
 }
 
+func TestInstanceCacheWithInMemoryDB(t *testing.T) {
+	db1 := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db1)
+
+	_, err := db1.Exec(`CREATE TABLE test AS SELECT 1 AS id`)
+	require.NoError(t, err)
+
+	db2 := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db2)
+
+	var id int
+	err = db2.QueryRow(`SELECT * FROM test`).Scan(&id)
+	require.ErrorContains(t, err, "Table with name test does not exist")
+}
+
 func Example_simpleConnection() {
 	// Connect to DuckDB using '[database/sql.Open]'.
 	db, err := sql.Open("duckdb", "?access_mode=READ_WRITE")


### PR DESCRIPTION
In a future PR, we can consider allowing the labelling of in-memory databases, similar to what the Python client does to cache them.
```
:memory:my_label:?...
```