### PR TITLE
Fallback for binding unresolved parameters

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -1,11 +1,13 @@
 package duckdb
 
+import "C"
 import (
 	"context"
 	"database/sql/driver"
 	"errors"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/marcboeker/go-duckdb/mapping"
 )
@@ -186,13 +188,35 @@ func (s *Stmt) bindTime(val driver.NamedValue, t Type, n int) (mapping.State, er
 	return state, nil
 }
 
+func (s *Stmt) tryBindComplexValue(val driver.NamedValue, t Type, n int) (mapping.State, error) {
+	switch val.Value.(type) {
+	case time.Time:
+		// Fallback to TIMESTAMP, if we cannot know the exact type.
+		// Let DuckDB cast the value.
+		return s.bindTimestamp(val, TYPE_TIMESTAMP, n)
+	}
+	name := typeToStringMap[t]
+	return mapping.StateError, addIndexToError(unsupportedTypeError(name), n+1)
+}
+
 func (s *Stmt) bindComplexValue(val driver.NamedValue, n int) (mapping.State, error) {
+	// For some queries, we cannot resolve the parameter type when preparing the query.
+	// E.g., for "SELECT * FROM (VALUES (?, ?)) t(a, b)", we cannot know the parameter types from the SQL statement alone.
+	// For these cases, ParamType returns TYPE_INVALID.
 	t, err := s.ParamType(n + 1)
 	if err != nil {
 		return mapping.StateError, err
 	}
-	if name, ok := unsupportedTypeToStringMap[t]; ok {
+
+	name, ok := unsupportedTypeToStringMap[t]
+	if ok && t != TYPE_INVALID {
 		return mapping.StateError, addIndexToError(unsupportedTypeError(name), n+1)
+	}
+
+	// We could not resolve this parameter when binding the query.
+	// Fall back to the Go type.
+	if t == TYPE_INVALID {
+		return s.tryBindComplexValue(val, t, n)
 	}
 
 	switch t {
@@ -206,8 +230,8 @@ func (s *Stmt) bindComplexValue(val driver.NamedValue, n int) (mapping.State, er
 		TYPE_ARRAY, TYPE_ENUM:
 		// FIXME: for timestamps: distinguish between timestamp[_s|ms|ns] once available.
 		// FIXME: for other types: duckdb_param_logical_type once available, then create duckdb_value + duckdb_bind_value
-		// FIXME: for other types: implement NamedValueChecker to support custom data types.
-		name := typeToStringMap[t]
+		// FIXME: for other types: use NamedValueChecker to support.
+		name = typeToStringMap[t]
 		return mapping.StateError, addIndexToError(unsupportedTypeError(name), n+1)
 	}
 	return mapping.StateError, addIndexToError(unsupportedTypeError(unknownTypeErrMsg), n+1)
@@ -231,7 +255,7 @@ func (s *Stmt) bindValue(val driver.NamedValue, n int) (mapping.State, error) {
 	case *big.Int:
 		return s.bindHugeint(v, n)
 	case Decimal:
-		// FIXME: implement NamedValueChecker to support custom data types.
+		// FIXME: use NamedValueChecker to support this type.
 		name := typeToStringMap[TYPE_DECIMAL]
 		return mapping.StateError, addIndexToError(unsupportedTypeError(name), n+1)
 	case uint8:

--- a/statement.go
+++ b/statement.go
@@ -1,6 +1,5 @@
 package duckdb
 
-import "C"
 import (
 	"context"
 	"database/sql/driver"
@@ -192,7 +191,6 @@ func (s *Stmt) tryBindComplexValue(val driver.NamedValue, t Type, n int) (mappin
 	switch val.Value.(type) {
 	case time.Time:
 		// Fallback to TIMESTAMP, if we cannot know the exact type.
-		// Let DuckDB cast the value.
 		return s.bindTimestamp(val, TYPE_TIMESTAMP, n)
 	}
 	name := typeToStringMap[t]

--- a/statement_test.go
+++ b/statement_test.go
@@ -426,4 +426,9 @@ func TestBindWithoutResolvedParams(t *testing.T) {
 	require.NoError(t, r.Scan(&a, &b))
 	require.Equal(t, "2022-02-07 00:00:00", a)
 	require.Equal(t, "2022-02-07 00:00:00", b)
+
+	// Type without a fallback.
+	s := []int32{1}
+	r = db.QueryRow(`SELECT a::VARCHAR, b::VARCHAR FROM (VALUES (?, ?)) t(a, b)`, s, s)
+	require.Contains(t, r.Err().Error(), "unsupported type")
 }

--- a/statement_test.go
+++ b/statement_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql/driver"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -410,4 +411,19 @@ func TestPreparePivot(t *testing.T) {
 	require.Equal(t, "Netherlands", name)
 	require.Equal(t, 42, population)
 	closePreparedWrapper(t, prepared)
+}
+
+func TestBindWithoutResolvedParams(t *testing.T) {
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
+
+	d := time.Date(2022, 0o2, 0o7, 0, 0, 0, 0, time.UTC)
+
+	r := db.QueryRow(`SELECT a::VARCHAR, b::VARCHAR FROM (VALUES (?, ?)) t(a, b)`, d, d)
+	require.NoError(t, r.Err())
+
+	var a, b string
+	require.NoError(t, r.Scan(&a, &b))
+	require.Equal(t, "2022-02-07 00:00:00", a)
+	require.Equal(t, "2022-02-07 00:00:00", b)
 }


### PR DESCRIPTION
For some queries (like the one below), we cannot successfully resolve all parameter (types) when binding, as the SQL statement does not give us enough type information.

```sql
SELECT a, b FROM (VALUES (?, ?)) t(a, b)
```

Inside duckdb, we prepare the query with `parameters_resolved = false`. We do not set the so-called `value_map` for the prepared statement - which contains the logical types for the parameters.

In go-duckdb, we expect the `value_map` to be there, when we try to get the logical type of the (more complex) bind arguments. We don't try to get the logical type for many of the primitive bind arguments (type switch catches them), so we don't see an error here for these types. However, for, e.g., `time.Time` (`TIMESTAMP`), the current bind code throws an error, if we cannot resolve (bind) the parameters in the SQL statement.

To solve this, we need a fallback function in the binding phase - if we cannot get the logical type via `ParamType`, then we need to fall back to the Go type, or try and create our own `duckdb_value` by reflecting the input argument type. For ambiguous types like `TIMESTAMP`, `DATE`, ..., (same Go `time.Time` type) they have to default to `TIMESTAMP`.

This PR implements that fall back for `time.Time`, and inserts any `time.Time` via `mapping.BindTimestamp`.
