### PR TITLE
GetConnectionId and expose the BindData struct in the scalar UDF executor

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -198,3 +198,20 @@ func (conn *Conn) prepareStmts(ctx context.Context, query string) (*Stmt, error)
 
 	return conn.prepareExtractedStmt(*stmts, count-1)
 }
+
+// GetConnectionId returns the connection ID of the internal DuckDB connection.
+// It expects a *sql.Conn connection.
+func GetConnectionId(c *sql.Conn) (uint64, error) {
+	var connId uint64
+
+	err := c.Raw(func(driverConn any) error {
+		conn := driverConn.(*Conn)
+		var ctx mapping.ClientContext
+		mapping.ConnectionGetClientContext(conn.conn, &ctx)
+		defer mapping.DestroyClientContext(&ctx)
+		connId = uint64(mapping.ClientContextGetConnectionId(ctx))
+		return nil
+	})
+
+	return connId, err
+}


### PR DESCRIPTION
Expose `GetConnectionId`:
```Go
// GetConnectionId returns the connection ID of the internal DuckDB connection.
// It expects a *sql.Conn connection.
func GetConnectionId(c *sql.Conn) (uint64, error)
```

Adds a new struct `BindData`, which contains data DuckDB, and in the future also clients, can set during scalar function binding. Currently, this only contains the connection ID. Together with `GetConnectionId`, this enables users to map their scalar functions to the connection that executes the scalar function.

I'm opening this as a draft PR, as there are still a few unresolved points. Also, to make arbitrary binding data available during execution, I need to PR more C API functions to DuckDB main.

**Questions:**
- Currently, go-duckdb does not keep a mapping of its open connections. Also, they do not yet contain a state as proposed in #418. Should clients keep such a mapping, and use only the connection ID to retrieve the matching connection? Should we make the context available, in `Conn` or even `BindData`?
- I've extended `type ScalarFuncExecutor struct` with another field allowing a new type of executor. This should be in line with Go's compatibility rules (https://go.dev/blog/module-compatibility) for structs. But please let me know if I am missing something here.

cc @VGSML @lorenzowritescode