### PR TITLE
fix: invalidation of cache on connection close

### DIFF
--- a/duckdb.go
+++ b/duckdb.go
@@ -22,7 +22,7 @@ var (
     cacheCreated  bool
 )
 
-func GetInstanceCache() mapping.InstanceCache {
+func getInstanceCache() mapping.InstanceCache {
 	cacheMutex.Lock()
 	defer cacheMutex.Unlock()
 	
@@ -33,7 +33,7 @@ func GetInstanceCache() mapping.InstanceCache {
 	return instanceCache
 }
 
-func InvalidateInstanceCache() {
+func destroyInstanceCache() {
 	cacheMutex.Lock()
 	defer cacheMutex.Unlock()
 	
@@ -110,7 +110,7 @@ func NewConnector(dsn string, connInitFn func(execer driver.ExecerContext) error
 		state = mapping.OpenExt("", &db, config, &errMsg)
 	} else {
 		// Open a file-backed database.
-		state = mapping.GetOrCreateFromCache(GetInstanceCache(), getDBPath(dsn), &db, config, &errMsg)
+		state = mapping.GetOrCreateFromCache(getInstanceCache(), getDBPath(dsn), &db, config, &errMsg)
 	}
 	if state == mapping.StateError {
 		mapping.Close(&db)
@@ -155,7 +155,7 @@ func (c *Connector) Close() error {
 	mapping.Close(&c.db)
 	c.closed = true
 
-    InvalidateInstanceCache()
+    destroyInstanceCache()
 
 	return nil
 }


### PR DESCRIPTION
Due to the absence of cache invalidation, we cannot re-establish a connection to a previously connected database. This commit serves to fix this by adding in the required functionality.

This resolves #509 