### PR TITLE
Format code with golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,5 @@
 version: "2"
+
 linters:
   default: all
   disable:
@@ -48,3 +49,20 @@ linters:
         - encoded-compare
         - float-compare
         - go-require
+
+formatters:
+  enable:
+    - gci
+    - gofumpt
+    - goimports
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/marcboeker/go-duckdb)
+    gofumpt:
+      extra-rules: true
+    goimports:
+      local-prefixes:
+        - github.com/marcboeker/go-duckdb

--- a/appender_test.go
+++ b/appender_test.go
@@ -12,7 +12,6 @@ import (
 	"reflect"
 	"testing"
 	"time"
-
 	_ "time/tzdata"
 
 	"github.com/go-viper/mapstructure/v2"
@@ -115,7 +114,7 @@ func castMapToStruct[T any](t *testing.T, val any) T {
 	return res
 }
 
-func randInt(lo int64, hi int64) int64 {
+func randInt(lo, hi int64) int64 {
 	return rand.Int63n(hi-lo+1) + lo
 }
 

--- a/arrow.go
+++ b/arrow.go
@@ -66,12 +66,12 @@ import (
 	"sync"
 	"unsafe"
 
-	"github.com/marcboeker/go-duckdb/arrowmapping"
-	"github.com/marcboeker/go-duckdb/mapping"
-
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/cdata"
+
+	"github.com/marcboeker/go-duckdb/arrowmapping"
+	"github.com/marcboeker/go-duckdb/mapping"
 )
 
 // Arrow exposes DuckDB Apache Arrow interface.

--- a/data_chunk.go
+++ b/data_chunk.go
@@ -38,7 +38,7 @@ func (chunk *DataChunk) SetSize(size int) error {
 }
 
 // GetValue returns a single value of a column.
-func (chunk *DataChunk) GetValue(colIdx int, rowIdx int) (any, error) {
+func (chunk *DataChunk) GetValue(colIdx, rowIdx int) (any, error) {
 	if colIdx >= len(chunk.columns) {
 		return nil, getError(errAPI, columnCountError(colIdx, len(chunk.columns)))
 	}
@@ -50,7 +50,7 @@ func (chunk *DataChunk) GetValue(colIdx int, rowIdx int) (any, error) {
 // SetValue writes a single value to a column in a data chunk.
 // Note that this requires casting the type for each invocation.
 // NOTE: Custom ENUM types must be passed as string.
-func (chunk *DataChunk) SetValue(colIdx int, rowIdx int, val any) error {
+func (chunk *DataChunk) SetValue(colIdx, rowIdx int, val any) error {
 	if colIdx >= len(chunk.columns) {
 		return getError(errAPI, columnCountError(colIdx, len(chunk.columns)))
 	}
@@ -63,7 +63,7 @@ func (chunk *DataChunk) SetValue(colIdx int, rowIdx int, val any) error {
 // The difference with `chunk.SetValue` is that `SetChunkValue` does not
 // require casting the value to `any` (implicitly).
 // NOTE: Custom ENUM types must be passed as string.
-func SetChunkValue[T any](chunk DataChunk, colIdx int, rowIdx int, val T) error {
+func SetChunkValue[T any](chunk DataChunk, colIdx, rowIdx int, val T) error {
 	if colIdx >= len(chunk.columns) {
 		return getError(errAPI, columnCountError(colIdx, len(chunk.columns)))
 	}

--- a/duckdb.go
+++ b/duckdb.go
@@ -172,7 +172,7 @@ func prepareConfig(parsedDSN *url.URL) (mapping.Config, error) {
 	return config, nil
 }
 
-func setConfigOption(config mapping.Config, name string, option string) error {
+func setConfigOption(config mapping.Config, name, option string) error {
 	if mapping.SetConfig(config, name, option) == mapping.StateError {
 		mapping.DestroyConfig(&config)
 		return getError(errSetConfig, fmt.Errorf("%s=%s", name, option))

--- a/duckdb_test.go
+++ b/duckdb_test.go
@@ -86,7 +86,7 @@ func closePreparedWrapper[T require.TestingT](t T, stmt *sql.Stmt) {
 	require.NoError(t, stmt.Close())
 }
 
-func newAppenderWrapper[T require.TestingT](t T, conn *driver.Conn, schema string, table string) *Appender {
+func newAppenderWrapper[T require.TestingT](t T, conn *driver.Conn, schema, table string) *Appender {
 	a, err := NewAppenderFromConn(*conn, schema, table)
 	require.NoError(t, err)
 	return a

--- a/errors.go
+++ b/errors.go
@@ -6,30 +6,30 @@ import (
 	"strings"
 )
 
-func getError(errDriver error, err error) error {
+func getError(errDriver, err error) error {
 	if err == nil {
 		return fmt.Errorf("%s: %w", driverErrMsg, errDriver)
 	}
 	return fmt.Errorf("%s: %w: %s", driverErrMsg, errDriver, err.Error())
 }
 
-func castError(actual string, expected string) error {
+func castError(actual, expected string) error {
 	return fmt.Errorf("%s: cannot cast %s to %s", castErrMsg, actual, expected)
 }
 
-func conversionError(actual int, min int, max int) error {
+func conversionError(actual, min, max int) error {
 	return fmt.Errorf("%s: cannot convert %d, minimum: %d, maximum: %d", convertErrMsg, actual, min, max)
 }
 
-func invalidInputError(actual string, expected string) error {
+func invalidInputError(actual, expected string) error {
 	return fmt.Errorf("%s: expected %s, got %s", invalidInputErrMsg, expected, actual)
 }
 
-func structFieldError(actual string, expected string) error {
+func structFieldError(actual, expected string) error {
 	return fmt.Errorf("%s: expected %s, got %s", structFieldErrMsg, expected, actual)
 }
 
-func columnCountError(actual int, expected int) error {
+func columnCountError(actual, expected int) error {
 	return fmt.Errorf("%s: expected %d, got %d", columnCountErrMsg, expected, actual)
 }
 

--- a/replacement_scan.go
+++ b/replacement_scan.go
@@ -33,7 +33,7 @@ func replacement_scan_delete_callback(info unsafe.Pointer) {
 }
 
 //export replacement_scan_callback
-func replacement_scan_callback(infoPtr unsafe.Pointer, tableNamePtr unsafe.Pointer, data unsafe.Pointer) {
+func replacement_scan_callback(infoPtr, tableNamePtr, data unsafe.Pointer) {
 	info := mapping.ReplacementScanInfo{Ptr: infoPtr}
 	tableName := C.GoString((*C.char)(tableNamePtr))
 

--- a/scalar_udf.go
+++ b/scalar_udf.go
@@ -165,7 +165,7 @@ func RegisterScalarUDFSet(c *sql.Conn, name string, functions ...ScalarFunc) err
 }
 
 //export scalar_udf_callback
-func scalar_udf_callback(functionInfoPtr unsafe.Pointer, inputPtr unsafe.Pointer, outputPtr unsafe.Pointer) {
+func scalar_udf_callback(functionInfoPtr, inputPtr, outputPtr unsafe.Pointer) {
 	functionInfo := mapping.FunctionInfo{Ptr: functionInfoPtr}
 	input := mapping.DataChunk{Ptr: inputPtr}
 	output := mapping.Vector{Ptr: outputPtr}

--- a/table_udf.go
+++ b/table_udf.go
@@ -233,7 +233,7 @@ func table_udf_local_init(infoPtr unsafe.Pointer) {
 }
 
 //export table_udf_callback
-func table_udf_callback(infoPtr unsafe.Pointer, outputPtr unsafe.Pointer) {
+func table_udf_callback(infoPtr, outputPtr unsafe.Pointer) {
 	info := mapping.FunctionInfo{Ptr: infoPtr}
 	output := mapping.DataChunk{Ptr: outputPtr}
 

--- a/type_info.go
+++ b/type_info.go
@@ -122,7 +122,7 @@ func NewTypeInfo(t Type) (TypeInfo, error) {
 
 // NewDecimalInfo returns DECIMAL type information.
 // Its input parameters are the width and scale of the DECIMAL type.
-func NewDecimalInfo(width uint8, scale uint8) (TypeInfo, error) {
+func NewDecimalInfo(width, scale uint8) (TypeInfo, error) {
 	if width < 1 || width > max_decimal_width {
 		return nil, getError(errAPI, errInvalidDecimalWidth)
 	}
@@ -224,7 +224,7 @@ func NewStructInfo(firstEntry StructEntry, others ...StructEntry) (TypeInfo, err
 // NewMapInfo returns MAP type information.
 // keyInfo contains the type information of the MAP keys.
 // valueInfo contains the type information of the MAP values.
-func NewMapInfo(keyInfo TypeInfo, valueInfo TypeInfo) (TypeInfo, error) {
+func NewMapInfo(keyInfo, valueInfo TypeInfo) (TypeInfo, error) {
 	if keyInfo == nil {
 		return nil, getError(errAPI, interfaceIsNilError("keyInfo"))
 	}

--- a/types.go
+++ b/types.go
@@ -10,10 +10,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/marcboeker/go-duckdb/mapping"
-
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/google/uuid"
+
+	"github.com/marcboeker/go-duckdb/mapping"
 )
 
 type numericType interface {

--- a/types_test.go
+++ b/types_test.go
@@ -328,7 +328,7 @@ func BenchmarkTypes(b *testing.B) {
 	benchmarkTypesResult = r
 }
 
-func compareDecimal(t *testing.T, want Decimal, got Decimal) {
+func compareDecimal(t *testing.T, want, got Decimal) {
 	require.Equal(t, want.Scale, got.Scale)
 	require.Equal(t, want.Width, got.Width)
 	require.Equal(t, want.Value.String(), got.Value.String())

--- a/vector_getters.go
+++ b/vector_getters.go
@@ -208,7 +208,7 @@ func (vec *vector) getArray(rowIdx mapping.IdxT) []any {
 	return vec.getSliceChild(uint64(rowIdx)*length, length)
 }
 
-func (vec *vector) getSliceChild(offset uint64, length uint64) []any {
+func (vec *vector) getSliceChild(offset, length uint64) []any {
 	slice := make([]any, 0, length)
 	child := &vec.childVectors[0]
 


### PR DESCRIPTION
What this means in practice for our code:

- Sort imports
- Group adjacent parameters with the same type
- Enforce rules in CI