### PR TITLE
Release C arrow array stream in Arrow.RegisterView() to fix memory leak

### DIFF
--- a/arrow.go
+++ b/arrow.go
@@ -328,6 +328,7 @@ func (a *Arrow) RegisterView(reader array.RecordReader, name string) (release fu
 
 	stream := C.calloc(1, C.sizeof_struct_ArrowArrayStream)
 	release = func() {
+		cdata.ReleaseCArrowArrayStream((*cdata.CArrowArrayStream)(stream))
 		C.free(stream)
 	}
 	cdata.ExportRecordReader(reader, (*cdata.CArrowArrayStream)(stream))


### PR DESCRIPTION
This PR fixes a memory leak I've observed while using the Arrow.RegisterView() method in my project.
The issue and the solution is described in [this issue here](https://github.com/marcboeker/go-duckdb/issues/437) and even in more detail in the [apache/arrow-go issue](https://github.com/apache/arrow-go/issues/371) .

Unfortunately, while I've verified that this fixes the memory leak in my project (and doesn't break the existing tests), creating a unit test exposing the difference in memory usage proved to be more complex and my first attempts to reproduce in a simple unit test failed. That's why I have not added a test here. If you think it's necessary I may have some more ideas I can try.