### PR TITLE
Expose GetTableNames

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -199,6 +199,10 @@ func (conn *Conn) prepareStmts(ctx context.Context, query string) (*Stmt, error)
 	return conn.prepareExtractedStmt(*stmts, count-1)
 }
 
+// GetTableNames returns the tables names of a query.
+// It expects a *sql.Conn connection, and a query for which to extract the table names.
+// If qualified is true, then it returns the fully qualified table names,
+// else it returns only the table names.
 func GetTableNames(c *sql.Conn, query string, qualified bool) ([]string, error) {
 	var v mapping.Value
 	err := c.Raw(func(driverConn any) error {

--- a/connection_test.go
+++ b/connection_test.go
@@ -1,0 +1,24 @@
+package duckdb
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetTableNames(t *testing.T) {
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
+
+	conn := openConnWrapper(t, db, context.Background())
+	defer closeConnWrapper(t, conn)
+
+	query := `SELECT * FROM schema1.table1, catalog3."schema.2"."table.2"`
+	tableNames, err := GetTableNames(conn, query, true)
+	require.NoError(t, err)
+
+	require.Len(t, tableNames, 2)
+	require.Contains(t, tableNames, `schema1.table1`)
+	require.Contains(t, tableNames, `catalog3."schema.2"."table.2"`)
+}


### PR DESCRIPTION
Expose `GetTableNames`, which was recently added to the C API.
Returns the optionally qualified tables names of a query.