### PR TITLE
perf(rows): preallocate reflect types for column scan

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -17,6 +17,30 @@ import (
 	"unsafe"
 )
 
+// Precomputed reflect type values to avoid repeated allocations.
+var (
+	reflectTypeBool      = reflect.TypeOf(true)
+	reflectTypeInt8      = reflect.TypeOf(int8(0))
+	reflectTypeInt16     = reflect.TypeOf(int16(0))
+	reflectTypeInt32     = reflect.TypeOf(int32(0))
+	reflectTypeInt64     = reflect.TypeOf(int64(0))
+	reflectTypeUint8     = reflect.TypeOf(uint8(0))
+	reflectTypeUint16    = reflect.TypeOf(uint16(0))
+	reflectTypeUint32    = reflect.TypeOf(uint32(0))
+	reflectTypeUint64    = reflect.TypeOf(uint64(0))
+	reflectTypeFloat32   = reflect.TypeOf(float32(0))
+	reflectTypeFloat64   = reflect.TypeOf(float64(0))
+	reflectTypeTime      = reflect.TypeOf(time.Time{})
+	reflectTypeInterval  = reflect.TypeOf(Interval{})
+	reflectTypeBigInt    = reflect.TypeOf(big.NewInt(0))
+	reflectTypeString    = reflect.TypeOf("")
+	reflectTypeBytes     = reflect.TypeOf([]byte{})
+	reflectTypeDecimal   = reflect.TypeOf(Decimal{})
+	reflectTypeSliceAny  = reflect.TypeOf([]any{})
+	reflectTypeMapString = reflect.TypeOf(map[string]any{})
+	reflectTypeMap       = reflect.TypeOf(Map{})
+)
+
 type rows struct {
 	res           C.duckdb_result
 	stmt          *stmt
@@ -184,61 +208,47 @@ func (r *rows) ColumnTypeScanType(index int) reflect.Type {
 	case C.DUCKDB_TYPE_INVALID:
 		return nil
 	case C.DUCKDB_TYPE_BOOLEAN:
-		return reflect.TypeOf(true)
+		return reflectTypeBool
 	case C.DUCKDB_TYPE_TINYINT:
-		return reflect.TypeOf(int8(0))
+		return reflectTypeInt8
 	case C.DUCKDB_TYPE_SMALLINT:
-		return reflect.TypeOf(int16(0))
+		return reflectTypeInt16
 	case C.DUCKDB_TYPE_INTEGER:
-		return reflect.TypeOf(int32(0))
+		return reflectTypeInt32
 	case C.DUCKDB_TYPE_BIGINT:
-		return reflect.TypeOf(int64(0))
+		return reflectTypeInt64
 	case C.DUCKDB_TYPE_UTINYINT:
-		return reflect.TypeOf(uint8(0))
+		return reflectTypeUint8
 	case C.DUCKDB_TYPE_USMALLINT:
-		return reflect.TypeOf(uint16(0))
+		return reflectTypeUint16
 	case C.DUCKDB_TYPE_UINTEGER:
-		return reflect.TypeOf(uint32(0))
+		return reflectTypeUint32
 	case C.DUCKDB_TYPE_UBIGINT:
-		return reflect.TypeOf(uint64(0))
+		return reflectTypeUint64
 	case C.DUCKDB_TYPE_FLOAT:
-		return reflect.TypeOf(float32(0))
+		return reflectTypeFloat32
 	case C.DUCKDB_TYPE_DOUBLE:
-		return reflect.TypeOf(float64(0))
-	case C.DUCKDB_TYPE_TIMESTAMP:
-		return reflect.TypeOf(time.Time{})
-	case C.DUCKDB_TYPE_DATE:
-		return reflect.TypeOf(time.Time{})
-	case C.DUCKDB_TYPE_TIME:
-		return reflect.TypeOf(time.Time{})
+		return reflectTypeFloat64
+	case C.DUCKDB_TYPE_TIMESTAMP, C.DUCKDB_TYPE_DATE, C.DUCKDB_TYPE_TIME,
+		C.DUCKDB_TYPE_TIMESTAMP_S, C.DUCKDB_TYPE_TIMESTAMP_MS, C.DUCKDB_TYPE_TIMESTAMP_NS,
+		C.DUCKDB_TYPE_TIMESTAMP_TZ:
+		return reflectTypeTime
 	case C.DUCKDB_TYPE_INTERVAL:
-		return reflect.TypeOf(Interval{})
+		return reflectTypeInterval
 	case C.DUCKDB_TYPE_HUGEINT:
-		return reflect.TypeOf(big.NewInt(0))
-	case C.DUCKDB_TYPE_VARCHAR:
-		return reflect.TypeOf("")
-	case C.DUCKDB_TYPE_ENUM:
-		return reflect.TypeOf("")
-	case C.DUCKDB_TYPE_BLOB:
-		return reflect.TypeOf([]byte{})
+		return reflectTypeBigInt
+	case C.DUCKDB_TYPE_VARCHAR, C.DUCKDB_TYPE_ENUM:
+		return reflectTypeString
+	case C.DUCKDB_TYPE_BLOB, C.DUCKDB_TYPE_UUID:
+		return reflectTypeBytes
 	case C.DUCKDB_TYPE_DECIMAL:
-		return reflect.TypeOf(Decimal{})
-	case C.DUCKDB_TYPE_TIMESTAMP_S:
-		return reflect.TypeOf(time.Time{})
-	case C.DUCKDB_TYPE_TIMESTAMP_MS:
-		return reflect.TypeOf(time.Time{})
-	case C.DUCKDB_TYPE_TIMESTAMP_NS:
-		return reflect.TypeOf(time.Time{})
+		return reflectTypeDecimal
 	case C.DUCKDB_TYPE_LIST:
-		return reflect.TypeOf([]any{})
+		return reflectTypeSliceAny
 	case C.DUCKDB_TYPE_STRUCT:
-		return reflect.TypeOf(map[string]any{})
+		return reflectTypeMapString
 	case C.DUCKDB_TYPE_MAP:
-		return reflect.TypeOf(Map{})
-	case C.DUCKDB_TYPE_UUID:
-		return reflect.TypeOf([]byte{})
-	case C.DUCKDB_TYPE_TIMESTAMP_TZ:
-		return reflect.TypeOf(time.Time{})
+		return reflectTypeMap
 	default:
 		return nil
 	}

--- a/rows.go
+++ b/rows.go
@@ -17,30 +17,6 @@ import (
 	"unsafe"
 )
 
-// Precomputed reflect type values to avoid repeated allocations.
-var (
-	reflectTypeBool      = reflect.TypeOf(true)
-	reflectTypeInt8      = reflect.TypeOf(int8(0))
-	reflectTypeInt16     = reflect.TypeOf(int16(0))
-	reflectTypeInt32     = reflect.TypeOf(int32(0))
-	reflectTypeInt64     = reflect.TypeOf(int64(0))
-	reflectTypeUint8     = reflect.TypeOf(uint8(0))
-	reflectTypeUint16    = reflect.TypeOf(uint16(0))
-	reflectTypeUint32    = reflect.TypeOf(uint32(0))
-	reflectTypeUint64    = reflect.TypeOf(uint64(0))
-	reflectTypeFloat32   = reflect.TypeOf(float32(0))
-	reflectTypeFloat64   = reflect.TypeOf(float64(0))
-	reflectTypeTime      = reflect.TypeOf(time.Time{})
-	reflectTypeInterval  = reflect.TypeOf(Interval{})
-	reflectTypeBigInt    = reflect.TypeOf(big.NewInt(0))
-	reflectTypeString    = reflect.TypeOf("")
-	reflectTypeBytes     = reflect.TypeOf([]byte{})
-	reflectTypeDecimal   = reflect.TypeOf(Decimal{})
-	reflectTypeSliceAny  = reflect.TypeOf([]any{})
-	reflectTypeMapString = reflect.TypeOf(map[string]any{})
-	reflectTypeMap       = reflect.TypeOf(Map{})
-)
-
 type rows struct {
 	res           C.duckdb_result
 	stmt          *stmt

--- a/types.go
+++ b/types.go
@@ -9,6 +9,8 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math/big"
+	"reflect"
+	"time"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -63,6 +65,31 @@ var duckdbTypeMap = map[C.duckdb_type]string{
 	C.DUCKDB_TYPE_TIME_TZ:      "TIMETZ",
 	C.DUCKDB_TYPE_TIMESTAMP_TZ: "TIMESTAMPTZ",
 }
+
+// Precomputed reflect type values to avoid repeated allocations.
+var (
+	reflectTypeBool      = reflect.TypeOf(true)
+	reflectTypeInt8      = reflect.TypeOf(int8(0))
+	reflectTypeInt16     = reflect.TypeOf(int16(0))
+	reflectTypeInt32     = reflect.TypeOf(int32(0))
+	reflectTypeInt64     = reflect.TypeOf(int64(0))
+	reflectTypeUint8     = reflect.TypeOf(uint8(0))
+	reflectTypeUint16    = reflect.TypeOf(uint16(0))
+	reflectTypeUint32    = reflect.TypeOf(uint32(0))
+	reflectTypeUint64    = reflect.TypeOf(uint64(0))
+	reflectTypeFloat32   = reflect.TypeOf(float32(0))
+	reflectTypeFloat64   = reflect.TypeOf(float64(0))
+	reflectTypeTime      = reflect.TypeOf(time.Time{})
+	reflectTypeInterval  = reflect.TypeOf(Interval{})
+	reflectTypeBigInt    = reflect.TypeOf(big.NewInt(0))
+	reflectTypeString    = reflect.TypeOf("")
+	reflectTypeBytes     = reflect.TypeOf([]byte{})
+	reflectTypeDecimal   = reflect.TypeOf(Decimal{})
+	reflectTypeSliceAny  = reflect.TypeOf([]any{})
+	reflectTypeMapString = reflect.TypeOf(map[string]any{})
+	reflectTypeMap       = reflect.TypeOf(Map{})
+	reflectTypeUUID      = reflect.TypeOf(UUID{})
+)
 
 type numericType interface {
 	int | int8 | int16 | int32 | int64 | uint | uint8 | uint16 | uint32 | uint64 | float32 | float64

--- a/vector.go
+++ b/vector.go
@@ -58,12 +58,12 @@ func (vec *vector) tryCast(val any) (any, error) {
 	case C.DUCKDB_TYPE_VARCHAR:
 		return tryPrimitiveCast[string](val, reflect.String.String())
 	case C.DUCKDB_TYPE_BLOB:
-		return tryPrimitiveCast[[]byte](val, reflect.TypeOf([]byte{}).String())
+		return tryPrimitiveCast[[]byte](val, reflectTypeBytes.String())
 	case C.DUCKDB_TYPE_TIMESTAMP, C.DUCKDB_TYPE_TIMESTAMP_S, C.DUCKDB_TYPE_TIMESTAMP_MS,
 		C.DUCKDB_TYPE_TIMESTAMP_NS, C.DUCKDB_TYPE_TIMESTAMP_TZ, C.DUCKDB_TYPE_DATE:
-		return tryPrimitiveCast[time.Time](val, reflect.TypeOf(time.Time{}).String())
+		return tryPrimitiveCast[time.Time](val, reflectTypeTime.String())
 	case C.DUCKDB_TYPE_UUID:
-		return tryPrimitiveCast[UUID](val, reflect.TypeOf(UUID{}).String())
+		return tryPrimitiveCast[UUID](val, reflectTypeUUID.String())
 	case C.DUCKDB_TYPE_LIST:
 		return vec.tryCastList(val)
 	case C.DUCKDB_TYPE_STRUCT:


### PR DESCRIPTION
Instead of calling `reflect.TypeOf(type{})` repetitively, we can precompute these types to save some CPU cycles and potentially skip an extra allocation for any non-primitive types (e.g. `time.Time`).