### PR TITLE
Improve appender speed v2

### DIFF
--- a/appender_test.go
+++ b/appender_test.go
@@ -1075,3 +1075,46 @@ func appendNestedData[T require.TestingT](t T, a *Appender, rowsToAppend []neste
 	}
 	require.NoError(t, a.Flush())
 }
+
+var types = map[reflect.Type]string{
+	reflect.TypeFor[int8](): "TINYINT",
+}
+
+func benchmarkAppenderSingle[T any](v T) func(*testing.B) {
+	return func(b *testing.B) {
+		if _, ok := types[reflect.TypeFor[T]()]; !ok {
+			b.Fatal("Type not defined in table:", reflect.TypeFor[T]())
+		}
+		tableSQL := fmt.Sprintf(createSingleTableSQL, types[reflect.TypeFor[T]()])
+		c, db, con, a := prepareAppender(b, tableSQL)
+		const rowsToAppend = 2048
+
+		var vec [rowsToAppend]T = [rowsToAppend]T{}
+		for i := 0; i < 2048; i++ {
+			vec[i] = v
+		}
+
+		b.ResetTimer()
+		for n := 0; n < b.N; n++ {
+			for i := 0; i < rowsToAppend; i++ {
+				// require took up the majority of the time
+				err := a.AppendRow(v)
+				if err != nil {
+					b.Error(err)
+				}
+			}
+		}
+		b.StopTimer()
+		cleanupAppender(b, c, db, con, a)
+	}
+}
+
+func BenchmarkAppenderSingle(b *testing.B) {
+	b.Run("int8", benchmarkAppenderSingle[int8](0))
+}
+
+const createSingleTableSQL = `
+	CREATE TABLE test (
+		nested_int_list %s,
+	)
+`

--- a/data_chunk.go
+++ b/data_chunk.go
@@ -2,6 +2,8 @@ package duckdb
 
 import "C"
 import (
+	"sync"
+
 	"github.com/marcboeker/go-duckdb/mapping"
 )
 
@@ -18,9 +20,9 @@ type DataChunk struct {
 }
 
 // GetDataChunkCapacity returns the capacity of a data chunk.
