### PR TITLE
Fix crash in arrowStreamReader.Next()

### DIFF
--- a/arrow.go
+++ b/arrow.go
@@ -153,6 +153,11 @@ func (r *arrowStreamReader) Next() bool {
 		return false
 	}
 
+	if r.res == nil {
+		r.err = errors.New("arrow result has already been released")
+		return false
+	}
+
 	select {
 	case <-r.ctx.Done():
 		r.err = r.ctx.Err()


### PR DESCRIPTION
Adds nil check in `arrowStreamReader.Next()` to prevent crashes when `r.res` becomes nil due to race condition between `Release()` and `Next()`.

The crash happened under high concurrency when:

1. Goroutine A calls Next() to read arrow data
2. Goroutine B calls Release() setting r.res = nil
3. Goroutine A continues with nil pointer to C++ layer
4. C++ code crashes on NULL shared_ptr dereference

Fixes #526