### PR TITLE
Call AppendDataChunk immediately instead of caching data chunks in the Appender

### DIFF
--- a/appender.go
+++ b/appender.go
@@ -15,7 +15,7 @@ type Appender struct {
 	appender mapping.Appender
 	closed   bool
 
-	// The current chunk to append to.
+	// The chunk to append to.
 	chunk DataChunk
 	// The column types of the table to append to.
 	types []mapping.LogicalType

--- a/appender.go
+++ b/appender.go
@@ -15,8 +15,8 @@ type Appender struct {
 	appender mapping.Appender
 	closed   bool
 
-	// The appender storage before flushing any data.
-	chunks []DataChunk
+	// The current chunk to append to.
+	chunk DataChunk
 	// The column types of the table to append to.
 	types []mapping.LogicalType
 	// The number of appended rows.
@@ -71,6 +71,14 @@ func NewAppender(driverConn driver.Conn, catalog, schema, table string) (*Append
 		}
 	}
 
+	// Initialize the data chunk.
+	if err := a.chunk.initFromTypes(a.types, true); err != nil {
+		a.chunk.close()
+		destroyTypeSlice(a.types)
+		mapping.AppenderDestroy(&appender)
+		return nil, getError(errAppenderCreation, err)
+	}
+
 	return a, nil
 }
 
