### PR TITLE
fix: escape union database type name

### DIFF
--- a/duckdb_test.go
+++ b/duckdb_test.go
@@ -611,22 +611,22 @@ func TestTypeNamesAndScanTypes(t *testing.T) {
 		{
 			sql:      `SELECT (123)::UNION(num INTEGER, str VARCHAR) AS col`,
 			value:    Union{Tag: "num", Value: int32(123)},
-			typeName: "UNION(num INTEGER, str VARCHAR)",
+			typeName: "UNION(\"num\" INTEGER, \"str\" VARCHAR)",
 		},
 		{
 			sql:      `SELECT ('hello')::UNION(num INTEGER, str VARCHAR) AS col`,
 			value:    Union{Tag: "str", Value: "hello"},
-			typeName: "UNION(num INTEGER, str VARCHAR)",
+			typeName: "UNION(\"num\" INTEGER, \"str\" VARCHAR)",
 		},
 		{
 			sql:      `SELECT (1.5)::UNION(d DOUBLE, i INTEGER, s VARCHAR) AS col`,
 			value:    Union{Tag: "d", Value: float64(1.5)},
-			typeName: "UNION(d DOUBLE, i INTEGER, s VARCHAR)",
+			typeName: "UNION(\"d\" DOUBLE, \"i\" INTEGER, \"s\" VARCHAR)",
 		},
 		{
 			sql:      `SELECT ('2024-01-01'::DATE)::UNION(d DATE, s VARCHAR) AS col`,
 			value:    Union{Tag: "d", Value: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
-			typeName: "UNION(d DATE, s VARCHAR)",
+			typeName: "UNION(\"d\" DATE, \"s\" VARCHAR)",
 		},
 	}
 

--- a/rows.go
+++ b/rows.go
@@ -271,7 +271,7 @@ func logicalTypeNameUnion(logicalType mapping.LogicalType) string {
 		memberType := mapping.UnionTypeMemberType(logicalType, mapping.IdxT(i))
 
 		// Add comma if not at the end of the list
-		name += memberName + " " + logicalTypeName(memberType)
+		name += escapeStructFieldName(memberName) + " " + logicalTypeName(memberType)
 		if i != count-1 {
 			name += ", "
 		}

--- a/types_test.go
+++ b/types_test.go
@@ -1072,14 +1072,14 @@ func TestUnionTypes(t *testing.T) {
 	// Test column type information.
 	t.Run("UNION column type info", func(t *testing.T) {
 		r, err := db.Query(`
-            SELECT (123)::UNION(num INTEGER, str VARCHAR) AS union_col
+            SELECT (123)::UNION(num INTEGER, "a str" VARCHAR) AS union_col
         `)
 		require.NoError(t, err)
 		defer closeRowsWrapper(t, r)
 
 		types, err := r.ColumnTypes()
 		require.NoError(t, err)
-		require.Equal(t, "UNION(num INTEGER, str VARCHAR)", types[0].DatabaseTypeName())
+		require.Equal(t, "UNION(\"num\" INTEGER, \"a str\" VARCHAR)", types[0].DatabaseTypeName())
 	})
 
 	// Test multiple UNION members.


### PR DESCRIPTION
It has been returning invalid name for fields with space