### PR TITLE
Fix validity corruption bug when appending data chunks

### DIFF
--- a/appender.go
+++ b/appender.go
@@ -182,7 +182,7 @@ func (a *Appender) appendDataChunk() error {
 		return getDuckDBError(mapping.AppenderError(a.appender))
 	}
 
-	a.chunk.reset()
+	a.chunk.reset(true)
 	a.rowCount = 0
 
 	return nil

--- a/appender.go
+++ b/appender.go
@@ -182,7 +182,7 @@ func (a *Appender) appendDataChunk() error {
 		return getDuckDBError(mapping.AppenderError(a.appender))
 	}
 
-	mapping.DataChunkReset(a.chunk.chunk)
+	a.chunk.reset()
 	a.rowCount = 0
 
 	return nil

--- a/appender_test.go
+++ b/appender_test.go
@@ -940,9 +940,7 @@ func TestAppenderAppendDataChunk(t *testing.T) {
 		require.NoError(t, a.AppendRow(i, Union{Value: "str2", Tag: "s"}))
 		require.NoError(t, a.AppendRow(i, nil))
 	}
-
-	err := a.Flush()
-	require.NoError(t, err)
+	require.NoError(t, a.Flush())
 }
 
 func BenchmarkAppenderNested(b *testing.B) {

--- a/appender_test.go
+++ b/appender_test.go
@@ -1061,7 +1061,8 @@ func TestAppenderAppendDataChunk(t *testing.T) {
 
 	// Add enough rows to overflow several chunks
 	for i := 0; i < GetDataChunkCapacity()*3; i++ {
-		appender.AppendRow(i, Union{Value: "str2", Tag: "s"})
+		err := appender.AppendRow(i, Union{Value: "str2", Tag: "s"})
+		require.NoError(t, err)
 	}
 
 	err = appender.Flush()

--- a/appender_test.go
+++ b/appender_test.go
@@ -1063,6 +1063,8 @@ func TestAppenderAppendDataChunk(t *testing.T) {
 	for i := 0; i < GetDataChunkCapacity()*3; i++ {
 		err := appender.AppendRow(i, Union{Value: "str2", Tag: "s"})
 		require.NoError(t, err)
+		err = appender.AppendRow(i, nil)
+		require.NoError(t, err)
 	}
 
 	err = appender.Flush()

--- a/data_chunk.go
+++ b/data_chunk.go
@@ -87,23 +87,22 @@ func (chunk *DataChunk) initFromTypes(types []mapping.LogicalType, writable bool
 	}
 
 	chunk.chunk = mapping.CreateDataChunk(types)
-	mapping.DataChunkSetSize(chunk.chunk, mapping.IdxT(GetDataChunkCapacity()))
-
-	// Initialize the vectors and their child vectors.
-	for i := 0; i < columnCount; i++ {
-		v := mapping.DataChunkGetVector(chunk.chunk, mapping.IdxT(i))
-		chunk.columns[i].initVectors(v, writable)
-	}
+	chunk.initVectors(writable)
 
 	return nil
 }
 
-func (chunk *DataChunk) reset() {
+func (chunk *DataChunk) reset(writable bool) {
 	mapping.DataChunkReset(chunk.chunk)
+	chunk.initVectors(writable)
+}
 
-	for i, col := range chunk.columns {
+func (chunk *DataChunk) initVectors(writable bool) {
+	mapping.DataChunkSetSize(chunk.chunk, mapping.IdxT(GetDataChunkCapacity()))
+
+	for i := 0; i < len(chunk.columns); i++ {
 		v := mapping.DataChunkGetVector(chunk.chunk, mapping.IdxT(i))
-		col.initVectors(v, true)
+		chunk.columns[i].initVectors(v, writable)
 	}
 }
 

--- a/data_chunk.go
+++ b/data_chunk.go
@@ -98,6 +98,15 @@ func (chunk *DataChunk) initFromTypes(types []mapping.LogicalType, writable bool
 	return nil
 }
 
+func (chunk *DataChunk) reset() {
+	mapping.DataChunkReset(chunk.chunk)
+
+	for i, col := range chunk.columns {
+		v := mapping.DataChunkGetVector(chunk.chunk, mapping.IdxT(i))
+		col.initVectors(v, true)
+	}
+}
+
 func (chunk *DataChunk) initFromDuckDataChunk(inputChunk mapping.DataChunk, writable bool) error {
 	columnCount := mapping.DataChunkGetColumnCount(inputChunk)
 	chunk.columns = make([]vector, columnCount)

--- a/vector.go
+++ b/vector.go
@@ -118,10 +118,10 @@ func (vec *vector) initVectors(v mapping.Vector, writable bool) {
 		mapping.VectorEnsureValidityWritable(v)
 	}
 	vec.maskPtr = mapping.VectorGetValidity(v)
-	vec.getChildVectors(v, writable)
+	vec.initChildVectors(v, writable)
 }
 
-func (vec *vector) getChildVectors(v mapping.Vector, writable bool) {
+func (vec *vector) initChildVectors(v mapping.Vector, writable bool) {
 	switch vec.Type {
 	case TYPE_LIST, TYPE_MAP:
 		child := mapping.ListVectorGetChild(v)


### PR DESCRIPTION
Fixes #431

Fixes a seg fault that was happening due to the validity map not being reloaded when new data chunks are appended to an appender. For the full explanation and investigation see the issue.

I think this issue is a bug resulting from the change in https://github.com/marcboeker/go-duckdb/pull/428 and became more apparent in usages of Union where all non-populated members (in child vectors) are set to null.