@@ -78,9 +86,10 @@ func NewAppender(driverConn driver.Conn, catalog, schema, table string) (*Append
 // Does not close the appender, even if it returns an error. Unless you have a good reason to call this,
 // call Close when you are done with the appender.
 func (a *Appender) Flush() error {
-	if err := a.appendDataChunks(); err != nil {
+	if err := a.appendDataChunk(); err != nil {
 		return getError(errAppenderFlush, invalidatedAppenderError(err))
 	}
+
 	if mapping.AppenderFlush(a.appender) == mapping.StateError {
 		err := getDuckDBError(mapping.AppenderError(a.appender))
 		return getError(errAppenderFlush, invalidatedAppenderError(err))
@@ -98,7 +107,8 @@ func (a *Appender) Close() error {
 	a.closed = true
 
 	// Append all remaining chunks.
-	errAppend := a.appendDataChunks()
+	errAppend := a.appendDataChunk()
+	a.chunk.close()
 
 	// We flush before closing to get a meaningful error message.
 	var errFlush error
@@ -135,16 +145,6 @@ func (a *Appender) AppendRow(args ...driver.Value) error {
 	return nil
 }
 
-func (a *Appender) addDataChunk() error {
-	var chunk DataChunk
-	if err := chunk.initFromTypes(a.types, true); err != nil {
-		return err
-	}
-	a.chunks = append(a.chunks, chunk)
-
-	return nil
-}
-
 func (a *Appender) appendRowSlice(args []driver.Value) error {
 	// Early-out, if the number of args does not match the column count.
 	if len(args) != len(a.types) {
@@ -152,17 +152,15 @@ func (a *Appender) appendRowSlice(args []driver.Value) error {
 	}
 
 	// Create a new data chunk if the current chunk is full.
-	if a.rowCount == GetDataChunkCapacity() || len(a.chunks) == 0 {
-		if err := a.addDataChunk(); err != nil {
+	if a.rowCount == GetDataChunkCapacity() {
+		if err := a.appendDataChunk(); err != nil {
 			return err
 		}
-		a.rowCount = 0
 	}
 
 	// Set all values.
 	for i, val := range args {
-		chunk := &a.chunks[len(a.chunks)-1]
-		err := chunk.SetValue(i, a.rowCount, val)
+		err := a.chunk.SetValue(i, a.rowCount, val)
 		if err != nil {
 			return err
 		}
@@ -172,31 +170,22 @@ func (a *Appender) appendRowSlice(args []driver.Value) error {
 	return nil
 }
 
-func (a *Appender) appendDataChunks() error {
-	var err error
-
-	for i, chunk := range a.chunks {
-		// All data chunks except the last are at maximum capacity.
-		size := GetDataChunkCapacity()
-		if i == len(a.chunks)-1 {
-			size = a.rowCount
-		}
-		if err = chunk.SetSize(size); err != nil {
-			break
-		}
-		if mapping.AppendDataChunk(a.appender, chunk.chunk) == mapping.StateError {
-			err = getDuckDBError(mapping.AppenderError(a.appender))
-			break
-		}
+func (a *Appender) appendDataChunk() error {
+	if a.rowCount == 0 {
+		// Nothing to append.
+		return nil
+	}
+	if err := a.chunk.SetSize(a.rowCount); err != nil {
+		return err
+	}
+	if mapping.AppendDataChunk(a.appender, a.chunk.chunk) == mapping.StateError {
+		return getDuckDBError(mapping.AppenderError(a.appender))
 	}
 
-	for _, chunk := range a.chunks {
-		chunk.close()
-	}
-	a.chunks = a.chunks[:0]
+	mapping.DataChunkReset(a.chunk.chunk)
 	a.rowCount = 0
 
-	return err
+	return nil
 }
 
 func destroyTypeSlice(slice []mapping.LogicalType) {

--- a/appender_test.go
+++ b/appender_test.go
@@ -494,7 +494,7 @@ func TestAppenderUUID(t *testing.T) {
 	}
 }
 
-func newAppenderHugeIntTest[T numericType](val T, c *Connector, db *sql.DB, a *Appender) func(t *testing.T) {
+func newAppenderHugeIntTest[T numericType](val T, db *sql.DB, a *Appender) func(t *testing.T) {
 	return func(t *testing.T) {
 		typeName := reflect.TypeOf(val).String()
 		require.NoError(t, a.AppendRow(val, typeName))
@@ -514,16 +514,16 @@ func TestAppenderHugeInt(t *testing.T) {
 	defer cleanupAppender(t, c, db, conn, a)
 
 	tests := map[string]func(t *testing.T){
-		"int8":    newAppenderHugeIntTest[int8](1, c, db, a),
-		"int16":   newAppenderHugeIntTest[int16](2, c, db, a),
-		"int32":   newAppenderHugeIntTest[int32](3, c, db, a),
-		"int64":   newAppenderHugeIntTest[int64](4, c, db, a),
-		"uint8":   newAppenderHugeIntTest[uint8](5, c, db, a),
-		"uint16":  newAppenderHugeIntTest[uint16](6, c, db, a),
-		"uint32":  newAppenderHugeIntTest[uint32](7, c, db, a),
-		"uint64":  newAppenderHugeIntTest[uint64](8, c, db, a),
-		"float32": newAppenderHugeIntTest[float32](9, c, db, a),
-		"float64": newAppenderHugeIntTest[float64](10, c, db, a),
+		"int8":    newAppenderHugeIntTest[int8](1, db, a),
+		"int16":   newAppenderHugeIntTest[int16](2, db, a),
+		"int32":   newAppenderHugeIntTest[int32](3, db, a),
+		"int64":   newAppenderHugeIntTest[int64](4, db, a),
+		"uint8":   newAppenderHugeIntTest[uint8](5, db, a),
+		"uint16":  newAppenderHugeIntTest[uint16](6, db, a),
+		"uint32":  newAppenderHugeIntTest[uint32](7, db, a),
+		"uint64":  newAppenderHugeIntTest[uint64](8, db, a),
+		"float32": newAppenderHugeIntTest[float32](9, db, a),
+		"float64": newAppenderHugeIntTest[float64](10, db, a),
 	}
 	for name, test := range tests {
 		t.Run(name, test)


### PR DESCRIPTION
DuckDB's `Appender` caches any data chunks it receives via `append_data_chunk`, until
1. explicitly calling `Flush`/`Close`, or
2. until it reaches DuckDB's default flush count (204800 tuples / 100 chunks).

```cpp
//! The amount of tuples that are gathered in the column data collection before flushing.
static constexpr const idx_t DEFAULT_FLUSH_COUNT = STANDARD_VECTOR_SIZE * 100ULL;
```

Before this PR, go-duckdb would cache data chunks, and only forward them to DuckDB when explicitly calling `Flush`/`Close`. This causes a few problems:
- memory management has to be done by go-duckdb (no default flush count during `AppendRow`) / the user has to call `Flush` repeatedly before being finished with the `Appender` to avoid go-duckdb's memory from increasing with each new cached data chunk.
- the semantics of go-duckdb's `Appender` differ from the intended use of DuckDB's `Appender`

Related issue comment: https://github.com/marcboeker/go-duckdb/issues/410#issuecomment-2785692336.

Closes https://github.com/marcboeker/go-duckdb/issues/410.

## Notes on compatibility

You might see some error messages slightly earlier now; but this PR should not change the result of your appends in DuckDB.
- for unsupported types during `Appender` creation instead of the first call to `AppendRow`
- for constraint violations, etc. during `AppendRow` instead of later during `Flush`
   - even when exceeding 100 chunks before calling `Flush`, and a constraint violation in a chunk after the first 100 chunks, the current implementation will default-flush the first 100 chunks before throwing the constraint violation on the later chunks. So the data being appended should not change with this PR.