### PR TITLE
Use runtime reflection type to bind query parameters

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -36,8 +36,8 @@ func newConn(conn mapping.Connection, ctxStore *contextStore) *Conn {
 // CheckNamedValue implements the driver.NamedValueChecker interface.
 func (conn *Conn) CheckNamedValue(nv *driver.NamedValue) error {
 	switch nv.Value.(type) {
-	case *big.Int, Interval, []any, []bool, []int8, []int16, []int32, []int64, []uint8, []uint16,
-		[]uint32, []uint64, []float32, []float64, []string, map[string]any:
+	case *big.Int, Interval, []any, []bool, []int8, []int16, []int32, []int64, []int, []uint8, []uint16,
+		[]uint32, []uint64, []uint, []float32, []float64, []string, map[string]any:
 		return nil
 	}
 	return driver.ErrSkip

--- a/connection.go
+++ b/connection.go
@@ -6,6 +6,7 @@ import (
 	"database/sql/driver"
 	"errors"
 	"math/big"
+	"reflect"
 
 	"github.com/marcboeker/go-duckdb/mapping"
 )
@@ -38,6 +39,11 @@ func (conn *Conn) CheckNamedValue(nv *driver.NamedValue) error {
 	switch nv.Value.(type) {
 	case *big.Int, Interval, []any, []bool, []int8, []int16, []int32, []int64, []int, []uint8, []uint16,
 		[]uint32, []uint64, []uint, []float32, []float64, []string, map[string]any:
+		return nil
+	}
+	vo := reflect.ValueOf(nv.Value)
+	switch vo.Kind() {
+	case reflect.Ptr, reflect.Interface, reflect.Slice, reflect.Map, reflect.Array:
 		return nil
 	}
 	return driver.ErrSkip

--- a/connection.go
+++ b/connection.go
@@ -5,10 +5,8 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"errors"
-	"math/big"
-	"reflect"
-
 	"github.com/marcboeker/go-duckdb/mapping"
+	"math/big"
 )
 
 // Conn holds a connection to a DuckDB database.
@@ -39,11 +37,6 @@ func (conn *Conn) CheckNamedValue(nv *driver.NamedValue) error {
 	switch nv.Value.(type) {
 	case *big.Int, Interval, []any, []bool, []int8, []int16, []int32, []int64, []int, []uint8, []uint16,
 		[]uint32, []uint64, []uint, []float32, []float64, []string, map[string]any:
-		return nil
-	}
-	vo := reflect.ValueOf(nv.Value)
-	switch vo.Kind() {
-	case reflect.Ptr, reflect.Interface, reflect.Slice, reflect.Map, reflect.Array:
 		return nil
 	}
 	return driver.ErrSkip

--- a/connection.go
+++ b/connection.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"github.com/marcboeker/go-duckdb/mapping"
 	"math/big"
+	"reflect"
 )
 
 // Conn holds a connection to a DuckDB database.
@@ -37,6 +38,12 @@ func (conn *Conn) CheckNamedValue(nv *driver.NamedValue) error {
 	switch nv.Value.(type) {
 	case *big.Int, Interval, []any, []bool, []int8, []int16, []int32, []int64, []int, []uint8, []uint16,
 		[]uint32, []uint64, []uint, []float32, []float64, []string, map[string]any:
+		return nil
+	}
+
+	vo := reflect.ValueOf(nv.Value)
+	switch vo.Kind() {
+	case reflect.Ptr, reflect.Interface, reflect.Slice, reflect.Map, reflect.Array:
 		return nil
 	}
 	return driver.ErrSkip

--- a/statement.go
+++ b/statement.go
@@ -276,6 +276,10 @@ func (s *Stmt) bindComplexValue(val driver.NamedValue, n int, t Type, name strin
 	}
 
 	switch t {
+	case TYPE_UUID:
+		if ss, ok := val.Value.(fmt.Stringer); ok {
+			return mapping.BindVarchar(*s.preparedStmt, mapping.IdxT(n+1), ss.String()), nil
+		}
 	case TYPE_TIMESTAMP, TYPE_TIMESTAMP_TZ, TYPE_TIMESTAMP_S, TYPE_TIMESTAMP_MS, TYPE_TIMESTAMP_NS:
 		return s.bindTimestamp(val, t, n)
 	case TYPE_DATE:

--- a/statement.go
+++ b/statement.go
@@ -240,7 +240,7 @@ func (s *Stmt) bindJSON(val driver.NamedValue, n int) (mapping.State, error) {
 	return mapping.StateError, addIndexToError(unsupportedTypeError("JSON interface, need []byte or string"), n+1)
 }
 
-func (s *Stmt) bindUUID(val driver.NamedValue, t Type, n int) (mapping.State, error) {
+func (s *Stmt) bindUUID(val driver.NamedValue, n int) (mapping.State, error) {
 	if ss, ok := val.Value.(fmt.Stringer); ok {
 		return mapping.BindVarchar(*s.preparedStmt, mapping.IdxT(n+1), ss.String()), nil
 	}
@@ -285,7 +285,7 @@ func (s *Stmt) bindComplexValue(val driver.NamedValue, n int, t Type, name strin
 
 	switch t {
 	case TYPE_UUID:
-		return s.bindUUID(val, t, n)
+		return s.bindUUID(val, n)
 	case TYPE_TIMESTAMP, TYPE_TIMESTAMP_TZ, TYPE_TIMESTAMP_S, TYPE_TIMESTAMP_MS, TYPE_TIMESTAMP_NS:
 		return s.bindTimestamp(val, t, n)
 	case TYPE_DATE:

--- a/statement_test.go
+++ b/statement_test.go
@@ -588,8 +588,4 @@ func TestPrepareComplexQueryParameter(t *testing.T) {
 	arrayPrepare, err := db.Prepare(`SELECT * from (VALUES (?))`)
 	defer closePreparedWrapper(t, arrayPrepare)
 	require.NoError(t, err)
-
-	err = arrayPrepare.QueryRow([1]any{123}).Scan(&res)
-	require.NoError(t, err)
-	require.Equal(t, []any{int64(123)}, res.Get())
 }

--- a/statement_test.go
+++ b/statement_test.go
@@ -583,5 +583,13 @@ func TestPrepareComplexQueryParameter(t *testing.T) {
 
 	err = ptrPrepare.QueryRow([]any{toPtr(1)}).Scan(&res)
 	require.NoError(t, err)
-	require.Equal(t, []int64{1}, res.Get())
+	require.Equal(t, []any{int64(1)}, res.Get())
+
+	arrayPrepare, err := db.Prepare(`SELECT * from (VALUES (?))`)
+	defer closePreparedWrapper(t, arrayPrepare)
+	require.NoError(t, err)
+
+	err = arrayPrepare.QueryRow([1]any{123}).Scan(&res)
+	require.NoError(t, err)
+	require.Equal(t, []any{int64(123)}, res.Get())
 }

--- a/statement_test.go
+++ b/statement_test.go
@@ -430,7 +430,9 @@ func TestBindWithoutResolvedParams(t *testing.T) {
 	// Type without a fallback.
 	s := []int32{1}
 	r = db.QueryRow(`SELECT a::VARCHAR, b::VARCHAR FROM (VALUES (?, ?)) t(a, b)`, s, s)
-	require.Contains(t, r.Err().Error(), "unsupported data type")
+	require.NoError(t, r.Scan(&a, &b))
+	require.Equal(t, "[1]", a)
+	require.Equal(t, "[1]", b)
 }
 
 func TestBindTimestampTypes(t *testing.T) {

--- a/statement_test.go
+++ b/statement_test.go
@@ -588,4 +588,8 @@ func TestPrepareComplexQueryParameter(t *testing.T) {
 	arrayPrepare, err := db.Prepare(`SELECT * from (VALUES (?))`)
 	defer closePreparedWrapper(t, arrayPrepare)
 	require.NoError(t, err)
+
+	err = arrayPrepare.QueryRow([1]any{123}).Scan(&res)
+	require.NoError(t, err)
+	require.Equal(t, []any{int64(123)}, res.Get())
 }

--- a/statement_test.go
+++ b/statement_test.go
@@ -634,4 +634,21 @@ func TestPrepareComplexQueryParameter(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, [][][]string{{{"a"}, {"b", "c"}}, {{"1", "2"}, {"3"}}, {{"d", "e", "f"}}}, tripleNestedRes.Get())
 
+	var emptySliceRes Composite[[]any]
+	emptySlicePrepare, err := db.Prepare(`SELECT * from (VALUES (?))`)
+	defer closePreparedWrapper(t, emptySlicePrepare)
+	require.NoError(t, err)
+
+	err = emptySlicePrepare.QueryRow([]float32{}).Scan(&emptySliceRes)
+	require.NoError(t, err)
+	require.Equal(t, []any{}, emptySliceRes.Get())
+
+	var nestedEmptySliceRes Composite[[][]any]
+	nestedEmptySlicePrepare, err := db.Prepare(`SELECT * from (VALUES (?))`)
+	defer closePreparedWrapper(t, nestedEmptySlicePrepare)
+	require.NoError(t, err)
+
+	err = nestedEmptySlicePrepare.QueryRow([][]string{}).Scan(&nestedEmptySliceRes)
+	require.NoError(t, err)
+	require.Equal(t, [][]any{}, nestedEmptySliceRes.Get())
 }

--- a/value.go
+++ b/value.go
@@ -161,6 +161,21 @@ func getPointerValue(v any) any {
 	}
 }
 
+func isNil(i any) bool {
+	if i == nil {
+		return true
+	}
+
+	value := reflect.ValueOf(i)
+	kind := value.Kind()
+
+	switch kind {
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.Interface, reflect.Slice:
+		return value.IsNil()
+	}
+	return false
+}
+
 func createValueByReflection(v any) (Type, *mapping.Value, error) {
 	t := TYPE_INVALID
 	switch v.(type) {
@@ -205,11 +220,11 @@ func createValueByReflection(v any) (Type, *mapping.Value, error) {
 	if t != TYPE_INVALID {
 		return t, createValueByTypeId(t, v), nil
 	}
-	r := reflect.Indirect(reflect.ValueOf(v))
-	if r.IsNil() {
+	if isNil(v) {
 		t = TYPE_SQLNULL
 		return t, createValueByTypeId(t, v), nil
 	}
+	r := reflect.ValueOf(v)
 	switch r.Kind() {
 	case reflect.Ptr:
 		return createValueByReflection(getPointerValue(v))

--- a/value.go
+++ b/value.go
@@ -220,6 +220,9 @@ func createValueByReflection(v any) (Type, *mapping.Value, error) {
 	if t != TYPE_INVALID {
 		return t, createValueByTypeId(t, v), nil
 	}
+	if ss, ok := v.(fmt.Stringer); ok {
+		return TYPE_VARCHAR, createValueByTypeId(TYPE_VARCHAR, ss.String()), nil
+	}
 	if isNil(v) {
 		t = TYPE_SQLNULL
 		return t, createValueByTypeId(t, v), nil

--- a/value.go
+++ b/value.go
@@ -178,7 +178,7 @@ func isNil(i any) bool {
 
 func createValueByReflection(v any) (Type, *mapping.Value, error) {
 	t := TYPE_INVALID
-	switch v.(type) {
+	switch vv := v.(type) {
 	case nil:
 		t = TYPE_SQLNULL
 	case bool:
@@ -193,7 +193,7 @@ func createValueByReflection(v any) (Type, *mapping.Value, error) {
 		t = TYPE_BIGINT
 	case int:
 		t = TYPE_BIGINT
-		v = int64(v.(int))
+		v = int64(vv)
 	case uint8:
 		t = TYPE_UTINYINT
 	case uint16:
@@ -204,7 +204,7 @@ func createValueByReflection(v any) (Type, *mapping.Value, error) {
 		t = TYPE_UBIGINT
 	case uint:
 		t = TYPE_UBIGINT
-		v = uint64(v.(uint))
+		v = uint64(vv)
 	case float32:
 		t = TYPE_FLOAT
 	case float64:
@@ -213,7 +213,7 @@ func createValueByReflection(v any) (Type, *mapping.Value, error) {
 		t = TYPE_VARCHAR
 	case []byte:
 		t = TYPE_VARCHAR
-		v = string(v.([]byte))
+		v = string(vv)
 	case time.Time:
 		t = TYPE_TIMESTAMP
 	}

--- a/value.go
+++ b/value.go
@@ -2,7 +2,6 @@ package duckdb
 
 import (
 	"fmt"
-	bindings "github.com/duckdb/duckdb-go-bindings/linux-amd64"
 	"reflect"
 	"time"
 
@@ -249,8 +248,8 @@ func tryGetMappedSliceValue[T any](val T, isArray bool, sliceLength int) (mappin
 	typeFunc := mapping.CreateListType
 	if isArray {
 		createFunc = mapping.CreateArrayValue
-		typeFunc = func(child bindings.LogicalType) bindings.LogicalType {
-			return mapping.CreateArrayType(child, bindings.IdxT(sliceLength))
+		typeFunc = func(child mapping.LogicalType) mapping.LogicalType {
+			return mapping.CreateArrayType(child, mapping.IdxT(sliceLength))
 		}
 	}
 

--- a/value.go
+++ b/value.go
@@ -190,7 +190,6 @@ func createValueByReflection(v any) (mapping.LogicalType, mapping.Value, error) 
 	r := reflect.ValueOf(v)
 	switch r.Kind() {
 	case reflect.Ptr:
-
 		return createValueByReflection(getPointerValue(v))
 	case reflect.Slice:
 		return tryGetMappedSliceValue(r.Interface(), false, r.Len())

--- a/value.go
+++ b/value.go
@@ -69,7 +69,7 @@ func getValue(info TypeInfo, v mapping.Value) (any, error) {
 
 func createValue(lt mapping.LogicalType, v any) (mapping.Value, error) {
 	t := mapping.GetTypeId(lt)
-	r, err := trCreateValueByTypeId(t, v)
+	r, err := tryCreateValueByTypeId(t, v)
 	if err != nil {
 		return r, err
 	}
@@ -88,7 +88,7 @@ func createValue(lt mapping.LogicalType, v any) (mapping.Value, error) {
 	}
 }
 
-func trCreateValueByTypeId(t mapping.Type, v any) (mapping.Value, error) {
+func tryCreateValueByTypeId(t mapping.Type, v any) (mapping.Value, error) {
 	switch t {
 	case TYPE_SQLNULL:
 		return mapping.CreateNullValue(), nil
@@ -181,17 +181,17 @@ func isNil(i any) bool {
 func createValueByReflection(v any) (mapping.LogicalType, mapping.Value, error) {
 	t, vv := inferTypeId(v)
 	if t != TYPE_INVALID {
-		retVal, err := trCreateValueByTypeId(t, vv)
+		retVal, err := tryCreateValueByTypeId(t, vv)
 		return mapping.CreateLogicalType(t), retVal, err
 	}
 	if ss, ok := v.(fmt.Stringer); ok {
 		t = TYPE_VARCHAR
-		retVal, err := trCreateValueByTypeId(t, ss.String())
+		retVal, err := tryCreateValueByTypeId(t, ss.String())
 		return mapping.CreateLogicalType(t), retVal, err
 	}
 	if isNil(v) {
 		t = TYPE_SQLNULL
-		retVal, err := trCreateValueByTypeId(t, v)
+		retVal, err := tryCreateValueByTypeId(t, v)
 		return mapping.CreateLogicalType(t), retVal, err
 	}
 	r := reflect.ValueOf(v)

--- a/value.go
+++ b/value.go
@@ -117,7 +117,7 @@ func tryCreateValueByTypeId(t mapping.Type, v any) (mapping.Value, error) {
 	case TYPE_VARCHAR:
 		return mapping.CreateVarchar(v.(string)), nil
 	case TYPE_TIMESTAMP, TYPE_TIMESTAMP_TZ:
-		vv, err := getMappedTimestamp(v)
+		vv, err := getMappedTimestamp(t, v)
 		if err != nil {
 			return mapping.Value{}, err
 		}


### PR DESCRIPTION
Fix #450 by replacing the `tryBindComplexValue`, support dynamic create query parameter values by runtime reflection type when DB engine is not able to determine the logic type of parameter from query statement 