### PR TITLE
docs: add warning about arrow concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,9 @@ for rdr.Next() {
 }
 ```
 
+> [!WARNING]  
+> Arrow connections are not safe for concurrent use, and do not benefit from `database/sql` connection pooling.
+
 ## DuckDB Extensions
 
 `go-duckdb` relies on the [`duckdb-go-bindings` module](https://github.com/duckdb/duckdb-go-bindings).


### PR DESCRIPTION
Fixes #479 