### PR TITLE
Add EXTRA_INFO to profiling metrics

### DIFF
--- a/profiling.go
+++ b/profiling.go
@@ -54,6 +54,12 @@ func (info *ProfilingInfo) getMetrics(profilingInfo mapping.ProfilingInfo) {
 	}
 	mapping.DestroyValue(&metricsMap)
 
+	// Extra info is not currently in the metric map
+	extraInfo := mapping.ProfilingInfoGetValue(profilingInfo, "EXTRA_INFO")
+	extraInfoStr := mapping.GetVarchar(extraInfo)
+	info.Metrics["EXTRA_INFO"] = extraInfoStr
+	mapping.DestroyValue(&extraInfo)
+
 	childCount := mapping.ProfilingInfoGetChildCount(profilingInfo)
 	for i := mapping.IdxT(0); i < childCount; i++ {
 		profilingInfoChild := mapping.ProfilingInfoGetChild(profilingInfo, i)


### PR DESCRIPTION
The EXTRA_INFO "metric" is not returned by default from duckdb. This adds it explicitly to each info node. 

This includes info such as which table the operator was on, which columns were projections, etc.