### PR TITLE
fix: free param_logical_type to avoid leak

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -334,6 +334,7 @@ func (s *Stmt) bindValue(val driver.NamedValue, n int) (mapping.State, error) {
 
 	if t != TYPE_INVALID {
 		lt, e := s.paramLogicalType(n + 1)
+		defer mapping.DestroyLogicalType(&lt)
 		if e != nil {
 			return mapping.StateError, e
 		}


### PR DESCRIPTION
We are seeing a memory leak from the duckdb-go-bindings C bindings:
```
1 (32 bytes) ROOT LEAK: <malloc in duckdb_param_logical_type 0x600000479700> [32]
```

When checking the JSON alias in `bindValue`, the result of ParamLogicalType isn't being freed. This change adds defer DestroyLogicalType to release the C memory, similar to: https://github.com/marcboeker/go-duckdb/blob/27bcaebe1957253e6058c39e778512337c9ee26b/statement.go#L267-L272