### PR TITLE
Announce project move to duckdb/duckdb-go

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ is to fully transfer the maintenance and day-to-day work of the driver to the Du
 That being said, the DuckDB Go client has become what it is also due to its many contributions from the community,
 and we are looking forward to your future PRs, issues, and discussions!
 
+The license is unchanged: the migrated repository keeps the original MIT license, which is the same for core DuckDB and other primary clients.
+
 ---
 
 # Go SQL Driver For [DuckDB](https://github.com/duckdb/duckdb)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,26 @@
+> [!IMPORTANT]
+> **This project has moved to [github.com/duckdb/duckdb-go](https://github.com/duckdb/duckdb-go) starting with `v2.5.0`.**
+>
+> **To migrate:** Update your import paths from `github.com/marcboeker/go-duckdb` to `github.com/duckdb/duckdb-go`.
+> **→ [Full migration guide](https://github.com/duckdb/duckdb-go/blob/main/README.md#migration-from-marcboekergo-duckdb)**
+
+Over the last few years, the Go client has become a [primary DuckDB client](https://duckdb.org/docs/stable/clients/overview).
+We'd like to thank [Marc Boeker](https://github.com/marcboeker) for all his work on creating this driver and implementing the various interfaces of the `database/sql` package!
+We'd also like to thank all the other external contributors for their various PRs and other contributions.
+
+With the driver being a primary DuckDB client, over the last years, the DuckDB team has gradually increased its involvement in the maintenance of the driver,
+to guarantee that it is constantly updated and that critical bugs (e.g., crashes) are fixed.
+Now we have a Long-Term Support release, so starting from early next year, we will have two releases in parallel (v1.4 LTS and v1.5).
+Additionally, more DuckDB customers use and rely on the Go client, which necessitates prioritization of certain features from us.
+
+These points all add to the maintenance work, which the DuckDB team is happy to perform!
+However, the motivation behind this fork, which is a joint effort of Marc Boeker and the DuckDB team,
+is to fully transfer the maintenance and day-to-day work of the driver to the DuckDB team.
+That being said, the DuckDB Go client has become what it is also due to its many contributions from the community,
+and we are looking forward to your future PRs, issues, and discussions!
+
+---
+
 # Go SQL Driver For [DuckDB](https://github.com/duckdb/duckdb)
 ![Tests status](https://github.com/marcboeker/go-duckdb/actions/workflows/tests.yaml/badge.svg)
 [![GoDoc](https://godoc.org/github.com/marcboeker/go-duckdb/v2?status.svg)](https://pkg.go.dev/github.com/marcboeker/go-duckdb/v2)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
+// Deprecated: This module has moved to github.com/duckdb/duckdb-go.
+// See https://github.com/duckdb/duckdb-go for migration instructions.
 module github.com/marcboeker/go-duckdb/v2
 
 go 1.24


### PR DESCRIPTION
Depends on https://github.com/duckdb/duckdb-go/pull/4

We need to push a new tag to make the deprecation notice take effect.

> To deprecate a module, an author may add a // Deprecated: comment and tag a new release.

https://go.dev/ref/mod