-func GetDataChunkCapacity() int {
+var GetDataChunkCapacity = sync.OnceValue(func() int {
 	return int(mapping.VectorSize())
-}
+})
 
 // GetSize returns the internal size of the data chunk.
 func (chunk *DataChunk) GetSize() int {

--- a/row.go
+++ b/row.go
@@ -24,8 +24,8 @@ func SetRowValue[T any](row Row, colIdx int, val T) error {
 	if projectedIdx < 0 || projectedIdx >= len(row.chunk.columns) {
 		return nil
 	}
-	vec := row.chunk.columns[projectedIdx]
-	return setVectorVal(&vec, row.r, val)
+	vec := &row.chunk.columns[projectedIdx]
+	return setVectorVal(vec, row.r, val)
 }
 
 // SetRowValue sets the value at colIdx to val. Returns an error on failure.

--- a/table_source.go
+++ b/table_source.go
@@ -1,0 +1,141 @@
+package duckdb
+
+type (
+	tableSource interface {
+		// ColumnInfos returns column information for each column of the table function.
+		ColumnInfos() []ColumnInfo
+		// Cardinality returns the cardinality information of the table function.
+		// Optionally, if no cardinality exists, it may return nil.
+		Cardinality() *CardinalityInfo
+	}
+
+	parallelTableSource interface {
+		tableSource
+		// Init the table source.
+		// Additionally, it returns information for the parallelism-aware table source.
+		Init() ParallelTableSourceInfo
+		// NewLocalState returns a thread-local execution state.
+		// It must return a pointer or a reference type for correct state updates.
+		// go-duckdb does not prevent non-reference values.
+		NewLocalState() any
+	}
+
+	sequentialTableSource interface {
+		tableSource
+		// Init the table source.
+		Init()
+	}
+
+	// A RowTableSource represents anything that produces rows in a non-vectorised way.
+	// The cardinality is requested before function initialization.
+	// After initializing the RowTableSource, go-duckdb requests the rows.
+	// It sequentially calls the FillRow method with a single thread.
+	RowTableSource interface {
+		sequentialTableSource
+		// FillRow takes a Row and fills it with values.
+		// Returns true, if there are more rows to fill.
+		FillRow(Row) (bool, error)
+	}
+
+	// A ParallelRowTableSource represents anything that produces rows in a non-vectorised way.
+	// The cardinality is requested before function initialization.
+	// After initializing the ParallelRowTableSource, go-duckdb requests the rows.
+	// It simultaneously calls the FillRow method with multiple threads.
+	// If ParallelTableSourceInfo.MaxThreads is greater than one, FillRow must use synchronisation
+	// primitives to avoid race conditions.
+	ParallelRowTableSource interface {
+		parallelTableSource
+		// FillRow takes a Row and fills it with values.
+		// Returns true, if there are more rows to fill.
+		FillRow(any, Row) (bool, error)
+	}
+
+	// A ChunkTableSource represents anything that produces rows in a vectorised way.
+	// The cardinality is requested before function initialization.
+	// After initializing the ChunkTableSource, go-duckdb requests the rows.
+	// It sequentially calls the FillChunk method with a single thread.
+	ChunkTableSource interface {
+		sequentialTableSource
+		// FillChunk takes a Chunk and fills it with values.
+		// Set the chunk size to 0 for end the function.
+		FillChunk(DataChunk) error
+	}
+
+	// A ParallelChunkTableSource represents anything that produces rows in a vectorised way.
+	// The cardinality is requested before function initialization.
+	// After initializing the ParallelChunkTableSource, go-duckdb requests the rows.
+	// It simultaneously calls the FillChunk method with multiple threads.
+	// If ParallelTableSourceInfo.MaxThreads is greater than one, FillChunk must use synchronization
+	// primitives to avoid race conditions.
+	ParallelChunkTableSource interface {
+		parallelTableSource
+		// FillChunk takes a Chunk and fills it with values.
+		// Set the chunk size to 0 for end the function
+		FillChunk(any, DataChunk) error
+	}
+
+	// parallelRowTSWrapper wraps a synchronous table source for a parallel context with nthreads=1
+	parallelRowTSWrapper struct {
+		s RowTableSource
+	}
+
+	// parallelChunkTSWrapper wraps a synchronous table source for a parallel context with nthreads=1
+	parallelChunkTSWrapper struct {
+		s ChunkTableSource
+	}
+
+	// ParallelTableSourceInfo contains information for initializing a parallelism-aware table source.
+	ParallelTableSourceInfo struct {
+		// MaxThreads is the maximum number of threads on which to run the table source function.
+		// If set to 0, it uses DuckDB's default thread configuration.
+		MaxThreads int
+	}
+)
+
+// ParallelRow wrapper
+func (s parallelRowTSWrapper) ColumnInfos() []ColumnInfo {
+	return s.s.ColumnInfos()
+}
+
+func (s parallelRowTSWrapper) Cardinality() *CardinalityInfo {
+	return s.s.Cardinality()
+}
+
+func (s parallelRowTSWrapper) Init() ParallelTableSourceInfo {
+	s.s.Init()
+	return ParallelTableSourceInfo{
+		MaxThreads: 1,
+	}
+}
+
+func (s parallelRowTSWrapper) NewLocalState() any {
+	return struct{}{}
+}
+
+func (s parallelRowTSWrapper) FillRow(ls any, chunk Row) (bool, error) {
+	return s.s.FillRow(chunk)
+}
+
+// ParallelChunk wrapper
+func (s parallelChunkTSWrapper) ColumnInfos() []ColumnInfo {
+	return s.s.ColumnInfos()
+}
+
+func (s parallelChunkTSWrapper) Cardinality() *CardinalityInfo {
+	return s.s.Cardinality()
+}
+
+func (s parallelChunkTSWrapper) Init() ParallelTableSourceInfo {
+	s.s.Init()
+	return ParallelTableSourceInfo{
+		MaxThreads: 1,
+	}
+}
+
+func (s parallelChunkTSWrapper) NewLocalState() any {
+	return struct{}{}
+}
+
+func (s parallelChunkTSWrapper) FillChunk(ls any, chunk DataChunk) error {
+	return s.s.FillChunk(chunk)
+}

--- a/table_udf.go
+++ b/table_udf.go
@@ -67,11 +67,6 @@ type (
 		RowTableFunction | ParallelRowTableFunction | ChunkTableFunction | ParallelChunkTableFunction
 	}
 
-	// sequentialTableFunction implements different table function types:
-	// RowTableFunction and ChunkTableFunction.
-	sequentialTableFunction interface {
-		RowTableFunction | ChunkTableFunction
-	}
 	// parallelTableFunction implements different table function types:
 	// ParallelRowTableFunction and ParallelChunkTableFunction.
 	parallelTableFunction interface {

--- a/table_udf.go
+++ b/table_udf.go
@@ -6,12 +6,9 @@ package duckdb
 
 void table_udf_bind_row(void *);
 void table_udf_bind_chunk(void *);
-void table_udf_bind_parallel_row(void *);
-void table_udf_bind_parallel_chunk(void *);
 typedef void (*table_udf_bind_t)(void *);
 
 void table_udf_init(void *);
-void table_udf_init_parallel(void *);
 void table_udf_local_init(void *);
 typedef void (*table_udf_init_t)(void *);
 
@@ -51,89 +48,9 @@ type (
 		Exact bool
 	}
 
-	// ParallelTableSourceInfo contains information for initializing a parallelism-aware table source.
-	ParallelTableSourceInfo struct {
-		// MaxThreads is the maximum number of threads on which to run the table source function.
-		// If set to 0, it uses DuckDB's default thread configuration.
-		MaxThreads int
-	}
-
 	tableFunctionData struct {
 		fun        any
 		projection []int
-	}
-
-	tableSource interface {
-		// ColumnInfos returns column information for each column of the table function.
-		ColumnInfos() []ColumnInfo
-		// Cardinality returns the cardinality information of the table function.
-		// Optionally, if no cardinality exists, it may return nil.
-		Cardinality() *CardinalityInfo
-	}
-
-	parallelTableSource interface {
-		tableSource
-		// Init the table source.
-		// Additionally, it returns information for the parallelism-aware table source.
-		Init() ParallelTableSourceInfo
-		// NewLocalState returns a thread-local execution state.
-		// It must return a pointer or a reference type for correct state updates.
-		// go-duckdb does not prevent non-reference values.
-		NewLocalState() any
-	}
-
-	sequentialTableSource interface {
-		tableSource
-		// Init the table source.
-		Init()
-	}
-
-	// A RowTableSource represents anything that produces rows in a non-vectorised way.
-	// The cardinality is requested before function initialization.
-	// After initializing the RowTableSource, go-duckdb requests the rows.
-	// It sequentially calls the FillRow method with a single thread.
-	RowTableSource interface {
-		sequentialTableSource
-		// FillRow takes a Row and fills it with values.
-		// It returns true, if there are more rows to fill.
-		FillRow(Row) (bool, error)
-	}
-
-	// A ParallelRowTableSource represents anything that produces rows in a non-vectorised way.
-	// The cardinality is requested before function initialization.
-	// After initializing the ParallelRowTableSource, go-duckdb requests the rows.
-	// It simultaneously calls the FillRow method with multiple threads.
-	// If ParallelTableSourceInfo.MaxThreads is greater than one, FillRow must use synchronisation
-	// primitives to avoid race conditions.
-	ParallelRowTableSource interface {
-		parallelTableSource
-		// FillRow takes a Row and fills it with values.
-		// It returns true, if there are more rows to fill.
-		FillRow(any, Row) (bool, error)
-	}
-
-	// A ChunkTableSource represents anything that produces rows in a vectorised way.
-	// The cardinality is requested before function initialization.
-	// After initializing the ChunkTableSource, go-duckdb requests the rows.
-	// It sequentially calls the FillChunk method with a single thread.
-	ChunkTableSource interface {
-		sequentialTableSource
-		// FillChunk takes a Chunk and fills it with values.
-		// It returns true, if there are more chunks to fill.
-		FillChunk(DataChunk) error
-	}
-
-	// A ParallelChunkTableSource represents anything that produces rows in a vectorised way.
-	// The cardinality is requested before function initialization.
-	// After initializing the ParallelChunkTableSource, go-duckdb requests the rows.
-	// It simultaneously calls the FillChunk method with multiple threads.
-	// If ParallelTableSourceInfo.MaxThreads is greater than one, FillChunk must use synchronization
-	// primitives to avoid race conditions.
-	ParallelChunkTableSource interface {
-		parallelTableSource
-		// FillChunk takes a Chunk and fills it with values.
-		// It returns true, if there are more chunks to fill.
-		FillChunk(any, DataChunk) error
 	}
 
 	// TableFunctionConfig contains any information passed to DuckDB when registering the table function.
@@ -148,6 +65,17 @@ type (
 	// RowTableFunction, ParallelRowTableFunction, ChunkTableFunction, and ParallelChunkTableFunction.
 	TableFunction interface {
 		RowTableFunction | ParallelRowTableFunction | ChunkTableFunction | ParallelChunkTableFunction
+	}
+
+	// sequentialTableFunction implements different table function types:
+	// RowTableFunction and ChunkTableFunction.
+	sequentialTableFunction interface {
+		RowTableFunction | ChunkTableFunction
+	}
+	// parallelTableFunction implements different table function types:
+	// ParallelRowTableFunction and ParallelChunkTableFunction.
+	parallelTableFunction interface {
+		ParallelRowTableFunction | ParallelChunkTableFunction
 	}
 
 	// A RowTableFunction is a type which can be bound to return a RowTableSource.
@@ -166,6 +94,26 @@ type (
 		BindArguments func(named map[string]any, args ...any) (T, error)
 	}
 )
+
+func wrapRowTF(f RowTableFunction) ParallelRowTableFunction {
+	return ParallelRowTableFunction{
+		Config: f.Config,
+		BindArguments: func(named map[string]any, args ...any) (ParallelRowTableSource, error) {
+			rts, err := f.BindArguments(named, args...)
+			return parallelRowTSWrapper{s: rts}, err
+		},
+	}
+}
+
+func wrapChunkTF(f ChunkTableFunction) ParallelChunkTableFunction {
+	return ParallelChunkTableFunction{
+		Config: f.Config,
+		BindArguments: func(named map[string]any, args ...any) (ParallelChunkTableSource, error) {
+			rts, err := f.BindArguments(named, args...)
+			return parallelChunkTSWrapper{s: rts}, err
+		},
+	}
+}
 
 func isRowIdColumn(i mapping.IdxT) bool {
 	// FIXME: Replace this with mapping.IsRowIdColumn(i) / virtual column changes, once available in the C API.
@@ -186,21 +134,11 @@ func (tfd *tableFunctionData) setColumnCount(info mapping.InitInfo) {
 
 //export table_udf_bind_row
 func table_udf_bind_row(infoPtr unsafe.Pointer) {
-	udfBindTyped[RowTableSource](infoPtr)
+	udfBindTyped[ParallelRowTableSource](infoPtr)
 }
 
 //export table_udf_bind_chunk
 func table_udf_bind_chunk(infoPtr unsafe.Pointer) {
-	udfBindTyped[ChunkTableSource](infoPtr)
-}
-
-//export table_udf_bind_parallel_row
-func table_udf_bind_parallel_row(infoPtr unsafe.Pointer) {
-	udfBindTyped[ParallelRowTableSource](infoPtr)
-}
-
-//export table_udf_bind_parallel_chunk
-func table_udf_bind_parallel_chunk(infoPtr unsafe.Pointer) {
 	udfBindTyped[ParallelChunkTableSource](infoPtr)
 }
 
@@ -282,17 +220,8 @@ func table_udf_init(infoPtr unsafe.Pointer) {
 	info := mapping.InitInfo{Ptr: infoPtr}
 	instance := getPinned[tableFunctionData](mapping.InitGetBindData(info))
 	instance.setColumnCount(info)
-	instance.fun.(sequentialTableSource).Init()
-}
-
-//export table_udf_init_parallel
-func table_udf_init_parallel(infoPtr unsafe.Pointer) {
-	info := mapping.InitInfo{Ptr: infoPtr}
-	instance := getPinned[tableFunctionData](mapping.InitGetBindData(info))
-	instance.setColumnCount(info)
 	initData := instance.fun.(parallelTableSource).Init()
-	maxThreads := initData.MaxThreads
-	mapping.InitSetMaxThreads(info, mapping.IdxT(maxThreads))
+	mapping.InitSetMaxThreads(info, mapping.IdxT(initData.MaxThreads))
 }
 
 //export table_udf_local_init
@@ -315,6 +244,7 @@ func table_udf_row_callback(infoPtr unsafe.Pointer, outputPtr unsafe.Pointer) {
 	output := mapping.DataChunk{Ptr: outputPtr}
 
 	instance := getPinned[tableFunctionData](mapping.FunctionGetBindData(info))
+	fun := instance.fun.(ParallelRowTableSource)
 
 	var chunk DataChunk
 	err := chunk.initFromDuckDataChunk(output, true)
@@ -329,31 +259,16 @@ func table_udf_row_callback(infoPtr unsafe.Pointer, outputPtr unsafe.Pointer) {
 	}
 	maxSize := mapping.IdxT(GetDataChunkCapacity())
 
-	switch fun := instance.fun.(type) {
-	case RowTableSource:
-		// At the end of the loop row.r must be the index of the last row.
-		for row.r = 0; row.r < maxSize; row.r++ {
-			next, errRow := fun.FillRow(row)
-			if errRow != nil {
-				mapping.FunctionSetError(info, errRow.Error())
-				break
-			}
-			if !next {
-				break
-			}
+	// At the end of the loop row.r must be the index of the last row.
+	localState := getPinned[any](mapping.FunctionGetLocalInitData(info))
+	for row.r = 0; row.r < maxSize; row.r++ {
+		next, errRow := fun.FillRow(localState, row)
+		if errRow != nil {
+			mapping.FunctionSetError(info, errRow.Error())
+			break
 		}
-	case ParallelRowTableSource:
-		// At the end of the loop row.r must be the index of the last row.
-		localState := getPinned[any](mapping.FunctionGetLocalInitData(info))
-		for row.r = 0; row.r < maxSize; row.r++ {
-			next, errRow := fun.FillRow(localState, row)
-			if errRow != nil {
-				mapping.FunctionSetError(info, errRow.Error())
-				break
-			}
-			if !next {
-				break
-			}
+		if !next {
+			break
 		}
 	}
 	mapping.DataChunkSetSize(output, row.r)
@@ -365,6 +280,7 @@ func table_udf_chunk_callback(infoPtr unsafe.Pointer, outputPtr unsafe.Pointer) 
 	output := mapping.DataChunk{Ptr: outputPtr}
 
 	instance := getPinned[tableFunctionData](mapping.FunctionGetBindData(info))
+	fun := instance.fun.(ParallelChunkTableSource)
 
 	var chunk DataChunk
 	err := chunk.initFromDuckDataChunk(output, true)
@@ -373,13 +289,8 @@ func table_udf_chunk_callback(infoPtr unsafe.Pointer, outputPtr unsafe.Pointer) 
 		return
 	}
 
-	switch fun := instance.fun.(type) {
-	case ChunkTableSource:
-		err = fun.FillChunk(chunk)
-	case ParallelChunkTableSource:
-		localState := getPinned[any](mapping.FunctionGetLocalInitData(info))
-		err = fun.FillChunk(localState, chunk)
-	}
+	localState := getPinned[any](mapping.FunctionGetLocalInitData(info))
+	err = fun.FillChunk(localState, chunk)
 	if err != nil {
 		mapping.FunctionSetError(info, err.Error())
 	}
@@ -398,6 +309,24 @@ func RegisterTableUDF[TFT TableFunction](conn *sql.Conn, name string, f TFT) err
 	if name == "" {
 		return getError(errAPI, errTableUDFNoName)
 	}
+
+	// normalise the function
+	var x any = f
+	switch tableFunc := x.(type) {
+	case RowTableFunction:
+		return registerParallelTableUDF(conn, name, wrapRowTF(tableFunc))
+	case ChunkTableFunction:
+		return registerParallelTableUDF(conn, name, wrapChunkTF(tableFunc))
+	case ParallelRowTableFunction:
+		return registerParallelTableUDF(conn, name, tableFunc)
+	case ParallelChunkTableFunction:
+		return registerParallelTableUDF(conn, name, tableFunc)
+	default:
+		return getError(errInternal, nil)
+	}
+}
+
+func registerParallelTableUDF[TFT parallelTableFunction](conn *sql.Conn, name string, f TFT) error {
 	function := mapping.CreateTableFunction()
 	mapping.TableFunctionSetName(function, name)
 
@@ -417,70 +346,27 @@ func RegisterTableUDF[TFT TableFunction](conn *sql.Conn, name string, f TFT) err
 
 	mapping.TableFunctionSupportsProjectionPushdown(function, true)
 
-	// Set the config.
+	initCallbackPtr := unsafe.Pointer(C.table_udf_init_t(C.table_udf_init))
+	mapping.TableFunctionSetInit(function, initCallbackPtr)
+
+	bindCallbackPtr := unsafe.Pointer(C.table_udf_bind_t(C.table_udf_bind_row))
+	mapping.TableFunctionSetBind(function, bindCallbackPtr)
+
+	callbackPtr := unsafe.Pointer(C.table_udf_callback_t(C.table_udf_row_callback))
+	mapping.TableFunctionSetFunction(function, callbackPtr)
+
+	localInitCallbackPtr := unsafe.Pointer(C.table_udf_init_t(C.table_udf_local_init))
+	mapping.TableFunctionSetLocalInit(function, localInitCallbackPtr)
+
 	var x any = f
 	switch tableFunc := x.(type) {
-	case RowTableFunction:
-		initCallbackPtr := unsafe.Pointer(C.table_udf_init_t(C.table_udf_init))
-		mapping.TableFunctionSetInit(function, initCallbackPtr)
-
-		bindCallbackPtr := unsafe.Pointer(C.table_udf_bind_t(C.table_udf_bind_row))
-		mapping.TableFunctionSetBind(function, bindCallbackPtr)
-
-		callbackPtr := unsafe.Pointer(C.table_udf_callback_t(C.table_udf_row_callback))
-		mapping.TableFunctionSetFunction(function, callbackPtr)
-
-		config = tableFunc.Config
-		if tableFunc.BindArguments == nil {
-			return getError(errAPI, errTableUDFMissingBindArgs)
-		}
-
-	case ChunkTableFunction:
-		initCallbackPtr := unsafe.Pointer(C.table_udf_init_t(C.table_udf_init))
-		mapping.TableFunctionSetInit(function, initCallbackPtr)
-
-		bindCallbackPtr := unsafe.Pointer(C.table_udf_bind_t(C.table_udf_bind_chunk))
-		mapping.TableFunctionSetBind(function, bindCallbackPtr)
-
-		callbackPtr := unsafe.Pointer(C.table_udf_callback_t(C.table_udf_chunk_callback))
-		mapping.TableFunctionSetFunction(function, callbackPtr)
-
-		config = tableFunc.Config
-		if tableFunc.BindArguments == nil {
-			return getError(errAPI, errTableUDFMissingBindArgs)
-		}
-
 	case ParallelRowTableFunction:
-		initCallbackPtr := unsafe.Pointer(C.table_udf_init_t(C.table_udf_init_parallel))
-		mapping.TableFunctionSetInit(function, initCallbackPtr)
-
-		bindCallbackPtr := unsafe.Pointer(C.table_udf_bind_t(C.table_udf_bind_parallel_row))
-		mapping.TableFunctionSetBind(function, bindCallbackPtr)
-
-		callbackPtr := unsafe.Pointer(C.table_udf_callback_t(C.table_udf_row_callback))
-		mapping.TableFunctionSetFunction(function, callbackPtr)
-
-		localInitCallbackPtr := unsafe.Pointer(C.table_udf_init_t(C.table_udf_local_init))
-		mapping.TableFunctionSetLocalInit(function, localInitCallbackPtr)
-
 		config = tableFunc.Config
 		if tableFunc.BindArguments == nil {
 			return getError(errAPI, errTableUDFMissingBindArgs)
 		}
 
 	case ParallelChunkTableFunction:
-		initCallbackPtr := unsafe.Pointer(C.table_udf_init_t(C.table_udf_init_parallel))
-		mapping.TableFunctionSetInit(function, initCallbackPtr)
-
-		bindCallbackPtr := unsafe.Pointer(C.table_udf_bind_t(C.table_udf_bind_parallel_chunk))
-		mapping.TableFunctionSetBind(function, bindCallbackPtr)
-
-		callbackPtr := unsafe.Pointer(C.table_udf_callback_t(C.table_udf_chunk_callback))
-		mapping.TableFunctionSetFunction(function, callbackPtr)
-
-		localInitCallbackPtr := unsafe.Pointer(C.table_udf_init_t(C.table_udf_local_init))
-		mapping.TableFunctionSetLocalInit(function, localInitCallbackPtr)
-
 		config = tableFunc.Config
 		if tableFunc.BindArguments == nil {
 			return getError(errAPI, errTableUDFMissingBindArgs)

--- a/table_udf_test.go
+++ b/table_udf_test.go
@@ -385,7 +385,6 @@ func (udf *parallelIncTableUDF) FillRow(localState any, row Row) (bool, error) {
 		udf.claimed += remaining
 		udf.lock.Unlock()
 	}
-
 	state.start++
 	err := SetRowValue(row, 0, state.start)
 	return true, err
@@ -444,7 +443,7 @@ func (udf *parallelChunkIncTableUDF) FillChunk(localState any, chunk DataChunk) 
 	if remaining <= 0 {
 		// No more work.
 		udf.lock.Unlock()
-		return nil
+		return chunk.SetSize(int(remaining))
 	} else if remaining >= 2048 {
 		remaining = 2048
 	}
@@ -454,7 +453,7 @@ func (udf *parallelChunkIncTableUDF) FillChunk(localState any, chunk DataChunk) 
 	udf.lock.Unlock()
 
 	for i := 0; i < int(remaining); i++ {
-		err := chunk.SetValue(0, i, int64(i)+state.start+1)
+		err := SetChunkValue(chunk, 0, i, int64(i)+state.start+1)
 		if err != nil {
 			return err
 		}
@@ -712,7 +711,7 @@ func (udf *chunkIncTableUDF) FillChunk(chunk DataChunk) error {
 			return err
 		}
 		udf.count++
-		err := chunk.SetValue(0, i, udf.count)
+		err := SetChunkValue(chunk, 0, i, udf.count)
 		if err != nil {
 			return err
 		}

--- a/vector_setters.go
+++ b/vector_setters.go
@@ -18,7 +18,7 @@ type fnSetVectorValue func(vec *vector, rowIdx mapping.IdxT, val any) error
 func (vec *vector) setNull(rowIdx mapping.IdxT) {
 	mapping.ValiditySetRowInvalid(vec.maskPtr, rowIdx)
 	if vec.Type == TYPE_STRUCT || vec.Type == TYPE_UNION {
-		for i := 0; i < len(vec.childVectors); i++ {
+		for i := range vec.childVectors {
 			vec.childVectors[i].setNull(rowIdx)
 		}
 	}
@@ -311,7 +311,7 @@ func setStruct[S any](vec *vector, rowIdx mapping.IdxT, val S) error {
 		rv := reflect.ValueOf(val)
 		structType := rv.Type()
 
-		for i := 0; i < structType.NumField(); i++ {
+		for i := range structType.NumField() {
 			if !rv.Field(i).CanInterface() {
 				continue
 			}
@@ -326,7 +326,7 @@ func setStruct[S any](vec *vector, rowIdx mapping.IdxT, val S) error {
 		}
 	}
 
-	for i := 0; i < len(vec.childVectors); i++ {
+	for i := range vec.childVectors {
 		child := &vec.childVectors[i]
 		name := vec.structEntries[i].Name()
 		v, ok := m[name]
@@ -395,7 +395,8 @@ func setUUID[S any](vec *vector, rowIdx mapping.IdxT, val S) error {
 		if len(v) != uuidLength {
 			return castError(reflect.TypeOf(val).String(), reflect.TypeOf(uuid).String())
 		}
-		for i := 0; i < uuidLength; i++ {
+		// TODO: test performance with cpy instead of a loop
+		for i := range uuidLength {
 			uuid[i] = v[i]
 		}
 	default:
@@ -471,14 +472,9 @@ func setUnion[S any](vec *vector, rowIdx mapping.IdxT, val S) error {
 }
 
 func setVectorVal[S any](vec *vector, rowIdx mapping.IdxT, val S) error {
-	name, inMap := unsupportedTypeToStringMap[vec.Type]
-	if inMap {
-		return unsupportedTypeError(name)
-	}
-
 	switch vec.Type {
 	case TYPE_BOOLEAN:
-		return setBool[S](vec, rowIdx, val)
+		return setBool(vec, rowIdx, val)
 	case TYPE_TINYINT:
 		return setNumeric[S, int8](vec, rowIdx, val)
 	case TYPE_SMALLINT:
@@ -502,33 +498,38 @@ func setVectorVal[S any](vec *vector, rowIdx mapping.IdxT, val S) error {
 	case TYPE_TIMESTAMP, TYPE_TIMESTAMP_S, TYPE_TIMESTAMP_MS, TYPE_TIMESTAMP_NS, TYPE_TIMESTAMP_TZ:
 		return setTS(vec, rowIdx, val)
 	case TYPE_DATE:
-		return setDate[S](vec, rowIdx, val)
+		return setDate(vec, rowIdx, val)
 	case TYPE_TIME, TYPE_TIME_TZ:
-		return setTime[S](vec, rowIdx, val)
+		return setTime(vec, rowIdx, val)
 	case TYPE_INTERVAL:
-		return setInterval[S](vec, rowIdx, val)
+		return setInterval(vec, rowIdx, val)
 	case TYPE_HUGEINT:
-		return setHugeint[S](vec, rowIdx, val)
+		return setHugeint(vec, rowIdx, val)
 	case TYPE_VARCHAR:
-		return setBytes[S](vec, rowIdx, val)
+		return setBytes(vec, rowIdx, val)
 	case TYPE_BLOB:
-		return setBytes[S](vec, rowIdx, val)
+		return setBytes(vec, rowIdx, val)
 	case TYPE_DECIMAL:
-		return setDecimal[S](vec, rowIdx, val)
+		return setDecimal(vec, rowIdx, val)
 	case TYPE_ENUM:
-		return setEnum[S](vec, rowIdx, val)
+		return setEnum(vec, rowIdx, val)
 	case TYPE_LIST:
-		return setList[S](vec, rowIdx, val)
+		return setList(vec, rowIdx, val)
 	case TYPE_STRUCT:
-		return setStruct[S](vec, rowIdx, val)
+		return setStruct(vec, rowIdx, val)
 	case TYPE_MAP, TYPE_ARRAY:
 		// FIXME: Is this already supported? And tested?
 		return unsupportedTypeError(unsupportedTypeToStringMap[vec.Type])
 	case TYPE_UUID:
-		return setUUID[S](vec, rowIdx, val)
+		return setUUID(vec, rowIdx, val)
 	case TYPE_UNION:
-		return setUnion[S](vec, rowIdx, val)
+		return setUnion(vec, rowIdx, val)
 	default:
+		name, inMap := unsupportedTypeToStringMap[vec.Type]
+		if inMap {
+			return unsupportedTypeError(name)
+		}
+
 		return unsupportedTypeError(unknownTypeErrMsg)
 	}
 }


### PR DESCRIPTION
This currently also includes the changes of #483, but I will rebase once that is merged.

This adds multiple ways to append, using all the variations of table sources.
Using just row-based is actually slower than the current solution, which may be expected as it operates very similarly but with extra steps. The real performance gains come from the parallel implementations.
The benchmarks don't show much improvement (~25% for both parallel row and parallel chunk), however this is due to the fact that they are both bottlenecked on appending the chunks in DuckDB itself. If instead the bottleneck would be the data ingestion/computation on the user-side (instead of a simple counter), this would be much more favorable to the parallel variations. Currently they barely show up as parallel on my laptop.

Another improvement would be setting entire vectors of data at a time, instead of individual values, this could be done in a future PR.