### PR TITLE
Simplify code for table functions

### DIFF
--- a/table_source.go
+++ b/table_source.go
@@ -57,7 +57,7 @@ type (
 	ChunkTableSource interface {
 		sequentialTableSource
 		// FillChunk takes a Chunk and fills it with values.
-		// Set the chunk size to 0 for end the function.
+		// Set the chunk size to 0 to end the function.
 		FillChunk(DataChunk) error
 	}
 
@@ -70,7 +70,7 @@ type (
 	ParallelChunkTableSource interface {
 		parallelTableSource
 		// FillChunk takes a Chunk and fills it with values.
-		// Set the chunk size to 0 for end the function
+		// Set the chunk size to 0 to end the function
 		FillChunk(any, DataChunk) error
 	}
 

--- a/table_source.go
+++ b/table_source.go
@@ -1,0 +1,141 @@
+package duckdb
+
+type (
+	tableSource interface {
+		// ColumnInfos returns column information for each column of the table function.
+		ColumnInfos() []ColumnInfo
+		// Cardinality returns the cardinality information of the table function.
+		// Optionally, if no cardinality exists, it may return nil.
+		Cardinality() *CardinalityInfo
+	}
+
+	parallelTableSource interface {
+		tableSource
+		// Init the table source.
+		// Additionally, it returns information for the parallelism-aware table source.
+		Init() ParallelTableSourceInfo
+		// NewLocalState returns a thread-local execution state.
+		// It must return a pointer or a reference type for correct state updates.
+		// go-duckdb does not prevent non-reference values.
+		NewLocalState() any
+	}
+
+	sequentialTableSource interface {
+		tableSource
+		// Init the table source.
+		Init()
+	}
+
+	// A RowTableSource represents anything that produces rows in a non-vectorised way.
+	// The cardinality is requested before function initialization.
+	// After initializing the RowTableSource, go-duckdb requests the rows.
+	// It sequentially calls the FillRow method with a single thread.
+	RowTableSource interface {
+		sequentialTableSource
+		// FillRow takes a Row and fills it with values.
+		// Returns true, if there are more rows to fill.
+		FillRow(Row) (bool, error)
+	}
+
+	// A ParallelRowTableSource represents anything that produces rows in a non-vectorised way.
+	// The cardinality is requested before function initialization.
+	// After initializing the ParallelRowTableSource, go-duckdb requests the rows.
+	// It simultaneously calls the FillRow method with multiple threads.
+	// If ParallelTableSourceInfo.MaxThreads is greater than one, FillRow must use synchronisation
+	// primitives to avoid race conditions.
+	ParallelRowTableSource interface {
+		parallelTableSource
+		// FillRow takes a Row and fills it with values.
+		// Returns true, if there are more rows to fill.
+		FillRow(any, Row) (bool, error)
+	}
+
+	// A ChunkTableSource represents anything that produces rows in a vectorised way.
+	// The cardinality is requested before function initialization.
+	// After initializing the ChunkTableSource, go-duckdb requests the rows.
+	// It sequentially calls the FillChunk method with a single thread.
+	ChunkTableSource interface {
+		sequentialTableSource
+		// FillChunk takes a Chunk and fills it with values.
+		// Set the chunk size to 0 for end the function.
+		FillChunk(DataChunk) error
+	}
+
+	// A ParallelChunkTableSource represents anything that produces rows in a vectorised way.
+	// The cardinality is requested before function initialization.
+	// After initializing the ParallelChunkTableSource, go-duckdb requests the rows.
+	// It simultaneously calls the FillChunk method with multiple threads.
+	// If ParallelTableSourceInfo.MaxThreads is greater than one, FillChunk must use synchronization
+	// primitives to avoid race conditions.
+	ParallelChunkTableSource interface {
+		parallelTableSource
+		// FillChunk takes a Chunk and fills it with values.
+		// Set the chunk size to 0 for end the function
+		FillChunk(any, DataChunk) error
+	}
+
+	// parallelRowTSWrapper wraps a synchronous table source for a parallel context with nthreads=1
+	parallelRowTSWrapper struct {
+		s RowTableSource
+	}
+
+	// parallelChunkTSWrapper wraps a synchronous table source for a parallel context with nthreads=1
+	parallelChunkTSWrapper struct {
+		s ChunkTableSource
+	}
+
+	// ParallelTableSourceInfo contains information for initializing a parallelism-aware table source.
+	ParallelTableSourceInfo struct {
+		// MaxThreads is the maximum number of threads on which to run the table source function.
+		// If set to 0, it uses DuckDB's default thread configuration.
+		MaxThreads int
+	}
+)
+
+// ParallelRow wrapper
+func (s parallelRowTSWrapper) ColumnInfos() []ColumnInfo {
+	return s.s.ColumnInfos()
+}
+
+func (s parallelRowTSWrapper) Cardinality() *CardinalityInfo {
+	return s.s.Cardinality()
+}
+
+func (s parallelRowTSWrapper) Init() ParallelTableSourceInfo {
+	s.s.Init()
+	return ParallelTableSourceInfo{
+		MaxThreads: 1,
+	}
+}
+
+func (s parallelRowTSWrapper) NewLocalState() any {
+	return struct{}{}
+}
+
+func (s parallelRowTSWrapper) FillRow(ls any, chunk Row) (bool, error) {
+	return s.s.FillRow(chunk)
+}
+
+// ParallelChunk wrapper
+func (s parallelChunkTSWrapper) ColumnInfos() []ColumnInfo {
+	return s.s.ColumnInfos()
+}
+
+func (s parallelChunkTSWrapper) Cardinality() *CardinalityInfo {
+	return s.s.Cardinality()
+}
+
+func (s parallelChunkTSWrapper) Init() ParallelTableSourceInfo {
+	s.s.Init()
+	return ParallelTableSourceInfo{
+		MaxThreads: 1,
+	}
+}
+
+func (s parallelChunkTSWrapper) NewLocalState() any {
+	return struct{}{}
+}
+
+func (s parallelChunkTSWrapper) FillChunk(ls any, chunk DataChunk) error {
+	return s.s.FillChunk(chunk)
+}

--- a/table_udf.go
+++ b/table_udf.go
@@ -67,11 +67,6 @@ type (
 		RowTableFunction | ParallelRowTableFunction | ChunkTableFunction | ParallelChunkTableFunction
 	}
 
-	// sequentialTableFunction implements different table function types:
-	// RowTableFunction and ChunkTableFunction.
-	sequentialTableFunction interface {
-		RowTableFunction | ChunkTableFunction
-	}
 	// parallelTableFunction implements different table function types:
 	// ParallelRowTableFunction and ParallelChunkTableFunction.
 	parallelTableFunction interface {

--- a/table_udf.go
+++ b/table_udf.go
@@ -6,12 +6,9 @@ package duckdb
 
 void table_udf_bind_row(void *);
 void table_udf_bind_chunk(void *);
-void table_udf_bind_parallel_row(void *);
-void table_udf_bind_parallel_chunk(void *);
 typedef void (*table_udf_bind_t)(void *);
 
 void table_udf_init(void *);
-void table_udf_init_parallel(void *);
 void table_udf_local_init(void *);
 typedef void (*table_udf_init_t)(void *);
 
@@ -51,89 +48,9 @@ type (
 		Exact bool
 	}
 
-	// ParallelTableSourceInfo contains information for initializing a parallelism-aware table source.
-	ParallelTableSourceInfo struct {
-		// MaxThreads is the maximum number of threads on which to run the table source function.
-		// If set to 0, it uses DuckDB's default thread configuration.
-		MaxThreads int
-	}
-
 	tableFunctionData struct {
 		fun        any
 		projection []int
-	}
-
-	tableSource interface {
-		// ColumnInfos returns column information for each column of the table function.
-		ColumnInfos() []ColumnInfo
-		// Cardinality returns the cardinality information of the table function.
-		// Optionally, if no cardinality exists, it may return nil.
-		Cardinality() *CardinalityInfo
-	}
-
-	parallelTableSource interface {
-		tableSource
-		// Init the table source.
-		// Additionally, it returns information for the parallelism-aware table source.
-		Init() ParallelTableSourceInfo
-		// NewLocalState returns a thread-local execution state.
-		// It must return a pointer or a reference type for correct state updates.
-		// go-duckdb does not prevent non-reference values.
-		NewLocalState() any
-	}
-
-	sequentialTableSource interface {
-		tableSource
-		// Init the table source.
-		Init()
-	}
-
-	// A RowTableSource represents anything that produces rows in a non-vectorised way.
-	// The cardinality is requested before function initialization.
-	// After initializing the RowTableSource, go-duckdb requests the rows.
-	// It sequentially calls the FillRow method with a single thread.
-	RowTableSource interface {
-		sequentialTableSource
-		// FillRow takes a Row and fills it with values.
-		// It returns true, if there are more rows to fill.
-		FillRow(Row) (bool, error)
-	}
-
-	// A ParallelRowTableSource represents anything that produces rows in a non-vectorised way.
-	// The cardinality is requested before function initialization.
-	// After initializing the ParallelRowTableSource, go-duckdb requests the rows.
-	// It simultaneously calls the FillRow method with multiple threads.
-	// If ParallelTableSourceInfo.MaxThreads is greater than one, FillRow must use synchronisation
-	// primitives to avoid race conditions.
-	ParallelRowTableSource interface {
-		parallelTableSource
-		// FillRow takes a Row and fills it with values.
-		// It returns true, if there are more rows to fill.
-		FillRow(any, Row) (bool, error)
-	}
-
-	// A ChunkTableSource represents anything that produces rows in a vectorised way.
-	// The cardinality is requested before function initialization.
-	// After initializing the ChunkTableSource, go-duckdb requests the rows.
-	// It sequentially calls the FillChunk method with a single thread.
-	ChunkTableSource interface {
-		sequentialTableSource
-		// FillChunk takes a Chunk and fills it with values.
-		// It returns true, if there are more chunks to fill.
-		FillChunk(DataChunk) error
-	}
-
-	// A ParallelChunkTableSource represents anything that produces rows in a vectorised way.
-	// The cardinality is requested before function initialization.
-	// After initializing the ParallelChunkTableSource, go-duckdb requests the rows.
-	// It simultaneously calls the FillChunk method with multiple threads.
-	// If ParallelTableSourceInfo.MaxThreads is greater than one, FillChunk must use synchronization
-	// primitives to avoid race conditions.
-	ParallelChunkTableSource interface {
-		parallelTableSource
-		// FillChunk takes a Chunk and fills it with values.
-		// It returns true, if there are more chunks to fill.
-		FillChunk(any, DataChunk) error
 	}
 
 	// TableFunctionConfig contains any information passed to DuckDB when registering the table function.
@@ -148,6 +65,17 @@ type (
 	// RowTableFunction, ParallelRowTableFunction, ChunkTableFunction, and ParallelChunkTableFunction.
 	TableFunction interface {
 		RowTableFunction | ParallelRowTableFunction | ChunkTableFunction | ParallelChunkTableFunction
+	}
+
+	// sequentialTableFunction implements different table function types:
+	// RowTableFunction and ChunkTableFunction.
+	sequentialTableFunction interface {
+		RowTableFunction | ChunkTableFunction
+	}
+	// parallelTableFunction implements different table function types:
+	// ParallelRowTableFunction and ParallelChunkTableFunction.
+	parallelTableFunction interface {
+		ParallelRowTableFunction | ParallelChunkTableFunction
 	}
 
 	// A RowTableFunction is a type which can be bound to return a RowTableSource.
@@ -166,6 +94,26 @@ type (
 		BindArguments func(named map[string]any, args ...any) (T, error)
 	}
 )
+
+func wrapRowTF(f RowTableFunction) ParallelRowTableFunction {
+	return ParallelRowTableFunction{
+		Config: f.Config,
+		BindArguments: func(named map[string]any, args ...any) (ParallelRowTableSource, error) {
+			rts, err := f.BindArguments(named, args...)
+			return parallelRowTSWrapper{s: rts}, err
+		},
+	}
+}
+
+func wrapChunkTF(f ChunkTableFunction) ParallelChunkTableFunction {
+	return ParallelChunkTableFunction{
+		Config: f.Config,
+		BindArguments: func(named map[string]any, args ...any) (ParallelChunkTableSource, error) {
+			rts, err := f.BindArguments(named, args...)
+			return parallelChunkTSWrapper{s: rts}, err
+		},
+	}
+}
 
 func isRowIdColumn(i mapping.IdxT) bool {
 	// FIXME: Replace this with mapping.IsRowIdColumn(i) / virtual column changes, once available in the C API.
@@ -186,21 +134,11 @@ func (tfd *tableFunctionData) setColumnCount(info mapping.InitInfo) {
 
 //export table_udf_bind_row
 func table_udf_bind_row(infoPtr unsafe.Pointer) {
-	udfBindTyped[RowTableSource](infoPtr)
+	udfBindTyped[ParallelRowTableSource](infoPtr)
 }
 
 //export table_udf_bind_chunk
 func table_udf_bind_chunk(infoPtr unsafe.Pointer) {
-	udfBindTyped[ChunkTableSource](infoPtr)
-}
-
-//export table_udf_bind_parallel_row
-func table_udf_bind_parallel_row(infoPtr unsafe.Pointer) {
-	udfBindTyped[ParallelRowTableSource](infoPtr)
-}
-
-//export table_udf_bind_parallel_chunk
-func table_udf_bind_parallel_chunk(infoPtr unsafe.Pointer) {
 	udfBindTyped[ParallelChunkTableSource](infoPtr)
 }
 
@@ -282,17 +220,8 @@ func table_udf_init(infoPtr unsafe.Pointer) {
 	info := mapping.InitInfo{Ptr: infoPtr}
 	instance := getPinned[tableFunctionData](mapping.InitGetBindData(info))
 	instance.setColumnCount(info)
-	instance.fun.(sequentialTableSource).Init()
-}
-
-//export table_udf_init_parallel
-func table_udf_init_parallel(infoPtr unsafe.Pointer) {
-	info := mapping.InitInfo{Ptr: infoPtr}
-	instance := getPinned[tableFunctionData](mapping.InitGetBindData(info))
-	instance.setColumnCount(info)
 	initData := instance.fun.(parallelTableSource).Init()
-	maxThreads := initData.MaxThreads
-	mapping.InitSetMaxThreads(info, mapping.IdxT(maxThreads))
+	mapping.InitSetMaxThreads(info, mapping.IdxT(initData.MaxThreads))
 }
 
 //export table_udf_local_init
@@ -315,6 +244,7 @@ func table_udf_row_callback(infoPtr unsafe.Pointer, outputPtr unsafe.Pointer) {
 	output := mapping.DataChunk{Ptr: outputPtr}
 
 	instance := getPinned[tableFunctionData](mapping.FunctionGetBindData(info))
+	fun := instance.fun.(ParallelRowTableSource)
 
 	var chunk DataChunk
 	err := chunk.initFromDuckDataChunk(output, true)
@@ -329,31 +259,16 @@ func table_udf_row_callback(infoPtr unsafe.Pointer, outputPtr unsafe.Pointer) {
 	}
 	maxSize := mapping.IdxT(GetDataChunkCapacity())
 
-	switch fun := instance.fun.(type) {
-	case RowTableSource:
-		// At the end of the loop row.r must be the index of the last row.
-		for row.r = 0; row.r < maxSize; row.r++ {
-			next, errRow := fun.FillRow(row)
-			if errRow != nil {
-				mapping.FunctionSetError(info, errRow.Error())
-				break
-			}
-			if !next {
-				break
-			}
+	// At the end of the loop row.r must be the index of the last row.
+	localState := getPinned[any](mapping.FunctionGetLocalInitData(info))
+	for row.r = 0; row.r < maxSize; row.r++ {
+		next, errRow := fun.FillRow(localState, row)
+		if errRow != nil {
+			mapping.FunctionSetError(info, errRow.Error())
+			break
 		}
-	case ParallelRowTableSource:
-		// At the end of the loop row.r must be the index of the last row.
-		localState := getPinned[any](mapping.FunctionGetLocalInitData(info))
-		for row.r = 0; row.r < maxSize; row.r++ {
-			next, errRow := fun.FillRow(localState, row)
-			if errRow != nil {
-				mapping.FunctionSetError(info, errRow.Error())
-				break
-			}
-			if !next {
-				break
-			}
+		if !next {
+			break
 		}
 	}
 	mapping.DataChunkSetSize(output, row.r)
@@ -365,6 +280,7 @@ func table_udf_chunk_callback(infoPtr unsafe.Pointer, outputPtr unsafe.Pointer) 
 	output := mapping.DataChunk{Ptr: outputPtr}
 
 	instance := getPinned[tableFunctionData](mapping.FunctionGetBindData(info))
+	fun := instance.fun.(ParallelChunkTableSource)
 
 	var chunk DataChunk
 	err := chunk.initFromDuckDataChunk(output, true)
@@ -373,13 +289,8 @@ func table_udf_chunk_callback(infoPtr unsafe.Pointer, outputPtr unsafe.Pointer) 
 		return
 	}
 
-	switch fun := instance.fun.(type) {
-	case ChunkTableSource:
-		err = fun.FillChunk(chunk)
-	case ParallelChunkTableSource:
-		localState := getPinned[any](mapping.FunctionGetLocalInitData(info))
-		err = fun.FillChunk(localState, chunk)
-	}
+	localState := getPinned[any](mapping.FunctionGetLocalInitData(info))
+	err = fun.FillChunk(localState, chunk)
 	if err != nil {
 		mapping.FunctionSetError(info, err.Error())
 	}
@@ -398,6 +309,24 @@ func RegisterTableUDF[TFT TableFunction](conn *sql.Conn, name string, f TFT) err
 	if name == "" {
 		return getError(errAPI, errTableUDFNoName)
 	}
+
+	// normalise the function
+	var x any = f
+	switch tableFunc := x.(type) {
+	case RowTableFunction:
+		return registerParallelTableUDF(conn, name, wrapRowTF(tableFunc))
+	case ChunkTableFunction:
+		return registerParallelTableUDF(conn, name, wrapChunkTF(tableFunc))
+	case ParallelRowTableFunction:
+		return registerParallelTableUDF(conn, name, tableFunc)
+	case ParallelChunkTableFunction:
+		return registerParallelTableUDF(conn, name, tableFunc)
+	default:
+		return getError(errInternal, nil)
+	}
+}
+
+func registerParallelTableUDF[TFT parallelTableFunction](conn *sql.Conn, name string, f TFT) error {
 	function := mapping.CreateTableFunction()
 	mapping.TableFunctionSetName(function, name)
 
@@ -417,70 +346,27 @@ func RegisterTableUDF[TFT TableFunction](conn *sql.Conn, name string, f TFT) err
 
 	mapping.TableFunctionSupportsProjectionPushdown(function, true)
 
-	// Set the config.
+	initCallbackPtr := unsafe.Pointer(C.table_udf_init_t(C.table_udf_init))
+	mapping.TableFunctionSetInit(function, initCallbackPtr)
+
+	bindCallbackPtr := unsafe.Pointer(C.table_udf_bind_t(C.table_udf_bind_row))
+	mapping.TableFunctionSetBind(function, bindCallbackPtr)
+
+	callbackPtr := unsafe.Pointer(C.table_udf_callback_t(C.table_udf_row_callback))
+	mapping.TableFunctionSetFunction(function, callbackPtr)
+
+	localInitCallbackPtr := unsafe.Pointer(C.table_udf_init_t(C.table_udf_local_init))
+	mapping.TableFunctionSetLocalInit(function, localInitCallbackPtr)
+
 	var x any = f
 	switch tableFunc := x.(type) {
-	case RowTableFunction:
-		initCallbackPtr := unsafe.Pointer(C.table_udf_init_t(C.table_udf_init))
-		mapping.TableFunctionSetInit(function, initCallbackPtr)
-
-		bindCallbackPtr := unsafe.Pointer(C.table_udf_bind_t(C.table_udf_bind_row))
-		mapping.TableFunctionSetBind(function, bindCallbackPtr)
-
-		callbackPtr := unsafe.Pointer(C.table_udf_callback_t(C.table_udf_row_callback))
-		mapping.TableFunctionSetFunction(function, callbackPtr)
-
-		config = tableFunc.Config
-		if tableFunc.BindArguments == nil {
-			return getError(errAPI, errTableUDFMissingBindArgs)
-		}
-
-	case ChunkTableFunction:
-		initCallbackPtr := unsafe.Pointer(C.table_udf_init_t(C.table_udf_init))
-		mapping.TableFunctionSetInit(function, initCallbackPtr)
-
-		bindCallbackPtr := unsafe.Pointer(C.table_udf_bind_t(C.table_udf_bind_chunk))
-		mapping.TableFunctionSetBind(function, bindCallbackPtr)
-
-		callbackPtr := unsafe.Pointer(C.table_udf_callback_t(C.table_udf_chunk_callback))
-		mapping.TableFunctionSetFunction(function, callbackPtr)
-
-		config = tableFunc.Config
-		if tableFunc.BindArguments == nil {
-			return getError(errAPI, errTableUDFMissingBindArgs)
-		}
-
 	case ParallelRowTableFunction:
-		initCallbackPtr := unsafe.Pointer(C.table_udf_init_t(C.table_udf_init_parallel))
-		mapping.TableFunctionSetInit(function, initCallbackPtr)
-
-		bindCallbackPtr := unsafe.Pointer(C.table_udf_bind_t(C.table_udf_bind_parallel_row))
-		mapping.TableFunctionSetBind(function, bindCallbackPtr)
-
-		callbackPtr := unsafe.Pointer(C.table_udf_callback_t(C.table_udf_row_callback))
-		mapping.TableFunctionSetFunction(function, callbackPtr)
-
-		localInitCallbackPtr := unsafe.Pointer(C.table_udf_init_t(C.table_udf_local_init))
-		mapping.TableFunctionSetLocalInit(function, localInitCallbackPtr)
-
 		config = tableFunc.Config
 		if tableFunc.BindArguments == nil {
 			return getError(errAPI, errTableUDFMissingBindArgs)
 		}
 
 	case ParallelChunkTableFunction:
-		initCallbackPtr := unsafe.Pointer(C.table_udf_init_t(C.table_udf_init_parallel))
-		mapping.TableFunctionSetInit(function, initCallbackPtr)
-
-		bindCallbackPtr := unsafe.Pointer(C.table_udf_bind_t(C.table_udf_bind_parallel_chunk))
-		mapping.TableFunctionSetBind(function, bindCallbackPtr)
-
-		callbackPtr := unsafe.Pointer(C.table_udf_callback_t(C.table_udf_chunk_callback))
-		mapping.TableFunctionSetFunction(function, callbackPtr)
-
-		localInitCallbackPtr := unsafe.Pointer(C.table_udf_init_t(C.table_udf_local_init))
-		mapping.TableFunctionSetLocalInit(function, localInitCallbackPtr)
-
 		config = tableFunc.Config
 		if tableFunc.BindArguments == nil {
 			return getError(errAPI, errTableUDFMissingBindArgs)


### PR DESCRIPTION
This reduces the amount of code needed for table functions. This is not fully the case, as the linecount did go up, but at least 50 lines of that have to be in my appender PR anyways. As you can see the giant ugly switch statement is no longer present.

All code is now made purely for parallel functions only, with some code to wrap the non-parallel functions to make them "parallel" (with max 1 concurrent invocation).