### PR TITLE
fix: fix new warnings of golangci-lint v2.5.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,7 @@ linters:
     - noinlineerr
     - paralleltest
     - testpackage
+    - unqueryvet
     - varnamelen
     - wrapcheck
     - wsl

--- a/table_source.go
+++ b/table_source.go
@@ -93,6 +93,7 @@ type (
 )
 
 // ParallelRow wrapper
+
 func (s parallelRowTSWrapper) ColumnInfos() []ColumnInfo {
 	return s.s.ColumnInfos()
 }
@@ -117,6 +118,7 @@ func (s parallelRowTSWrapper) FillRow(ls any, chunk Row) (bool, error) {
 }
 
 // ParallelChunk wrapper
+
 func (s parallelChunkTSWrapper) ColumnInfos() []ColumnInfo {
 	return s.s.ColumnInfos()
 }

--- a/types.go
+++ b/types.go
@@ -164,7 +164,7 @@ func (i *Interval) getMappedInterval() mapping.Interval {
 	return mapping.NewInterval(i.Months, i.Days, i.Micros)
 }
 
-// Use as the `Scanner` type for any composite types (maps, lists, structs)
+// Composite use as the `Scanner` type for any composite types (maps, lists, structs)
 type Composite[T any] struct {
 	t T
 }


### PR DESCRIPTION
golangci-lint add 3 new linters in v2.5.0, causes several new warnings:
<img width="1186" height="399" alt="image" src="https://github.com/user-attachments/assets/af3b785a-6b61-4d75-bb95-0f09064ba6eb" />

- Fix for godoclint
- Disable unqueryvet because there are too many warnings and most of them are useless. It only reports `SELECT *` and `SELECT func(*)`.