### PR TITLE
fix: switch Decimal methods to value receivers

### DIFF
--- a/types.go
+++ b/types.go
@@ -151,7 +151,7 @@ type Decimal struct {
 	Value *big.Int
 }
 
-func (d *Decimal) Float64() float64 {
+func (d Decimal) Float64() float64 {
 	scale := big.NewInt(int64(d.Scale))
 	factor := new(big.Float).SetInt(new(big.Int).Exp(big.NewInt(10), scale, nil))
 	value := new(big.Float).SetInt(d.Value)
@@ -160,7 +160,7 @@ func (d *Decimal) Float64() float64 {
 	return f
 }
 
-func (d *Decimal) String() string {
+func (d Decimal) String() string {
 	// Get the sign, and return early, if zero.
 	if d.Value.Sign() == 0 {
 		return "0"

--- a/types_test.go
+++ b/types_test.go
@@ -441,6 +441,8 @@ func TestDecimal(t *testing.T) {
 			var fs Decimal
 			require.NoError(t, r.Scan(&fs))
 			require.Equal(t, test.want, fs.String())
+			//confirms Decimal implements fmt.Stringer correctly (see #424)
+			require.Equal(t, test.want, fmt.Sprint(fs))
 		}
 	})
 }


### PR DESCRIPTION
Switches the Decimal methods from pointer to value receivers.

The ScanType of DECIMAL columns is Decimal, not *Decimal. Users would expect that methods are available on the exact type returned from ScanType, and this fix implements it. For example, this fix allows Decimal to be used where fmt.Stringer is expected, e.g. in the `fmt.*Print*` functions.

Closes #424 