### PR TITLE
perf(rows): cache column scan types

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -28,22 +28,33 @@ type rows struct {
 	chunkIdx mapping.IdxT
 	// rowCount is the number of scanned rows.
 	rowCount int
+	// cached column metadata to avoid repeated CGO calls
+	scanTypes   []reflect.Type
+	dbTypeNames []string
 }
 
 func newRowsWithStmt(res mapping.Result, stmt *Stmt) *rows {
 	columnCount := mapping.ColumnCount(&res)
 	r := rows{
-		res:        res,
-		stmt:       stmt,
-		chunk:      DataChunk{},
-		chunkCount: mapping.ResultChunkCount(res),
-		chunkIdx:   0,
-		rowCount:   0,
+		res:         res,
+		stmt:        stmt,
+		chunk:       DataChunk{},
+		chunkCount:  mapping.ResultChunkCount(res),
+		chunkIdx:    0,
+		rowCount:    0,
+		scanTypes:   make([]reflect.Type, columnCount),
+		dbTypeNames: make([]string, columnCount),
 	}
 
 	for i := mapping.IdxT(0); i < columnCount; i++ {
 		columnName := mapping.ColumnName(&res, i)
 		r.chunk.columnNames = append(r.chunk.columnNames, columnName)
+
+		// Cache column metadata
+		logicalType := mapping.ColumnLogicalType(&res, i)
+		r.scanTypes[i] = r.getScanType(logicalType, i)
+		r.dbTypeNames[i] = r.getDBTypeName(logicalType, i)
+		mapping.DestroyLogicalType(&logicalType)
 	}
 
 	return &r
@@ -86,15 +97,16 @@ func (r *rows) Next(dst []driver.Value) error {
 
 // ColumnTypeScanType implements driver.RowsColumnTypeScanType.
 func (r *rows) ColumnTypeScanType(index int) reflect.Type {
-	logicalType := mapping.ColumnLogicalType(&r.res, mapping.IdxT(index))
-	defer mapping.DestroyLogicalType(&logicalType)
+	return r.scanTypes[index]
+}
 
+func (r *rows) getScanType(logicalType mapping.LogicalType, index mapping.IdxT) reflect.Type {
 	alias := mapping.LogicalTypeGetAlias(logicalType)
 	if alias == aliasJSON {
 		return reflect.TypeFor[any]()
 	}
 
-	t := mapping.ColumnType(&r.res, mapping.IdxT(index))
+	t := mapping.ColumnType(&r.res, index)
 	switch t {
 	case TYPE_INVALID:
 		return nil
@@ -151,15 +163,16 @@ func (r *rows) ColumnTypeScanType(index int) reflect.Type {
 
 // ColumnTypeDatabaseTypeName implements driver.RowsColumnTypeScanType.
 func (r *rows) ColumnTypeDatabaseTypeName(index int) string {
-	logicalType := mapping.ColumnLogicalType(&r.res, mapping.IdxT(index))
-	defer mapping.DestroyLogicalType(&logicalType)
+	return r.dbTypeNames[index]
+}
 
+func (r *rows) getDBTypeName(logicalType mapping.LogicalType, index mapping.IdxT) string {
 	alias := mapping.LogicalTypeGetAlias(logicalType)
 	if alias == aliasJSON {
 		return aliasJSON
 	}
 
-	t := mapping.ColumnType(&r.res, mapping.IdxT(index))
+	t := mapping.ColumnType(&r.res, index)
 	switch t {
 	case TYPE_DECIMAL, TYPE_ENUM, TYPE_LIST, TYPE_STRUCT, TYPE_MAP, TYPE_ARRAY, TYPE_UNION:
 		return logicalTypeName(logicalType)


### PR DESCRIPTION
Also another minor optimisation I noticed where we could precompute all the scan types in advance and store them in slices so the database driver doesn't make any extra unpredictable CGO calls than necessary. Also maybe some spatial locality performance gains, but that's fairly negligible.

This PR overshadows #536 and makes it less impactful, but oh well 🙈 