### PR TITLE
Reset child vector validity mask during list resize

### DIFF
--- a/vector.go
+++ b/vector.go
@@ -107,6 +107,7 @@ func (vec *vector) resizeListVector(newLength mapping.IdxT) {
 func (vec *vector) resetChildData() {
 	for i := range vec.childVectors {
 		vec.childVectors[i].dataPtr = mapping.VectorGetData(vec.childVectors[i].vec)
+		vec.childVectors[i].maskPtr = mapping.VectorGetValidity(vec.childVectors[i].vec)
 		vec.childVectors[i].resetChildData()
 	}
 }


### PR DESCRIPTION
I am encountering another segfault similar to #432, but this time when appending to a column of type `MAP(VARCHAR, UNION(i INT, s VARCHAR))`. It occurs during the step where all of the unset tags of the union are set to null.

Using a debug duckdb build the address sanitizer enabled I found that the validity mask had been freed during a list vector reserve operation.

Reloading the validity mask pointer for child vectors after a list resize has made the issue go away in my application, however I have not yet been able to create an isolated test for this.

### Segfault stack trace
```
SIGABRT: abort
PC=0x187088388 m=4 sigcode=0
signal arrived during cgo execution

goroutine 68 gp=0x114000483c00 m=4 mp=0x11400008b808 [syscall]:
runtime.cgocall(0x101a2daa8, 0x1140017daaa8)
	runtime/cgocall.go:167 +0x44 fp=0x1140017daa70 sp=0x1140017daa30 pc=0x100a28e44
github.com/duckdb/duckdb-go-bindings/darwin-arm64._Cfunc_duckdb_validity_set_row_invalid(0x611000844e40, 0x7f6)
	_cgo_gotypes.go:4966 +0x30 fp=0x1140017daaa0 sp=0x1140017daa70 pc=0x101578f10
github.com/duckdb/duckdb-go-bindings/darwin-arm64.ValiditySetRowInvalid(0x10dae0fc0?, 0x1?)
	github.com/duckdb/duckdb-go-bindings/darwin-arm64@v0.1.12/bindings.go:2733 +0x24 fp=0x1140017daac0 sp=0x1140017daaa0 pc=0x10157ffe4
github.com/marcboeker/go-duckdb/v2.(*vector).setNull(0x11400003ec18, 0x7f6)
	github.com/marcboeker/go-duckdb/v2@v2.3.0/vector_setters.go:19 +0x34 fp=0x1140017daaf0 sp=0x1140017daac0 pc=0x101598124
github.com/marcboeker/go-duckdb/v2.(*vector).init.initBool.func4(0x602000305dd0?, 0x1140017dab30?, {0x0?, 0x0?})
	github.com/marcboeker/go-duckdb/v2@v2.3.0/vector.go:150 +0x50 fp=0x1140017dab30 sp=0x1140017daaf0 pc=0x10159bc40
github.com/marcboeker/go-duckdb/v2.setUnion[...](0x1140005d23e8?, 0x7f6, {0x111308520, 0x114001a13480?})
	github.com/marcboeker/go-duckdb/v2@v2.3.0/vector_setters.go:430 +0x3c8 fp=0x1140017dabf0 sp=0x1140017dab30 pc=0x1015a0a18
github.com/marcboeker/go-duckdb/v2.(*vector).initUnion.func2(0x1140017dac78?, 0x2?, {0x111308520?, 0x114001a13480?})
	github.com/marcboeker/go-duckdb/v2@v2.3.0/vector.go:542 +0x40 fp=0x1140017dac30 sp=0x1140017dabf0 pc=0x10159b3a0
github.com/marcboeker/go-duckdb/v2.setStruct[...](0x1140000db3b0?, 0x7f6, {0x111261ee0, 0x114001001590?})
	github.com/marcboeker/go-duckdb/v2@v2.3.0/vector_setters.go:336 +0x5e8 fp=0x1140017dafa0 sp=0x1140017dac30 pc=0x1015a1b98
github.com/marcboeker/go-duckdb/v2.(*vector).initStruct.func2(0x0?, 0x0?, {0x111261ee0?, 0x114001001590?})
	github.com/marcboeker/go-duckdb/v2@v2.3.0/vector.go:423 +0x40 fp=0x1140017dafe0 sp=0x1140017dafa0 pc=0x10159b6e0
github.com/marcboeker/go-duckdb/v2.setSliceChildren(0x1140003bd778?, {0x1140019a3500?, 0xc, 0x100a2a0ac?}, 0x7f6)
	github.com/marcboeker/go-duckdb/v2@v2.3.0/vector_setters.go:379 +0x88 fp=0x1140017db030 sp=0x1140017dafe0 pc=0x1015984c8
github.com/marcboeker/go-duckdb/v2.setList[...](0x1140003bd778?, 0x111, {0x1140019a3500, 0x1140017db0d8?, 0x10157fabc?})
	github.com/marcboeker/go-duckdb/v2@v2.3.0/vector_setters.go:293 +0xdc fp=0x1140017db090 sp=0x1140017db030 pc=0x1015a102c
github.com/marcboeker/go-duckdb/v2.setMap[...](0x1140003bd778?, 0x111, {0x1112aa200, 0x114001001560?})
	github.com/marcboeker/go-duckdb/v2@v2.3.0/vector_setters.go:361 +0x32c fp=0x1140017db1e0 sp=0x1140017db090 pc=0x1015a0f0c
github.com/marcboeker/go-duckdb/v2.(*vector).initMap.func2(0x17dc00000114120?, 0x11400008b808?, {0x1112aa200?, 0x114001001560?})
	github.com/marcboeker/go-duckdb/v2@v2.3.0/vector.go:465 +0x40 fp=0x1140017db220 sp=0x1140017db1e0 pc=0x10159b5d0
github.com/marcboeker/go-duckdb/v2.(*DataChunk).SetValue(0x1140013080d0?, 0x1cb?, 0x1cb?, {0x1112aa200?, 0x114001001560?})
	github.com/marcboeker/go-duckdb/v2@v2.3.0/data_chunk.go:59 +0x54 fp=0x1140017db290 sp=0x1140017db220 pc=0x1015987c4
github.com/marcboeker/go-duckdb/v2.(*Appender).appendRowSlice(0x11400052c820, {0x1140019e1d10, 0xf, 0x100a29d38?})
	github.com/marcboeker/go-duckdb/v2@v2.3.0/appender.go:163 +0x13c fp=0x1140017db310 sp=0x1140017db290 pc=0x1015846ec
github.com/marcboeker/go-duckdb/v2.(*Appender).AppendRow(0x1cb?, {0x1140019e1d10?, 0x2017db388?, 0x1631df848?})
	github.com/marcboeker/go-duckdb/v2@v2.3.0/appender.go:140 +0x28 fp=0x1140017db340 sp=0x1140017db310 pc=0x101584518
```

```
SIGABRT: abort
PC=0x187088388 m=4 sigcode=0
signal arrived during cgo execution

goroutine 68 gp=0x114000483c00 m=4 mp=0x11400008b808 [syscall]:
runtime.cgocall(0x101a2daa8, 0x1140017daaa8)
	runtime/cgocall.go:167 +0x44 fp=0x1140017daa70 sp=0x1140017daa30 pc=0x100a28e44
github.com/duckdb/duckdb-go-bindings/darwin-arm64._Cfunc_duckdb_validity_set_row_invalid(0x611000844e40, 0x7f6)
	_cgo_gotypes.go:4966 +0x30 fp=0x1140017daaa0 sp=0x1140017daa70 pc=0x101578f10
github.com/duckdb/duckdb-go-bindings/darwin-arm64.ValiditySetRowInvalid(0x10dae0fc0?, 0x1?)
	github.com/duckdb/duckdb-go-bindings/darwin-arm64@v0.1.12/bindings.go:2733 +0x24 fp=0x1140017daac0 sp=0x1140017daaa0 pc=0x10157ffe4
github.com/marcboeker/go-duckdb/v2.(*vector).setNull(0x11400003ec18, 0x7f6)
	github.com/marcboeker/go-duckdb/v2@v2.3.0/vector_setters.go:19 +0x34 fp=0x1140017daaf0 sp=0x1140017daac0 pc=0x101598124
github.com/marcboeker/go-duckdb/v2.(*vector).init.initBool.func4(0x602000305dd0?, 0x1140017dab30?, {0x0?, 0x0?})
	github.com/marcboeker/go-duckdb/v2@v2.3.0/vector.go:150 +0x50 fp=0x1140017dab30 sp=0x1140017daaf0 pc=0x10159bc40
github.com/marcboeker/go-duckdb/v2.setUnion[...](0x1140005d23e8?, 0x7f6, {0x111308520, 0x114001a13480?})
	github.com/marcboeker/go-duckdb/v2@v2.3.0/vector_setters.go:430 +0x3c8 fp=0x1140017dabf0 sp=0x1140017dab30 pc=0x1015a0a18
github.com/marcboeker/go-duckdb/v2.(*vector).initUnion.func2(0x1140017dac78?, 0x2?, {0x111308520?, 0x114001a13480?})
	github.com/marcboeker/go-duckdb/v2@v2.3.0/vector.go:542 +0x40 fp=0x1140017dac30 sp=0x1140017dabf0 pc=0x10159b3a0
github.com/marcboeker/go-duckdb/v2.setStruct[...](0x1140000db3b0?, 0x7f6, {0x111261ee0, 0x114001001590?})
	github.com/marcboeker/go-duckdb/v2@v2.3.0/vector_setters.go:336 +0x5e8 fp=0x1140017dafa0 sp=0x1140017dac30 pc=0x1015a1b98
github.com/marcboeker/go-duckdb/v2.(*vector).initStruct.func2(0x0?, 0x0?, {0x111261ee0?, 0x114001001590?})
	github.com/marcboeker/go-duckdb/v2@v2.3.0/vector.go:423 +0x40 fp=0x1140017dafe0 sp=0x1140017dafa0 pc=0x10159b6e0
github.com/marcboeker/go-duckdb/v2.setSliceChildren(0x1140003bd778?, {0x1140019a3500?, 0xc, 0x100a2a0ac?}, 0x7f6)
	github.com/marcboeker/go-duckdb/v2@v2.3.0/vector_setters.go:379 +0x88 fp=0x1140017db030 sp=0x1140017dafe0 pc=0x1015984c8
github.com/marcboeker/go-duckdb/v2.setList[...](0x1140003bd778?, 0x111, {0x1140019a3500, 0x1140017db0d8?, 0x10157fabc?})
	github.com/marcboeker/go-duckdb/v2@v2.3.0/vector_setters.go:293 +0xdc fp=0x1140017db090 sp=0x1140017db030 pc=0x1015a102c
github.com/marcboeker/go-duckdb/v2.setMap[...](0x1140003bd778?, 0x111, {0x1112aa200, 0x114001001560?})
	github.com/marcboeker/go-duckdb/v2@v2.3.0/vector_setters.go:361 +0x32c fp=0x1140017db1e0 sp=0x1140017db090 pc=0x1015a0f0c
github.com/marcboeker/go-duckdb/v2.(*vector).initMap.func2(0x17dc00000114120?, 0x11400008b808?, {0x1112aa200?, 0x114001001560?})
	github.com/marcboeker/go-duckdb/v2@v2.3.0/vector.go:465 +0x40 fp=0x1140017db220 sp=0x1140017db1e0 pc=0x10159b5d0
github.com/marcboeker/go-duckdb/v2.(*DataChunk).SetValue(0x1140013080d0?, 0x1cb?, 0x1cb?, {0x1112aa200?, 0x114001001560?})
	github.com/marcboeker/go-duckdb/v2@v2.3.0/data_chunk.go:59 +0x54 fp=0x1140017db290 sp=0x1140017db220 pc=0x1015987c4
github.com/marcboeker/go-duckdb/v2.(*Appender).appendRowSlice(0x11400052c820, {0x1140019e1d10, 0xf, 0x100a29d38?})
	github.com/marcboeker/go-duckdb/v2@v2.3.0/appender.go:163 +0x13c fp=0x1140017db310 sp=0x1140017db290 pc=0x1015846ec
github.com/marcboeker/go-duckdb/v2.(*Appender).AppendRow(0x1cb?, {0x1140019e1d10?, 0x2017db388?, 0x1631df848?})
	github.com/marcboeker/go-duckdb/v2@v2.3.0/appender.go:140 +0x28 fp=0x1140017db340 sp=0x1140017db310 pc=0x101584518
```

### Address Sanitizer Logs

```
==44913==ERROR: AddressSanitizer: heap-use-after-free on address 0x611000844f38 at pc 0x000108be7244 bp 0x00017b45ee30 sp 0x00017b45ee28
READ of size 8 at 0x611000844f38 thread T3

0x611000844f38 is located 248 bytes inside of 256-byte region [0x611000844e40,0x611000844f40)
freed by thread T3 here:
    #0 0x0001185cb4dc in _ZdaPv+0x6c (libclang_rt.asan_osx_dynamic.dylib:arm64+0x634dc)
    #1 0x000101a7cc3c in std::__1::default_delete<unsigned long long []>::_EnableIfConvertible<unsigned long long>::type std::__1::default_delete<unsigned long long []>::operator()[abi:ne200100]<unsigned long long>(unsigned long long*) const+0x48 (microtel:arm64+0x1010c8c3c)
    #2 0x000101a7cdfc  (microtel:arm64+0x1010c8dfc)
    #3 0x000101a7ccf8  (microtel:arm64+0x1010c8cf8)
    #4 0x000101a7cc98  (microtel:arm64+0x1010c8c98)
    #5 0x000101a7c4a8  (microtel:arm64+0x1010c84a8)
    #6 0x000101a7d6e0  (microtel:arm64+0x1010c96e0)
    #7 0x000101a7d684  (microtel:arm64+0x1010c9684)
    #8 0x000101a7d62c  (microtel:arm64+0x1010c962c)
    #9 0x000101a7d5b0 in void std::__1::allocator_traits<std::__1::allocator<duckdb::TemplatedValidityData<unsigned long long>>>::destroy[abi:ne200100]<duckdb::TemplatedValidityData<unsigned long long>, 0>(std::__1::allocator<duckdb::TemplatedValidityData<unsigned long long>>&, duckdb::TemplatedValidityData<unsigned long long>*)+0x1c (microtel:arm64+0x1010c95b0)
    #10 0x000101a7d4e0 in void std::__1::__shared_ptr_emplace<duckdb::TemplatedValidityData<unsigned long long>, std::__1::allocator<duckdb::TemplatedValidityData<unsigned long long>>>::__on_zero_shared_impl[abi:ne200100]<std::__1::allocator<duckdb::TemplatedValidityData<unsigned long long>>, 0>()+0x240 (microtel:arm64+0x1010c94e0)
    #11 0x000101a7b7cc  (microtel:arm64+0x1010c77cc)
    #12 0x000101a3e4f0  (microtel:arm64+0x10108a4f0)
    #13 0x000101a3e284  (microtel:arm64+0x10108a284)
    #14 0x000101a3e184  (microtel:arm64+0x10108a184)
    #15 0x000101a3dfe4  (microtel:arm64+0x101089fe4)
    #16 0x000101a3df88  (microtel:arm64+0x101089f88)
    #17 0x000101a3df2c  (microtel:arm64+0x101089f2c)
    #18 0x000101a798c8 in duckdb::shared_ptr<duckdb::TemplatedValidityData<unsigned long long>, true>::operator=(duckdb::shared_ptr<duckdb::TemplatedValidityData<unsigned long long>, true>&&)+0x1d4 (microtel:arm64+0x1010c58c8)
    #19 0x000106191230 in duckdb::ValidityMask::Resize(unsigned long long)+0x82c (microtel:arm64+0x1057dd230)
    #20 0x00010611d338 in duckdb::Vector::Resize(unsigned long long, unsigned long long)+0x5e0 (microtel:arm64+0x105769338)
    #21 0x0001061f2644 in duckdb::VectorListBuffer::Reserve(unsigned long long)+0x548 (microtel:arm64+0x10583e644)
    #22 0x00010621bea8 in duckdb::ListVector::Reserve(duckdb::Vector&, unsigned long long)+0x544 (microtel:arm64+0x105867ea8)
    #23 0x000108be69c8 in duckdb_list_vector_reserve+0x70 (microtel:arm64+0x1082329c8)
    #24 0x000101a2c720 in _cgo_0e8f113c97a4_Cfunc_duckdb_list_vector_reserve+0x20 (microtel:arm64+0x101078720)
    #25 0x000100a34e38  (microtel:arm64+0x100080e38)

previously allocated by thread T22 here:
    #0 0x0001185cb0fc in _Znam+0x6c (libclang_rt.asan_osx_dynamic.dylib:arm64+0x630fc)
    #1 0x000101a7c2ac in duckdb::unique_ptr<unsigned long long [], std::__1::default_delete<unsigned long long []>, false> duckdb::make_unsafe_uniq_array_uninitialized<unsigned long long>(unsigned long)+0x30 (microtel:arm64+0x1010c82ac)
    #2 0x000101a7bf3c  (microtel:arm64+0x1010c7f3c)
    #3 0x000101a7bdac  (microtel:arm64+0x1010c7dac)
    #4 0x000101a7bd4c in void std::__1::allocator<duckdb::TemplatedValidityData<unsigned long long>>::construct[abi:ne200100]<duckdb::TemplatedValidityData<unsigned long long>, unsigned long long&>(duckdb::TemplatedValidityData<unsigned long long>*, unsigned long long&)+0xec (microtel:arm64+0x1010c7d4c)
    #5 0x000101a7b5e8 in void std::__1::allocator_traits<std::__1::allocator<duckdb::TemplatedValidityData<unsigned long long>>>::construct[abi:ne200100]<duckdb::TemplatedValidityData<unsigned long long>, unsigned long long&, 0>(std::__1::allocator<duckdb::TemplatedValidityData<unsigned long long>>&, duckdb::TemplatedValidityData<unsigned long long>*, unsigned long long&)+0x68 (microtel:arm64+0x1010c75e8)
    #6 0x000101a7b2b4  (microtel:arm64+0x1010c72b4)
    #7 0x000101a7a588  (microtel:arm64+0x1010c6588)
    #8 0x000101a7a1b4  (microtel:arm64+0x1010c61b4)
    #9 0x000101a79ef0  (microtel:arm64+0x1010c5ef0)
    #10 0x000101a79c34 in duckdb::shared_ptr<duckdb::TemplatedValidityData<unsigned long long>, true> duckdb::make_shared_ptr<duckdb::TemplatedValidityData<unsigned long long>, unsigned long long&>(unsigned long long&)+0x150 (microtel:arm64+0x1010c5c34)
    #11 0x000101a796e4 in duckdb::shared_ptr<duckdb::TemplatedValidityData<unsigned long long>, true> duckdb::make_buffer<duckdb::TemplatedValidityData<unsigned long long>, unsigned long long&>(unsigned long long&)+0x54 (microtel:arm64+0x1010c56e4)
    #12 0x000101a79240 in duckdb::TemplatedValidityMask<unsigned long long>::Initialize(unsigned long long)+0x1c4 (microtel:arm64+0x1010c5240)
    #13 0x00010201d044 in duckdb::TemplatedValidityMask<unsigned long long>::Initialize()+0x90 (microtel:arm64+0x101669044)
    #14 0x00010201cfa0 in duckdb::TemplatedValidityMask<unsigned long long>::EnsureWritable()+0x98 (microtel:arm64+0x101668fa0)
    #15 0x000108be6548 in duckdb_vector_ensure_validity_writable+0xf4 (microtel:arm64+0x108232548)
    #16 0x000100a34e38  (microtel:arm64+0x100080e38)
```
